### PR TITLE
fix(deps): move to python 3.6 as minimum supported level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 
 matrix:
   include:
-    - python: 3.5
     - python: 3.6
     - python: 3.7
     - python: 3.8
+    - python: 3.9
 
 dist: xenial
 
@@ -36,7 +36,7 @@ deploy:
   script: npx semantic-release
   skip_cleanup: true
   on:
-    python: '3.5'
+    python: '3.6'
     branch: master
 
 - provider: pypi
@@ -45,5 +45,5 @@ deploy:
   repository: https://upload.pypi.org/legacy
   skip_cleanup: true
   on:
-    python: '3.5'
+    python: '3.6'
     tags: true

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ setup: deps dev_deps install_project
 all: setup test-unit lint
 
 deps:
+	python -m pip install --upgrade pip
 	python -m pip install -r requirements.txt
 
 dev_deps:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Service Name | Imported Class Name
 
 * An [IBM Cloud][ibm-cloud-onboarding] account.
 * An IAM API key to allow the SDK to access your account. Create one [here](https://cloud.ibm.com/iam/apikeys).
-* Python 3.5 or above.
+* Python 3.6 or above.
 
 ## Installation
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,17 +1,9 @@
 # test dependencies
-jproperties
-pytest>=5.0
-responses>=0.10
-python-dotenv>=0.1.5
-pylint>=1.4.4
-tox>=2.9.1
-couchdb>=1.2
-
-# code coverage
-coverage<5
-codecov>=1.6.3,<3.0.0
+codecov>=2.1.0,<3.0.0
+couchdb>=1.2,<2.0.0
+coverage>=4.5.4
+pylint>=2.6.0,<3.0.0
+pytest>=6.2.1,<7.0.0
 pytest-cov>=2.2.1,<3.0.0
-
-# documentation
-recommonmark>=0.2.0
-Sphinx>=1.3.1
+responses>=0.12.1,<1.0.0
+tox>=3.2.0,<4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.24.0,<3.0
 python_dateutil>=2.5.3,<3.0.0
-ibm_cloud_sdk_core>=3.3.6,<4.0.0
+ibm_cloud_sdk_core>=3.4.0,<4.0.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,9 @@ PACKAGE_NAME = 'ibm_platform_services'
 PACKAGE_DESC = 'Python client library for IBM Cloud Platform Services'
 
 with open('requirements.txt') as f:
-    install_requires = [str(req) for req in pkg_resources.parse_requirements(f)]
+    install_requires = [
+        str(req) for req in pkg_resources.parse_requirements(f)
+    ]
 with open('requirements-dev.txt') as f:
     tests_require = [str(req) for req in pkg_resources.parse_requirements(f)]
 
@@ -38,56 +40,36 @@ if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload -r pypi')
     sys.exit()
 
-class PyTest(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = ['--strict', '--verbose', '--tb=long', 'test']
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        errcode = pytest.main(self.test_args)
-        sys.exit(errcode)
-
-class PyTestUnit(PyTest):
-    def finalize_options(self):
-        self.test_args = ['--strict', '--verbose', '--tb=long', 'test/unit']
-
-class PyTestIntegration(PyTest):
-    def finalize_options(self):
-        self.test_args = ['--strict', '--verbose', '--tb=long', 'test/integration']
-
 with open("README.md", "r") as fh:
     readme = fh.read()
 
-setup(name=PACKAGE_NAME.replace('_', '-'),
-      version=__version__,
-      description=PACKAGE_DESC,
-      license='Apache 2.0',
-      install_requires=install_requires,
-      tests_require=tests_require,
-      cmdclass={'test': PyTest, 'test_unit': PyTestUnit, 'test_integration': PyTestIntegration},
-      author='IBM',
-      author_email='devexdev@us.ibm.com',
-      long_description=readme,
-      long_description_content_type='text/markdown',
-      url='https://github.com/IBM/platform-services-python-sdk',
-      packages=[PACKAGE_NAME],
-      include_package_data=True,
-      keywords=PACKAGE_NAME,
-      classifiers=[
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.5',
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7',
-          'Programming Language :: Python :: 3.8',
-          'Development Status :: 4 - Beta',
-          'Intended Audience :: Developers',
-          'License :: OSI Approved :: Apache Software License',
-          'Operating System :: OS Independent',
-          'Topic :: Software Development :: Libraries :: Python Modules',
-          'Topic :: Software Development :: Libraries :: Application Frameworks',
-      ],
-      zip_safe=True
-     )
+setup(
+    name=PACKAGE_NAME.replace('_', '-'),
+    version=__version__,
+    description=PACKAGE_DESC,
+    license='Apache 2.0',
+    install_requires=install_requires,
+    tests_require=tests_require,
+    author='IBM',
+    author_email='devexdev@us.ibm.com',
+    long_description=readme,
+    long_description_content_type='text/markdown',
+    url='https://github.com/IBM/platform-services-python-sdk',
+    packages=[PACKAGE_NAME],
+    include_package_data=True,
+    keywords=PACKAGE_NAME,
+    classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: Software Development :: Libraries :: Application Frameworks',
+    ],
+    zip_safe=True)

--- a/test/integration/test_catalog_management_v1.py
+++ b/test/integration/test_catalog_management_v1.py
@@ -12,25 +12,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-'''
-Test the platform service Catalog Management API operations
-'''
+"""
+Integration Tests for CatalogManagementV1
+"""
 
 import unittest
 import os
 from ibm_cloud_sdk_core import *
 from ibm_platform_services.catalog_management_v1 import *
 import pytest
-from dotenv import load_dotenv
 import time
 
-configFile = 'catalog_mgmt.env'
-configLoaded = None
+config_file = 'catalog_mgmt.env'
+
+sdk_label_prefix = 'python-sdk-IT'
 
 timestamp = int(time.time())
 expectedAccount = '67d27f28d43948b2b3bda9138f251a13'
-expectedLabel = 'integration-test-{}'.format(timestamp)
+expectedLabel = '{}-{}'.format(sdk_label_prefix, timestamp)
 expectedShortDesc = 'test'
 expectedURL = 'https://cm.globalcatalog.test.cloud.ibm.com/api/v1-beta/catalogs/{}'
 expectedOfferingsURL = 'https://cm.globalcatalog.test.cloud.ibm.com/api/v1-beta/catalogs/{}/offerings'
@@ -39,47 +38,51 @@ fakeVersionLocator = 'bogus.bogus'
 expectedOfferingName = "test-offering"
 expectedOfferingURL = "https://cm.globalcatalog.test.cloud.ibm.com/api/v1-beta/catalogs/{}/offerings/{}"
 
-if os.path.exists(configFile):
-    load_dotenv(dotenv_path=configFile)
-    configLoaded = True
-else:
-    print('External configuration was not found, skipping tests...')
 
 class TestCatalogManagementV1(unittest.TestCase):
     """
     Integration Test Class for CaatalogManagementV1
     """
+    @classmethod
+    def setup_class(cls):
+        if os.path.exists(config_file):
+            os.environ['IBM_CREDENTIALS_FILE'] = config_file
+
+            cls.service = CatalogManagementV1.new_instance()
+
+            cls.config = read_external_sources(
+                CatalogManagementV1.DEFAULT_SERVICE_NAME)
+            assert cls.config is not None
+
+            cls.gitToken = cls.config.get('GIT_TOKEN')
+            assert cls.gitToken is not None
+
+            cls.clean_catalogs(cls, expectedLabel)
+
+            print('Finished setup.')
 
     @classmethod
-    def setUpClass(self):
-        if not configLoaded:
-            raise unittest.SkipTest('External configuration not available, skipping...')
+    def teardown_class(cls):
+        cls.clean_catalogs(cls, expectedLabel)
 
-        self.service = CatalogManagementV1.new_instance()
+    needscredentials = pytest.mark.skipif(
+        not os.path.exists(config_file),
+        reason="External configuration not available, skipping...")
 
-        self.config = read_external_sources(CatalogManagementV1.DEFAULT_SERVICE_NAME)
-        assert self.config is not None
-
-        self.gitToken = self.config.get('GIT_TOKEN')
-        assert self.gitToken is not None
-
-    def setUp(self):
+    def clean_catalogs(self, label):
+        print('Cleaning catalogs...')
         result = self.service.list_catalogs().get_result()
-
         if result is not None:
             resources = result.get('resources')
+            # print("Catalogs to clean up: ", json.dumps(resources, indent=2))
             for resource in resources:
-                if resource.get('label') == expectedLabel:
-                    self.service.delete_catalog(catalog_identifier=resource.get('id'))
-
-    def tearDown(self):
-        result = self.service.list_catalogs().get_result()
-
-        if result is not None:
-            resources = result.get('resources')
-            for resource in resources:
-                if resource.get('label') == expectedLabel:
-                    self.service.delete_catalog(catalog_identifier=resource.get('id'))
+                label = resource.get('label')
+                if label.startswith(sdk_label_prefix):
+                    catalog_id = resource.get('id')
+                    print('Deleting catalog id={}, label={}'.format(
+                        catalog_id, label))
+                    self.service.delete_catalog(catalog_identifier=catalog_id)
+        print('Finished cleaning catalogs.')
 
     def test_get_catalog_account(self):
         response = self.service.get_catalog_account()
@@ -91,8 +94,10 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert result.get('id') == expectedAccount
         assert result.get('account_filters').get('include_all') is True
         assert result.get('account_filters').get('category_filters') is None
-        assert result.get('account_filters').get('id_filters').get('include') is None
-        assert result.get('account_filters').get('id_filters').get('exclude') is None
+        assert result.get('account_filters').get('id_filters').get(
+            'include') is None
+        assert result.get('account_filters').get('id_filters').get(
+            'exclude') is None
 
     def test_get_catalog_account_filters(self):
         response = self.service.get_catalog_account_filters()
@@ -103,14 +108,17 @@ class TestCatalogManagementV1(unittest.TestCase):
         result = response.get_result()
         assert result.get('account_filters')[0].get('include_all') is True
         assert result.get('account_filters')[0].get('category_filters') is None
-        assert result.get('account_filters')[0].get('id_filters') .get('include') is None
-        assert result.get('account_filters')[0].get('id_filters') .get('exclude') is None
+        assert result.get('account_filters')[0].get('id_filters').get(
+            'include') is None
+        assert result.get('account_filters')[0].get('id_filters').get(
+            'exclude') is None
 
     def test_list_catalogs(self):
         catalogCount = 0
         catalogIndex = -1
 
-        createResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        createResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         createResult = createResponse.get_result()
 
         listResponse = self.service.list_catalogs()
@@ -118,7 +126,8 @@ class TestCatalogManagementV1(unittest.TestCase):
         self.service.delete_catalog(catalog_identifier=createResult.get('id'))
 
         if listResponse.get_result() is not None:
-            for i, resource in enumerate(listResponse.get_result().get('resources')):
+            for i, resource in enumerate(
+                    listResponse.get_result().get('resources')):
                 if resource.get('label') == expectedLabel:
                     catalogCount = catalogCount + 1
                     catalogIndex = i
@@ -137,17 +146,26 @@ class TestCatalogManagementV1(unittest.TestCase):
         resources = listResult.get('resources')
         assert resources is not None
         assert resources[catalogIndex].get('label') == expectedLabel
-        assert resources[catalogIndex].get('short_description') == expectedShortDesc
-        assert resources[catalogIndex].get('url') == expectedURL.format(createResult.get('id'))
-        assert resources[catalogIndex].get('offerings_url') == expectedOfferingsURL.format(createResult.get('id'))
+        assert resources[catalogIndex].get(
+            'short_description') == expectedShortDesc
+        assert resources[catalogIndex].get('url') == expectedURL.format(
+            createResult.get('id'))
+        assert resources[catalogIndex].get(
+            'offerings_url') == expectedOfferingsURL.format(
+                createResult.get('id'))
         assert resources[catalogIndex].get('owning_account') == expectedAccount
-        assert resources[catalogIndex].get('catalog_filters').get('include_all') is False
-        assert resources[catalogIndex].get('catalog_filters').get('category_filters') is None
-        assert resources[catalogIndex].get('catalog_filters').get('id_filters').get('include') is None
-        assert resources[catalogIndex].get('catalog_filters').get('id_filters').get('exclude') is None
+        assert resources[catalogIndex].get('catalog_filters').get(
+            'include_all') is False
+        assert resources[catalogIndex].get('catalog_filters').get(
+            'category_filters') is None
+        assert resources[catalogIndex].get('catalog_filters').get(
+            'id_filters').get('include') is None
+        assert resources[catalogIndex].get('catalog_filters').get(
+            'id_filters').get('exclude') is None
 
     def test_create_catalog(self):
-        response = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        response = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
 
         assert response is not None
         assert response.get_status_code() == 201
@@ -159,18 +177,23 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert result.get('label') == expectedLabel
         assert result.get('short_description') == expectedShortDesc
         assert result.get('url') == expectedURL.format(result.get('id'))
-        assert result.get('offerings_url') == expectedOfferingsURL.format(result.get('id'))
+        assert result.get('offerings_url') == expectedOfferingsURL.format(
+            result.get('id'))
         assert result.get('owning_account') == expectedAccount
         assert result.get('catalog_filters').get('include_all') is False
         assert result.get('catalog_filters').get('category_filters') is None
-        assert result.get('catalog_filters').get('id_filters').get('include') is None
-        assert result.get('catalog_filters').get('id_filters').get('exclude') is None
+        assert result.get('catalog_filters').get('id_filters').get(
+            'include') is None
+        assert result.get('catalog_filters').get('id_filters').get(
+            'exclude') is None
 
     def test_get_catalog(self):
-        createResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        createResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         createResult = createResponse.get_result()
 
-        getResponse = self.service.get_catalog(catalog_identifier=createResult.get('id'))
+        getResponse = self.service.get_catalog(
+            catalog_identifier=createResult.get('id'))
         getResult = getResponse.get_result()
 
         assert getResponse is not None
@@ -181,12 +204,15 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert getResult.get('label') == expectedLabel
         assert getResult.get('short_description') == expectedShortDesc
         assert getResult.get('url') == expectedURL.format(getResult.get('id'))
-        assert getResult.get('offerings_url') == expectedOfferingsURL.format(getResult.get('id'))
+        assert getResult.get('offerings_url') == expectedOfferingsURL.format(
+            getResult.get('id'))
         assert getResult.get('owning_account') == expectedAccount
         assert getResult.get('catalog_filters').get('include_all') is False
         assert getResult.get('catalog_filters').get('category_filters') is None
-        assert getResult.get('catalog_filters').get('id_filters').get('include') is None
-        assert getResult.get('catalog_filters').get('id_filters').get('exclude') is None
+        assert getResult.get('catalog_filters').get('id_filters').get(
+            'include') is None
+        assert getResult.get('catalog_filters').get('id_filters').get(
+            'exclude') is None
 
     def test_get_catalog_failure(self):
         with pytest.raises(ApiException) as e:
@@ -194,13 +220,18 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert e.value.code == 404
 
     def test_update_catalog(self):
-        expectedLabelUpdated     = "test2"
+        expectedLabelUpdated = "test2"
         expectedShortDescUpdated = "integration-test-update"
 
-        createResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        createResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         createResult = createResponse.get_result()
 
-        updateResponse = self.service.replace_catalog(catalog_identifier=createResult.get('id'), id=createResult.get('id'), label=expectedLabelUpdated, short_description=expectedShortDescUpdated)
+        updateResponse = self.service.replace_catalog(
+            catalog_identifier=createResult.get('id'),
+            id=createResult.get('id'),
+            label=expectedLabelUpdated,
+            short_description=expectedShortDescUpdated)
         updateResult = updateResponse.get_result()
 
         self.service.delete_catalog(catalog_identifier=createResult.get('id'))
@@ -209,40 +240,53 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert updateResponse.get_status_code() == 200
 
         assert updateResult.get('label') == expectedLabelUpdated
-        assert updateResult.get('short_description') == expectedShortDescUpdated
+        assert updateResult.get(
+            'short_description') == expectedShortDescUpdated
         # assert updateResult.get('url') == expectedURL.format(createResult.get('id'))
         # assert updateResult.get('offerings_url') == expectedOfferingsURL.format(createResult.get('id'))
         # assert updateResult.get('owning_account') == expectedAccount
         assert updateResult.get('catalog_filters').get('include_all') is True
-        assert updateResult.get('catalog_filters').get('category_filters') is None
-        assert updateResult.get('catalog_filters').get('id_filters').get('include') is None
-        assert updateResult.get('catalog_filters').get('id_filters').get('exclude') is None
+        assert updateResult.get('catalog_filters').get(
+            'category_filters') is None
+        assert updateResult.get('catalog_filters').get('id_filters').get(
+            'include') is None
+        assert updateResult.get('catalog_filters').get('id_filters').get(
+            'exclude') is None
 
     def test_update_catalog_failure(self):
         with pytest.raises(ApiException) as e:
-            self.service.replace_catalog(catalog_identifier=fakeName, id=fakeName)
+            self.service.replace_catalog(catalog_identifier=fakeName,
+                                         id=fakeName)
         assert e.value.code == 404
 
     def test_delete_catalog(self):
-        createResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        createResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         createResult = createResponse.get_result()
 
-        deleteResponse = self.service.delete_catalog(catalog_identifier=createResult.get('id'), id=createResult.get('id'))
+        deleteResponse = self.service.delete_catalog(
+            catalog_identifier=createResult.get('id'),
+            id=createResult.get('id'))
 
         assert deleteResponse is not None
         assert deleteResponse.get_status_code() == 200
 
     def test_delete_catalog_failure(self):
-        deleteResponse = self.service.delete_catalog(catalog_identifier=fakeName, id=fakeName)
+        deleteResponse = self.service.delete_catalog(
+            catalog_identifier=fakeName, id=fakeName)
 
         assert deleteResponse is not None
         assert deleteResponse.get_status_code() == 200
 
     def test_create_offering(self):
-        catalogResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        catalogResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         catalogResult = catalogResponse.get_result()
 
-        offeringResponse = self.service.create_offering(catalog_identifier=catalogResult.get('id'), name=expectedOfferingName, label=expectedLabel)
+        offeringResponse = self.service.create_offering(
+            catalog_identifier=catalogResult.get('id'),
+            name=expectedOfferingName,
+            label=expectedLabel)
         offeringResult = offeringResponse.get_result()
 
         self.service.delete_catalog(catalog_identifier=catalogResult.get('id'))
@@ -250,17 +294,24 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert offeringResponse is not None
         assert offeringResponse.get_status_code() == 201
         assert offeringResult.get('name') == expectedOfferingName
-        assert offeringResult.get('url') == expectedOfferingURL.format(catalogResult.get('id'), offeringResult.get('id'))
+        assert offeringResult.get('url') == expectedOfferingURL.format(
+            catalogResult.get('id'), offeringResult.get('id'))
         assert offeringResult.get('label') == expectedLabel
 
     def test_get_offering(self):
-        catalogResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        catalogResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         catalogResult = catalogResponse.get_result()
 
-        offeringResponse = self.service.create_offering(catalog_identifier=catalogResult.get('id'), name=expectedOfferingName, label=expectedLabel)
+        offeringResponse = self.service.create_offering(
+            catalog_identifier=catalogResult.get('id'),
+            name=expectedOfferingName,
+            label=expectedLabel)
         offeringResult = offeringResponse.get_result()
 
-        getResponse = self.service.get_offering(catalog_identifier=catalogResult.get('id'), offering_id=offeringResult.get('id'))
+        getResponse = self.service.get_offering(
+            catalog_identifier=catalogResult.get('id'),
+            offering_id=offeringResult.get('id'))
         getResult = getResponse.get_result()
 
         self.service.delete_catalog(catalog_identifier=catalogResult.get('id'))
@@ -268,34 +319,45 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert getResponse is not None
         assert getResponse.get_status_code() == 200
         assert getResult.get('name') == expectedOfferingName
-        assert getResult.get('url') == expectedOfferingURL.format(catalogResult.get('id'), offeringResult.get('id'))
+        assert getResult.get('url') == expectedOfferingURL.format(
+            catalogResult.get('id'), offeringResult.get('id'))
         assert getResult.get('label') == expectedLabel
 
     def test_get_offering_failure(self):
-        createResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        createResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         createResult = createResponse.get_result()
 
         with pytest.raises(ApiException) as e:
-            self.service.get_offering(catalog_identifier=createResult.get('id'), offering_id=fakeName)
+            self.service.get_offering(
+                catalog_identifier=createResult.get('id'),
+                offering_id=fakeName)
         assert e.value.code == 404
 
         self.service.delete_catalog(catalog_identifier=createResult.get('id'))
 
         with pytest.raises(ApiException) as e:
-            self.service.get_offering(catalog_identifier=createResult.get('id'), offering_id=fakeName)
+            self.service.get_offering(
+                catalog_identifier=createResult.get('id'),
+                offering_id=fakeName)
         assert e.value.code == 403
 
     def test_list_offerings(self):
         expectedFirst = "/api/v1-beta/catalogs/{}/offerings?limit=100&sort=label"
         expectedLast = "/api/v1-beta/catalogs/{}/offerings?limit=100&sort=label"
 
-        catalogResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        catalogResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         catalogResult = catalogResponse.get_result()
 
-        offeringResponse = self.service.create_offering(catalog_identifier=catalogResult.get('id'), name=expectedOfferingName, label=expectedLabel)
+        offeringResponse = self.service.create_offering(
+            catalog_identifier=catalogResult.get('id'),
+            name=expectedOfferingName,
+            label=expectedLabel)
         offeringResult = offeringResponse.get_result()
 
-        listResponse = self.service.list_offerings(catalog_identifier=catalogResult.get('id'))
+        listResponse = self.service.list_offerings(
+            catalog_identifier=catalogResult.get('id'))
         listResult = listResponse.get_result()
 
         self.service.delete_catalog(catalog_identifier=catalogResult.get('id'))
@@ -306,26 +368,35 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert listResult.get('limit') == 100
         assert listResult.get('total_count') == 1
         assert listResult.get('resource_count') == 1
-        assert listResult.get('first') == expectedFirst.format(catalogResult.get('id'))
-        assert listResult.get('last') == expectedLast.format(catalogResult.get('id'))
+        assert listResult.get('first') == expectedFirst.format(
+            catalogResult.get('id'))
+        assert listResult.get('last') == expectedLast.format(
+            catalogResult.get('id'))
 
         resources = listResult.get('resources')
         assert resources is not None
         assert resources[0].get('id') == offeringResult.get('id')
-        assert resources[0].get('url') == expectedOfferingURL.format(catalogResult.get('id'), offeringResult.get('id'))
+        assert resources[0].get('url') == expectedOfferingURL.format(
+            catalogResult.get('id'), offeringResult.get('id'))
         assert resources[0].get('label') == expectedLabel
         assert resources[0].get('name') == expectedOfferingName
         assert resources[0].get('catalog_id') == catalogResult.get('id')
         assert resources[0].get('catalog_name') == expectedLabel
 
     def test_delete_offering(self):
-        catalogResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        catalogResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         catalogResult = catalogResponse.get_result()
 
-        offeringResponse = self.service.create_offering(catalog_identifier=catalogResult.get('id'), name=expectedOfferingName, label=expectedLabel)
+        offeringResponse = self.service.create_offering(
+            catalog_identifier=catalogResult.get('id'),
+            name=expectedOfferingName,
+            label=expectedLabel)
         offeringResult = offeringResponse.get_result()
 
-        deleteResponse = self.service.delete_offering(catalog_identifier=catalogResult.get('id'), offering_id=offeringResult.get('id'))
+        deleteResponse = self.service.delete_offering(
+            catalog_identifier=catalogResult.get('id'),
+            offering_id=offeringResult.get('id'))
 
         self.service.delete_catalog(catalog_identifier=catalogResult.get('id'))
 
@@ -333,10 +404,12 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert deleteResponse.get_status_code() == 200
 
     def test_delete_offering_failure(self):
-        catalogResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        catalogResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         catalogResult = catalogResponse.get_result()
 
-        deleteResponse = self.service.delete_offering(catalog_identifier=catalogResult.get('id'), offering_id=fakeName)
+        deleteResponse = self.service.delete_offering(
+            catalog_identifier=catalogResult.get('id'), offering_id=fakeName)
 
         self.service.delete_catalog(catalog_identifier=catalogResult.get('id'))
 
@@ -344,20 +417,32 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert deleteResponse.get_status_code() == 200
 
         with pytest.raises(ApiException) as e:
-            self.service.delete_offering(catalog_identifier=catalogResult.get('id'), offering_id=fakeName)
+            self.service.delete_offering(
+                catalog_identifier=catalogResult.get('id'),
+                offering_id=fakeName)
         assert e.value.code == 403
 
     def test_update_offering(self):
-        expectedLabelUpdate     = "test-update"
+        expectedLabelUpdate = "test-update"
         expectedShortDescUpdate = "test-desc-update"
 
-        catalogResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        catalogResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         catalogResult = catalogResponse.get_result()
 
-        offeringResponse = self.service.create_offering(catalog_identifier=catalogResult.get('id'), name=expectedOfferingName, label=expectedLabel)
+        offeringResponse = self.service.create_offering(
+            catalog_identifier=catalogResult.get('id'),
+            name=expectedOfferingName,
+            label=expectedLabel)
         offeringResult = offeringResponse.get_result()
 
-        updateResponse = self.service.replace_offering(catalog_identifier=catalogResult.get('id'), offering_id=offeringResult.get('id'), id=offeringResult.get('id'), rev=offeringResult.get('_rev'), label=expectedLabelUpdate, short_description=expectedShortDescUpdate)
+        updateResponse = self.service.replace_offering(
+            catalog_identifier=catalogResult.get('id'),
+            offering_id=offeringResult.get('id'),
+            id=offeringResult.get('id'),
+            rev=offeringResult.get('_rev'),
+            label=expectedLabelUpdate,
+            short_description=expectedShortDescUpdate)
         updateResult = updateResponse.get_result()
 
         self.service.delete_catalog(catalog_identifier=catalogResult.get('id'))
@@ -365,21 +450,31 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert updateResponse is not None
         assert updateResponse.get_status_code() == 200
         assert updateResult.get('short_description') == expectedShortDescUpdate
-        assert updateResult.get('url') == expectedOfferingURL.format(catalogResult.get('id'), offeringResult.get('id'))
+        assert updateResult.get('url') == expectedOfferingURL.format(
+            catalogResult.get('id'), offeringResult.get('id'))
         assert updateResult.get('label') == expectedLabelUpdate
 
     def test_update_offering_failure(self):
-        createResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        createResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         createResult = createResponse.get_result()
 
         with pytest.raises(ApiException) as e:
-            self.service.replace_offering(catalog_identifier=createResult.get('id'), offering_id=fakeName, id=fakeName, rev=fakeName)
+            self.service.replace_offering(
+                catalog_identifier=createResult.get('id'),
+                offering_id=fakeName,
+                id=fakeName,
+                rev=fakeName)
         assert e.value.code == 404
 
         self.service.delete_catalog(catalog_identifier=createResult.get('id'))
 
         with pytest.raises(ApiException) as e:
-            self.service.replace_offering(catalog_identifier=createResult.get('id'), offering_id=fakeName, id=fakeName, rev=fakeName)
+            self.service.replace_offering(
+                catalog_identifier=createResult.get('id'),
+                offering_id=fakeName,
+                id=fakeName,
+                rev=fakeName)
         assert e.value.code == 403
 
     def test_get_consumption_offerings(self):
@@ -397,17 +492,21 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert getResult.get('resources') is not None
 
     def test_import_offering(self):
-        expectedOfferingZipURL  = 'https://github.com/operator-framework/community-operators/blob/master/community-operators/jenkins-operator/0.4.0/jenkins-operator.v0.4.0.clusterserviceversion.yaml'
+        expectedOfferingZipURL = 'https://github.com/operator-framework/community-operators/blob/master/community-operators/jenkins-operator/0.4.0/jenkins-operator.v0.4.0.clusterserviceversion.yaml'
         expectedOfferingTargetKind = 'roks'
-        expectedOfferingVersion    = "0.4.0"
+        expectedOfferingVersion = "0.4.0"
         expectedJenkinsOfferingName = 'jenkins-operator'
         expectedJenkinsOfferingLabel = 'Jenkins Operator'
-        expectedJenkinsOfferingShortDesc  = 'Kubernetes native operator which fully manages Jenkins on Openshift.'
+        expectedJenkinsOfferingShortDesc = 'Kubernetes native operator which fully manages Jenkins on Openshift.'
 
-        catalogResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        catalogResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         catalogResult = catalogResponse.get_result()
 
-        offeringResponse = self.service.import_offering(catalog_identifier=catalogResult.get('id'), zipurl=expectedOfferingZipURL, x_auth_token=self.gitToken)
+        offeringResponse = self.service.import_offering(
+            catalog_identifier=catalogResult.get('id'),
+            zipurl=expectedOfferingZipURL,
+            x_auth_token=self.gitToken)
         offeringResult = offeringResponse.get_result()
 
         self.service.delete_catalog(catalog_identifier=catalogResult.get('id'))
@@ -415,34 +514,47 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert offeringResponse is not None
         assert offeringResponse.get_status_code() == 201
         assert offeringResult.get('name') == expectedJenkinsOfferingName
-        assert offeringResult.get('url') == expectedOfferingURL.format(catalogResult.get('id'), offeringResult.get('id'))
+        assert offeringResult.get('url') == expectedOfferingURL.format(
+            catalogResult.get('id'), offeringResult.get('id'))
         assert offeringResult.get('label') == expectedJenkinsOfferingLabel
-        assert offeringResult.get('short_description') == expectedJenkinsOfferingShortDesc
+        assert offeringResult.get(
+            'short_description') == expectedJenkinsOfferingShortDesc
         assert offeringResult.get('catalog_name') == expectedLabel
         assert offeringResult.get('catalog_id') == catalogResult.get('id')
         assert offeringResult.get('kinds') is not None
-        assert offeringResult.get('kinds')[0].get('target_kind') == expectedOfferingTargetKind
+        assert offeringResult.get('kinds')[0].get(
+            'target_kind') == expectedOfferingTargetKind
         assert offeringResult.get('kinds')[0].get('versions') is not None
-        assert offeringResult.get('kinds')[0].get('versions')[0].get('version') == expectedOfferingVersion
-        assert offeringResult.get('kinds')[0].get('versions')[0].get('tgz_url') == expectedOfferingZipURL
+        assert offeringResult.get('kinds')[0].get('versions')[0].get(
+            'version') == expectedOfferingVersion
+        assert offeringResult.get('kinds')[0].get('versions')[0].get(
+            'tgz_url') == expectedOfferingZipURL
 
     def test_import_offering_version(self):
-        expectedOfferingZipURL  = 'https://github.com/operator-framework/community-operators/blob/master/community-operators/jenkins-operator/0.3.31/jenkins-operator.v0.3.31.clusterserviceversion.yaml'
+        expectedOfferingZipURL = 'https://github.com/operator-framework/community-operators/blob/master/community-operators/jenkins-operator/0.3.31/jenkins-operator.v0.3.31.clusterserviceversion.yaml'
         expectedOfferingZipURLUpdate = "https://github.com/operator-framework/community-operators/blob/master/community-operators/jenkins-operator/0.4.0/jenkins-operator.v0.4.0.clusterserviceversion.yaml"
         expectedOfferingTargetKind = 'roks'
-        expectedOfferingVersion    = "0.3.31"
-        expectedOfferingVersionUpdate    = "0.4.0"
+        expectedOfferingVersion = "0.3.31"
+        expectedOfferingVersionUpdate = "0.4.0"
         expectedJenkinsOfferingName = 'jenkins-operator'
         expectedJenkinsOfferingLabel = 'Jenkins Operator'
-        expectedJenkinsOfferingShortDesc  = 'Kubernetes native operator which fully manages Jenkins on Openshift.'
+        expectedJenkinsOfferingShortDesc = 'Kubernetes native operator which fully manages Jenkins on Openshift.'
 
-        catalogResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        catalogResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         catalogResult = catalogResponse.get_result()
 
-        offeringResponse = self.service.import_offering(catalog_identifier=catalogResult.get('id'), zipurl=expectedOfferingZipURL, x_auth_token=self.gitToken)
+        offeringResponse = self.service.import_offering(
+            catalog_identifier=catalogResult.get('id'),
+            zipurl=expectedOfferingZipURL,
+            x_auth_token=self.gitToken)
         offeringResult = offeringResponse.get_result()
 
-        versionResponse = self.service.import_offering_version(catalog_identifier=catalogResult.get('id'), offering_id=offeringResult.get('id'), zipurl=expectedOfferingZipURLUpdate, x_auth_token=self.gitToken)
+        versionResponse = self.service.import_offering_version(
+            catalog_identifier=catalogResult.get('id'),
+            offering_id=offeringResult.get('id'),
+            zipurl=expectedOfferingZipURLUpdate,
+            x_auth_token=self.gitToken)
         versionResult = versionResponse.get_result()
 
         self.service.delete_catalog(catalog_identifier=catalogResult.get('id'))
@@ -450,33 +562,49 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert versionResponse is not None
         assert versionResponse.get_status_code() == 201
         assert versionResult.get('name') == expectedJenkinsOfferingName
-        assert versionResult.get('url') == expectedOfferingURL.format(catalogResult.get('id'), offeringResult.get('id'))
+        assert versionResult.get('url') == expectedOfferingURL.format(
+            catalogResult.get('id'), offeringResult.get('id'))
         assert versionResult.get('label') == expectedJenkinsOfferingLabel
-        assert versionResult.get('short_description') == expectedJenkinsOfferingShortDesc
+        assert versionResult.get(
+            'short_description') == expectedJenkinsOfferingShortDesc
         assert versionResult.get('catalog_name') == expectedLabel
         assert versionResult.get('catalog_id') == catalogResult.get('id')
         assert versionResult.get('kinds') is not None
-        assert versionResult.get('kinds')[0].get('target_kind') == expectedOfferingTargetKind
+        assert versionResult.get('kinds')[0].get(
+            'target_kind') == expectedOfferingTargetKind
         assert versionResult.get('kinds')[0].get('versions') is not None
-        assert versionResult.get('kinds')[0].get('versions')[0].get('version') == expectedOfferingVersion
-        assert versionResult.get('kinds')[0].get('versions')[0].get('tgz_url') == expectedOfferingZipURL
-        assert versionResult.get('kinds')[0].get('versions')[1].get('version') == expectedOfferingVersionUpdate
-        assert versionResult.get('kinds')[0].get('versions')[1].get('tgz_url') == expectedOfferingZipURLUpdate
+        assert versionResult.get('kinds')[0].get('versions')[0].get(
+            'version') == expectedOfferingVersion
+        assert versionResult.get('kinds')[0].get('versions')[0].get(
+            'tgz_url') == expectedOfferingZipURL
+        assert versionResult.get('kinds')[0].get('versions')[1].get(
+            'version') == expectedOfferingVersionUpdate
+        assert versionResult.get('kinds')[0].get('versions')[1].get(
+            'tgz_url') == expectedOfferingZipURLUpdate
 
     def test_import_offering_version_failure(self):
-        expectedOfferingZipURL  = 'https://github.com/operator-framework/community-operators/blob/master/community-operators/jenkins-operator/0.3.31/jenkins-operator.v0.3.31.clusterserviceversion.yaml'
+        expectedOfferingZipURL = 'https://github.com/operator-framework/community-operators/blob/master/community-operators/jenkins-operator/0.3.31/jenkins-operator.v0.3.31.clusterserviceversion.yaml'
 
-        createResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        createResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         createResult = createResponse.get_result()
 
         with pytest.raises(ApiException) as e:
-            self.service.import_offering_version(catalog_identifier=createResult.get('id'), offering_id=fakeName, zipurl=expectedOfferingZipURL, x_auth_token=self.gitToken)
+            self.service.import_offering_version(
+                catalog_identifier=createResult.get('id'),
+                offering_id=fakeName,
+                zipurl=expectedOfferingZipURL,
+                x_auth_token=self.gitToken)
         assert e.value.code == 404
 
         self.service.delete_catalog(catalog_identifier=createResult.get('id'))
 
         with pytest.raises(ApiException) as e:
-            self.service.import_offering_version(catalog_identifier=createResult.get('id'), offering_id=fakeName, zipurl=expectedOfferingZipURL, x_auth_token=self.gitToken)
+            self.service.import_offering_version(
+                catalog_identifier=createResult.get('id'),
+                offering_id=fakeName,
+                zipurl=expectedOfferingZipURL,
+                x_auth_token=self.gitToken)
         assert e.value.code == 403
 
     def test_reload_offering(self):
@@ -487,13 +615,22 @@ class TestCatalogManagementV1(unittest.TestCase):
         expectedJenkinsOfferingLabel = 'Jenkins Operator'
         expectedJenkinsOfferingShortDesc = 'Kubernetes native operator which fully manages Jenkins on Openshift.'
 
-        catalogResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        catalogResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         catalogResult = catalogResponse.get_result()
 
-        offeringResponse = self.service.import_offering(catalog_identifier=catalogResult.get('id'), zipurl=expectedOfferingZipURL, x_auth_token=self.gitToken)
+        offeringResponse = self.service.import_offering(
+            catalog_identifier=catalogResult.get('id'),
+            zipurl=expectedOfferingZipURL,
+            x_auth_token=self.gitToken)
         offeringResult = offeringResponse.get_result()
 
-        reloadResponse = self.service.reload_offering(catalog_identifier=catalogResult.get('id'), offering_id=offeringResult.get('id'), zipurl=expectedOfferingZipURL, target_version=expectedOfferingVersion, x_auth_token=self.gitToken)
+        reloadResponse = self.service.reload_offering(
+            catalog_identifier=catalogResult.get('id'),
+            offering_id=offeringResult.get('id'),
+            zipurl=expectedOfferingZipURL,
+            target_version=expectedOfferingVersion,
+            x_auth_token=self.gitToken)
         reloadResult = reloadResponse.get_result()
 
         self.service.delete_catalog(catalog_identifier=catalogResult.get('id'))
@@ -501,32 +638,46 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert reloadResponse is not None
         assert reloadResponse.get_status_code() == 200
         assert reloadResult.get('name') == expectedJenkinsOfferingName
-        assert reloadResult.get('url') == expectedOfferingURL.format(catalogResult.get('id'), offeringResult.get('id'))
+        assert reloadResult.get('url') == expectedOfferingURL.format(
+            catalogResult.get('id'), offeringResult.get('id'))
         assert reloadResult.get('label') == expectedJenkinsOfferingLabel
-        assert reloadResult.get('short_description') == expectedJenkinsOfferingShortDesc
+        assert reloadResult.get(
+            'short_description') == expectedJenkinsOfferingShortDesc
         assert reloadResult.get('catalog_name') == expectedLabel
         assert reloadResult.get('catalog_id') == catalogResult.get('id')
         assert reloadResult.get('kinds') is not None
-        assert reloadResult.get('kinds')[0].get('target_kind') == expectedOfferingTargetKind
+        assert reloadResult.get('kinds')[0].get(
+            'target_kind') == expectedOfferingTargetKind
         assert reloadResult.get('kinds')[0].get('versions') is not None
-        assert reloadResult.get('kinds')[0].get('versions')[0].get('version') == expectedOfferingVersion
-        assert reloadResult.get('kinds')[0].get('versions')[0].get('tgz_url') == expectedOfferingZipURL
+        assert reloadResult.get('kinds')[0].get('versions')[0].get(
+            'version') == expectedOfferingVersion
+        assert reloadResult.get('kinds')[0].get('versions')[0].get(
+            'tgz_url') == expectedOfferingZipURL
 
     def test_reload_offering_failure(self):
-        expectedOfferingZipURL  = 'https://github.com/operator-framework/community-operators/blob/master/community-operators/jenkins-operator/0.3.31/jenkins-operator.v0.3.31.clusterserviceversion.yaml'
+        expectedOfferingZipURL = 'https://github.com/operator-framework/community-operators/blob/master/community-operators/jenkins-operator/0.3.31/jenkins-operator.v0.3.31.clusterserviceversion.yaml'
         expectedOfferingVersion = "0.4.0"
 
-        createResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        createResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         createResult = createResponse.get_result()
 
         with pytest.raises(ApiException) as e:
-            self.service.reload_offering(catalog_identifier=createResult.get('id'), offering_id=fakeName, zipurl=expectedOfferingZipURL, target_version=expectedOfferingVersion)
+            self.service.reload_offering(
+                catalog_identifier=createResult.get('id'),
+                offering_id=fakeName,
+                zipurl=expectedOfferingZipURL,
+                target_version=expectedOfferingVersion)
         assert e.value.code == 404
 
         self.service.delete_catalog(catalog_identifier=createResult.get('id'))
 
         with pytest.raises(ApiException) as e:
-            self.service.reload_offering(catalog_identifier=createResult.get('id'), offering_id=fakeName, zipurl=expectedOfferingZipURL, target_version=expectedOfferingVersion)
+            self.service.reload_offering(
+                catalog_identifier=createResult.get('id'),
+                offering_id=fakeName,
+                zipurl=expectedOfferingZipURL,
+                target_version=expectedOfferingVersion)
         assert e.value.code == 403
 
     def test_get_version(self):
@@ -537,13 +688,19 @@ class TestCatalogManagementV1(unittest.TestCase):
         expectedJenkinsOfferingLabel = 'Jenkins Operator'
         expectedJenkinsOfferingShortDesc = 'Kubernetes native operator which fully manages Jenkins on Openshift.'
 
-        catalogResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        catalogResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         catalogResult = catalogResponse.get_result()
 
-        offeringResponse = self.service.import_offering(catalog_identifier=catalogResult.get('id'), zipurl=expectedOfferingZipURL, x_auth_token=self.gitToken)
+        offeringResponse = self.service.import_offering(
+            catalog_identifier=catalogResult.get('id'),
+            zipurl=expectedOfferingZipURL,
+            x_auth_token=self.gitToken)
         offeringResult = offeringResponse.get_result()
 
-        reloadResponse = self.service.get_version(version_loc_id=offeringResult.get('kinds')[0].get('versions')[0].get('version_locator'))
+        reloadResponse = self.service.get_version(
+            version_loc_id=offeringResult.get('kinds')[0].get(
+                'versions')[0].get('version_locator'))
         reloadResult = reloadResponse.get_result()
 
         self.service.delete_catalog(catalog_identifier=catalogResult.get('id'))
@@ -551,32 +708,43 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert reloadResponse is not None
         assert reloadResponse.get_status_code() == 200
         assert reloadResult.get('name') == expectedJenkinsOfferingName
-        assert reloadResult.get('url') == expectedOfferingURL.format(catalogResult.get('id'), offeringResult.get('id'))
+        assert reloadResult.get('url') == expectedOfferingURL.format(
+            catalogResult.get('id'), offeringResult.get('id'))
         assert reloadResult.get('label') == expectedJenkinsOfferingLabel
-        assert reloadResult.get('short_description') == expectedJenkinsOfferingShortDesc
+        assert reloadResult.get(
+            'short_description') == expectedJenkinsOfferingShortDesc
         assert reloadResult.get('catalog_name') == expectedLabel
         assert reloadResult.get('catalog_id') == catalogResult.get('id')
         assert reloadResult.get('kinds') is not None
-        assert reloadResult.get('kinds')[0].get('target_kind') == expectedOfferingTargetKind
+        assert reloadResult.get('kinds')[0].get(
+            'target_kind') == expectedOfferingTargetKind
         assert reloadResult.get('kinds')[0].get('versions') is not None
-        assert reloadResult.get('kinds')[0].get('versions')[0].get('version') == expectedOfferingVersion
-        assert reloadResult.get('kinds')[0].get('versions')[0].get('tgz_url') == expectedOfferingZipURL
+        assert reloadResult.get('kinds')[0].get('versions')[0].get(
+            'version') == expectedOfferingVersion
+        assert reloadResult.get('kinds')[0].get('versions')[0].get(
+            'tgz_url') == expectedOfferingZipURL
 
     def test_get_version_failure(self):
         with pytest.raises(ApiException) as e:
-             self.service.get_version(version_loc_id=fakeVersionLocator)
+            self.service.get_version(version_loc_id=fakeVersionLocator)
         assert e.value.code == 404
 
     def test_delete_version(self):
         expectedOfferingZipURL = "https://github.com/operator-framework/community-operators/blob/master/community-operators/jenkins-operator/0.4.0/jenkins-operator.v0.4.0.clusterserviceversion.yaml"
 
-        catalogResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        catalogResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         catalogResult = catalogResponse.get_result()
 
-        offeringResponse = self.service.import_offering(catalog_identifier=catalogResult.get('id'), zipurl=expectedOfferingZipURL, x_auth_token=self.gitToken)
+        offeringResponse = self.service.import_offering(
+            catalog_identifier=catalogResult.get('id'),
+            zipurl=expectedOfferingZipURL,
+            x_auth_token=self.gitToken)
         offeringResult = offeringResponse.get_result()
 
-        reloadResponse = self.service.delete_version(version_loc_id=offeringResult.get('kinds')[0].get('versions')[0].get('version_locator'))
+        reloadResponse = self.service.delete_version(
+            version_loc_id=offeringResult.get('kinds')[0].get(
+                'versions')[0].get('version_locator'))
 
         self.service.delete_catalog(catalog_identifier=catalogResult.get('id'))
 
@@ -591,13 +759,19 @@ class TestCatalogManagementV1(unittest.TestCase):
     def test_get_version_about(self):
         expectedOfferingZipURL = "https://github.com/operator-framework/community-operators/blob/master/community-operators/jenkins-operator/0.4.0/jenkins-operator.v0.4.0.clusterserviceversion.yaml"
 
-        catalogResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        catalogResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         catalogResult = catalogResponse.get_result()
 
-        offeringResponse = self.service.import_offering(catalog_identifier=catalogResult.get('id'), zipurl=expectedOfferingZipURL, x_auth_token=self.gitToken)
+        offeringResponse = self.service.import_offering(
+            catalog_identifier=catalogResult.get('id'),
+            zipurl=expectedOfferingZipURL,
+            x_auth_token=self.gitToken)
         offeringResult = offeringResponse.get_result()
 
-        getResponse = self.service.get_version_about(version_loc_id=offeringResult.get('kinds')[0].get('versions')[0].get('version_locator'))
+        getResponse = self.service.get_version_about(
+            version_loc_id=offeringResult.get('kinds')[0].get(
+                'versions')[0].get('version_locator'))
         getResult = getResponse.get_result()
 
         self.service.delete_catalog(catalog_identifier=catalogResult.get('id'))
@@ -612,20 +786,30 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert e.value.code == 404
 
     def test_get_version_updates(self):
-        expectedOfferingZipURL  = 'https://github.com/operator-framework/community-operators/blob/master/community-operators/jenkins-operator/0.3.31/jenkins-operator.v0.3.31.clusterserviceversion.yaml'
+        expectedOfferingZipURL = 'https://github.com/operator-framework/community-operators/blob/master/community-operators/jenkins-operator/0.3.31/jenkins-operator.v0.3.31.clusterserviceversion.yaml'
         expectedOfferingZipURLUpdate = "https://github.com/operator-framework/community-operators/blob/master/community-operators/jenkins-operator/0.4.0/jenkins-operator.v0.4.0.clusterserviceversion.yaml"
-        expectedOfferingVersionUpdate    = "0.4.0"
+        expectedOfferingVersionUpdate = "0.4.0"
 
-        catalogResponse = self.service.create_catalog(label=expectedLabel, short_description=expectedShortDesc)
+        catalogResponse = self.service.create_catalog(
+            label=expectedLabel, short_description=expectedShortDesc)
         catalogResult = catalogResponse.get_result()
 
-        offeringResponse = self.service.import_offering(catalog_identifier=catalogResult.get('id'), zipurl=expectedOfferingZipURL, x_auth_token=self.gitToken)
+        offeringResponse = self.service.import_offering(
+            catalog_identifier=catalogResult.get('id'),
+            zipurl=expectedOfferingZipURL,
+            x_auth_token=self.gitToken)
         offeringResult = offeringResponse.get_result()
 
-        versionResponse = self.service.import_offering_version(catalog_identifier=catalogResult.get('id'), offering_id=offeringResult.get('id'), zipurl=expectedOfferingZipURLUpdate, x_auth_token=self.gitToken)
+        versionResponse = self.service.import_offering_version(
+            catalog_identifier=catalogResult.get('id'),
+            offering_id=offeringResult.get('id'),
+            zipurl=expectedOfferingZipURLUpdate,
+            x_auth_token=self.gitToken)
         versionResult = versionResponse.get_result()
 
-        updateResponse = self.service.get_version_updates(version_loc_id=offeringResult.get('kinds')[0].get('versions')[0].get('version_locator'))
+        updateResponse = self.service.get_version_updates(
+            version_loc_id=offeringResult.get('kinds')[0].get(
+                'versions')[0].get('version_locator'))
         updateResult = updateResponse.get_result()
 
         self.service.delete_catalog(catalog_identifier=catalogResult.get('id'))
@@ -633,9 +817,11 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert updateResponse is not None
         assert updateResponse.get_status_code() == 200
         assert updateResult is not None
-        assert updateResult[0].get('version_locator') == versionResult.get('kinds')[0].get('versions')[1].get('version_locator')
+        assert updateResult[0].get('version_locator') == versionResult.get(
+            'kinds')[0].get('versions')[1].get('version_locator')
         assert updateResult[0].get('version') == expectedOfferingVersionUpdate
-        assert updateResult[0].get('package_version') == expectedOfferingVersionUpdate
+        assert updateResult[0].get(
+            'package_version') == expectedOfferingVersionUpdate
         assert updateResult[0].get('can_update') is True
 
     def test_get_version_updates_failure(self):
@@ -644,8 +830,8 @@ class TestCatalogManagementV1(unittest.TestCase):
         assert e.value.code == 404
 
     def test_get_license_providers(self):
-        expectedTotalResults  = 1
-        expectedTotalPages  = 1
+        expectedTotalResults = 1
+        expectedTotalPages = 1
         expectedName = "IBM Passport Advantage"
         expectedOfferingType = "content"
         expectedCreateURL = "https://www.ibm.com/software/passportadvantage/aboutpassport.html"
@@ -698,6 +884,7 @@ class TestCatalogManagementV1(unittest.TestCase):
         with pytest.raises(ApiException) as e:
             self.service.search_license_offerings(q=fakeName)
         assert e.value.code == 403
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, py35, py36, py37, py38
+envlist = lint, py36, py37, py38, py39
 
 [testenv:lint]
 basepython = python3.7


### PR DESCRIPTION
## PR summary

This commit updates the minimum supported python version
from 3.5 to 3.6 (python 3.5 has already passed its
"end of service" date), and adds support for building/testing
on python 3.9.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->