### PR TITLE
build: update pytest to v7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ deploy:
     branch: main
 
 - provider: pypi
+  setuptools_version: "60.8.2"
   user: __token__
   password: $PYPI_TOKEN
   repository: https://upload.pypi.org/legacy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 couchdb>=1.2,<2.0.0
 coverage>=4.5.4
 pylint>=2.6.0,<3.0.0
-pytest>=6.2.1,<7.0.0
+pytest>=7.0.1,<8.0.0
 pytest-cov>=2.2.1,<3.0.0
 responses>=0.12.1,<1.0.0
 tox>=3.2.0,<4.0.0


### PR DESCRIPTION
## PR summary
This PR updates pytest to the next major version (7.x.x) and pins the `setuptools` package version in the Travis deploy step to fix publishing to PyPi.

~~NOTE: Python 3.6 is no longer supported officially, but it seems to work.~~

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->