### PR TITLE
fix: bump core to 3.15.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.26.0,<3.0.0
 urllib3>=1.26.0,<2.0.0
 python_dateutil>=2.5.3,<3.0.0
-ibm_cloud_sdk_core>=3.15.1,<4.0.0
+ibm_cloud_sdk_core>=3.15.2,<4.0.0


### PR DESCRIPTION
## PR summary
This PR bumps the python core to 3.15.2 so that a new version of PyJWT is pulled in (to avoid a vulnerability).


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->