### PR TITLE
chore: asoc configuration

### DIFF
--- a/appscan-config.xml
+++ b/appscan-config.xml
@@ -1,0 +1,8 @@
+<Configuration>
+  <Targets>
+    <Target path=".">
+      <Exclude>test/</Exclude>
+      <Exclude>examples/</Exclude>
+    </Target>
+  </Targets>
+</Configuration>


### PR DESCRIPTION
This PR tells our code scanning tool to ignore the `test` directory on its subsequent runs.