### PR TITLE
fix: use absolute URLs in README.md

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include requirements.txt
 include requirements-dev.txt
 include LICENSE
-include CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ Before that, please search for similar issues. It's possible that someone has al
 Find more open source projects on the [IBM Github Page](http://ibm.github.io/)
 
 ## Contributing
-See [CONTRIBUTING](CONTRIBUTING.md).
+See [CONTRIBUTING.md](https://github.com/IBM/platform-services-python-sdk/blob/master/CONTRIBUTING.md).
 
 ## License
 
-The IBM Cloud Platform Services Python SDK is released under the Apache 2.0 license.
-The license's full text can be found in [LICENSE](LICENSE).
+This SDK is released under the Apache 2.0 license.
+The license's full text can be found in [LICENSE](https://github.com/IBM/platform-services-python-sdk/blob/master/LICENSE).


### PR DESCRIPTION
## PR summary
This PR makes minor changes to the README.md so that when it is displayed on the pypi.org project page, the links to LICENSE and CONTRIBUTING.md will correctly point back to the github repo.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->