### PR TITLE
build: use fixed version of setuptools in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
 - sudo apt-get update
 - sudo apt-get install pandoc
 - pip install pypandoc
+- pip install setuptools=="60.8.2"
 
 script:
 - make ci


### PR DESCRIPTION
## PR summary
This commit fixes the version of the `setuptools` package 
to fix build issues with Python 3.7 and 3.8.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
Current: builds are failing for Python 3.7/8
New: hopefully every build will pass :) 
## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->