### PR TITLE
feat(IAM Policy Management): add support for v2/policies

### DIFF
--- a/examples/test_iam_policy_management_v1_examples.py
+++ b/examples/test_iam_policy_management_v1_examples.py
@@ -255,33 +255,46 @@ class TestIamPolicyManagementV1Examples:
             # begin-v2_create_policy
 
             policy_subject = V2PolicyBaseSubject(
-                attributes=[
-                    V2PolicyAttribute(key='iam_id', value=example_user_id, operator='stringEquals')
-                ]
+                attributes=[V2PolicyAttribute(key='iam_id', value=example_user_id, operator='stringEquals')]
             )
             policy_role = PolicyRole(role_id='crn:v1:bluemix:public:iam::::role:Viewer')
-            account_id_resource_attribute = V2PolicyAttribute(key='accountId', value=example_account_id, operator='stringEquals')
-            service_name_resource_attribute = V2PolicyAttribute(key='serviceType', value='service', operator='stringEquals')
+            account_id_resource_attribute = V2PolicyAttribute(
+                key='accountId', value=example_account_id, operator='stringEquals'
+            )
+            service_name_resource_attribute = V2PolicyAttribute(
+                key='serviceType', value='service', operator='stringEquals'
+            )
             policy_resource = PolicyResource(
                 attributes=[account_id_resource_attribute, service_name_resource_attribute],
             )
-            policy_control = V2PolicyBaseControl(
-                grant=V2PolicyBaseControlGrant(
-                    roles=[policy_role]
-                )
-            )
+            policy_control = V2PolicyBaseControl(grant=V2PolicyBaseControlGrant(roles=[policy_role]))
             policy_rule = V2PolicyBaseRuleV2RuleWithConditions(
                 operator='and',
                 conditions=[
-                    V2PolicyAttribute(key='{{environment.attributes.day_of_week}}', operator='dayOfWeekAnyOf', value=[1, 2, 3, 4, 5]),
-                    V2PolicyAttribute(key='{{environment.attributes.current_time}}', operator='timeGreaterThanOrEquals', value='09:00:00+00:00'),
-                    V2PolicyAttribute(key='{{environment.attributes.current_time}}', operator='timeLessThanOrEquals', value='17:00:00+00:00'),
-                ]
+                    V2PolicyAttribute(
+                        key='{{environment.attributes.day_of_week}}', operator='dayOfWeekAnyOf', value=[1, 2, 3, 4, 5]
+                    ),
+                    V2PolicyAttribute(
+                        key='{{environment.attributes.current_time}}',
+                        operator='timeGreaterThanOrEquals',
+                        value='09:00:00+00:00',
+                    ),
+                    V2PolicyAttribute(
+                        key='{{environment.attributes.current_time}}',
+                        operator='timeLessThanOrEquals',
+                        value='17:00:00+00:00',
+                    ),
+                ],
             )
-            policy_pattern='time-based-restrictions:weekly'
+            policy_pattern = 'time-based-restrictions:weekly'
 
             policy = iam_policy_management_service.v2_create_policy(
-                type='access', subject=policy_subject, control=policy_control, resource=policy_resource, rule=policy_rule, pattern=policy_pattern
+                type='access',
+                subject=policy_subject,
+                control=policy_control,
+                resource=policy_resource,
+                rule=policy_rule,
+                pattern=policy_pattern,
             ).get_result()
 
             print(json.dumps(policy, indent=2))
@@ -327,30 +340,38 @@ class TestIamPolicyManagementV1Examples:
             # begin-v2_update_policy
 
             policy_subject = V2PolicyBaseSubject(
-                attributes=[
-                    V2PolicyAttribute(key='iam_id', value=example_user_id, operator='stringEquals')
-                ]
+                attributes=[V2PolicyAttribute(key='iam_id', value=example_user_id, operator='stringEquals')]
             )
             updated_policy_role = PolicyRole(role_id='crn:v1:bluemix:public:iam::::role:Editor')
-            account_id_resource_attribute = V2PolicyAttribute(key='accountId', value=example_account_id, operator='stringEquals')
-            service_name_resource_attribute = V2PolicyAttribute(key='serviceType', value='service', operator='stringEquals')
+            account_id_resource_attribute = V2PolicyAttribute(
+                key='accountId', value=example_account_id, operator='stringEquals'
+            )
+            service_name_resource_attribute = V2PolicyAttribute(
+                key='serviceType', value='service', operator='stringEquals'
+            )
             policy_resource = PolicyResource(
                 attributes=[account_id_resource_attribute, service_name_resource_attribute],
             )
-            policy_control = V2PolicyBaseControl(
-                grant=V2PolicyBaseControlGrant(
-                    roles=[updated_policy_role]
-                )
-            )
+            policy_control = V2PolicyBaseControl(grant=V2PolicyBaseControlGrant(roles=[updated_policy_role]))
             policy_rule = V2PolicyBaseRuleV2RuleWithConditions(
                 operator='and',
                 conditions=[
-                    V2PolicyAttribute(key='{{environment.attributes.day_of_week}}', operator='dayOfWeekAnyOf', value=[1, 2, 3, 4, 5]),
-                    V2PolicyAttribute(key='{{environment.attributes.current_time}}', operator='timeGreaterThanOrEquals', value='09:00:00+00:00'),
-                    V2PolicyAttribute(key='{{environment.attributes.current_time}}', operator='timeLessThanOrEquals', value='17:00:00+00:00'),
-                ]
+                    V2PolicyAttribute(
+                        key='{{environment.attributes.day_of_week}}', operator='dayOfWeekAnyOf', value=[1, 2, 3, 4, 5]
+                    ),
+                    V2PolicyAttribute(
+                        key='{{environment.attributes.current_time}}',
+                        operator='timeGreaterThanOrEquals',
+                        value='09:00:00+00:00',
+                    ),
+                    V2PolicyAttribute(
+                        key='{{environment.attributes.current_time}}',
+                        operator='timeLessThanOrEquals',
+                        value='17:00:00+00:00',
+                    ),
+                ],
             )
-            policy_pattern='time-based-restrictions:weekly'
+            policy_pattern = 'time-based-restrictions:weekly'
 
             response = iam_policy_management_service.v2_update_policy(
                 type='access',

--- a/examples/test_iam_policy_management_v1_examples.py
+++ b/examples/test_iam_policy_management_v1_examples.py
@@ -244,6 +244,174 @@ class TestIamPolicyManagementV1Examples:
             pytest.fail(str(e))
 
     @needscredentials
+    def test_v2_create_policy_example(self):
+        """
+        v2_create_policy request example
+        """
+        try:
+            global example_policy_id
+
+            print('\nv2_create_policy() result:')
+            # begin-v2_create_policy
+
+            policy_subject = V2PolicyBaseSubject(
+                attributes=[
+                    V2PolicyAttribute(key='iam_id', value=example_user_id, operator='stringEquals')
+                ]
+            )
+            policy_role = PolicyRole(role_id='crn:v1:bluemix:public:iam::::role:Viewer')
+            account_id_resource_attribute = V2PolicyAttribute(key='accountId', value=example_account_id, operator='stringEquals')
+            service_name_resource_attribute = V2PolicyAttribute(key='serviceType', value='service', operator='stringEquals')
+            policy_resource = PolicyResource(
+                attributes=[account_id_resource_attribute, service_name_resource_attribute],
+            )
+            policy_control = V2PolicyBaseControl(
+                grant=V2PolicyBaseControlGrant(
+                    roles=[policy_role]
+                )
+            )
+            policy_rule = V2PolicyBaseRuleV2RuleWithConditions(
+                operator='and',
+                conditions=[
+                    V2PolicyAttribute(key='{{environment.attributes.day_of_week}}', operator='dayOfWeekAnyOf', value=[1, 2, 3, 4, 5]),
+                    V2PolicyAttribute(key='{{environment.attributes.current_time}}', operator='timeGreaterThanOrEquals', value='09:00:00+00:00'),
+                    V2PolicyAttribute(key='{{environment.attributes.current_time}}', operator='timeLessThanOrEquals', value='17:00:00+00:00'),
+                ]
+            )
+            policy_pattern='time-based-restrictions:weekly'
+
+            policy = iam_policy_management_service.v2_create_policy(
+                type='access', subject=policy_subject, control=policy_control, resource=policy_resource, rule=policy_rule, pattern=policy_pattern
+            ).get_result()
+
+            print(json.dumps(policy, indent=2))
+
+            # end-v2_create_policy
+
+            example_policy_id = policy['id']
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_v2_get_policy_example(self):
+        """
+        v2_get_policy request example
+        """
+        try:
+            global example_policy_etag
+
+            print('\nv2_get_policy() result:')
+            # begin-v2_get_policy
+
+            response = iam_policy_management_service.v2_get_policy(policy_id=example_policy_id)
+            policy = response.get_result()
+
+            print(json.dumps(policy, indent=2))
+
+            # end-v2_get_policy
+
+            example_policy_etag = response.get_headers().get("Etag")
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_v2_update_policy_example(self):
+        """
+        v2_update_policy request example
+        """
+        try:
+
+            print('\nupdate_policy() result:')
+            # begin-v2_update_policy
+
+            policy_subject = V2PolicyBaseSubject(
+                attributes=[
+                    V2PolicyAttribute(key='iam_id', value=example_user_id, operator='stringEquals')
+                ]
+            )
+            updated_policy_role = PolicyRole(role_id='crn:v1:bluemix:public:iam::::role:Editor')
+            account_id_resource_attribute = V2PolicyAttribute(key='accountId', value=example_account_id, operator='stringEquals')
+            service_name_resource_attribute = V2PolicyAttribute(key='serviceType', value='service', operator='stringEquals')
+            policy_resource = PolicyResource(
+                attributes=[account_id_resource_attribute, service_name_resource_attribute],
+            )
+            policy_control = V2PolicyBaseControl(
+                grant=V2PolicyBaseControlGrant(
+                    roles=[updated_policy_role]
+                )
+            )
+            policy_rule = V2PolicyBaseRuleV2RuleWithConditions(
+                operator='and',
+                conditions=[
+                    V2PolicyAttribute(key='{{environment.attributes.day_of_week}}', operator='dayOfWeekAnyOf', value=[1, 2, 3, 4, 5]),
+                    V2PolicyAttribute(key='{{environment.attributes.current_time}}', operator='timeGreaterThanOrEquals', value='09:00:00+00:00'),
+                    V2PolicyAttribute(key='{{environment.attributes.current_time}}', operator='timeLessThanOrEquals', value='17:00:00+00:00'),
+                ]
+            )
+            policy_pattern='time-based-restrictions:weekly'
+
+            response = iam_policy_management_service.v2_update_policy(
+                type='access',
+                policy_id=example_policy_id,
+                if_match=example_policy_etag,
+                subject=policy_subject,
+                control=policy_control,
+                resource=policy_resource,
+                rule=policy_rule,
+                pattern=policy_pattern,
+            )
+            policy = response.get_result()
+
+            print(json.dumps(policy, indent=2))
+
+            # end-v2_update_policy
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_v2_list_policies_example(self):
+        """
+        v2_list_policies request example
+        """
+        try:
+
+            print('\nlist_policies() result:')
+            # begin-v2_list_policies
+
+            policy_list = iam_policy_management_service.v2_list_policies(
+                account_id=example_account_id, iam_id=example_user_id, format='include_last_permit'
+            ).get_result()
+
+            print(json.dumps(policy_list, indent=2))
+
+            # end-v2_list_policies
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_v2_delete_policy_example(self):
+        """
+        v2_delete_policy request example
+        """
+        try:
+
+            print('\nv2_delete_policy() result:')
+            # begin-v2_delete_policy
+
+            response = iam_policy_management_service.v2_delete_policy(policy_id=example_policy_id).get_result()
+
+            print(json.dumps(response, indent=2))
+
+            # end-v2_delete_policy
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
     def test_create_role_example(self):
         """
         create_role request example

--- a/ibm_platform_services/iam_policy_management_v1.py
+++ b/ibm_platform_services/iam_policy_management_v1.py
@@ -38,6 +38,7 @@ from .common import get_sdk_headers
 # Service
 ##############################################################################
 
+
 class IamPolicyManagementV1(BaseService):
     """The iam_policy_management V1 service."""
 
@@ -45,23 +46,23 @@ class IamPolicyManagementV1(BaseService):
     DEFAULT_SERVICE_NAME = 'iam_policy_management'
 
     @classmethod
-    def new_instance(cls,
-                     service_name: str = DEFAULT_SERVICE_NAME,
-                    ) -> 'IamPolicyManagementV1':
+    def new_instance(
+        cls,
+        service_name: str = DEFAULT_SERVICE_NAME,
+    ) -> 'IamPolicyManagementV1':
         """
         Return a new client for the iam_policy_management service using the
                specified parameters and external configuration.
         """
         authenticator = get_authenticator_from_environment(service_name)
-        service = cls(
-            authenticator
-            )
+        service = cls(authenticator)
         service.configure_service(service_name)
         return service
 
-    def __init__(self,
-                 authenticator: Authenticator = None,
-                ) -> None:
+    def __init__(
+        self,
+        authenticator: Authenticator = None,
+    ) -> None:
         """
         Construct a new client for the iam_policy_management service.
 
@@ -69,17 +70,14 @@ class IamPolicyManagementV1(BaseService):
                Get up to date information from https://github.com/IBM/python-sdk-core/blob/main/README.md
                about initializing the authenticator of your choice.
         """
-        BaseService.__init__(self,
-                             service_url=self.DEFAULT_SERVICE_URL,
-                             authenticator=authenticator)
-
+        BaseService.__init__(self, service_url=self.DEFAULT_SERVICE_URL, authenticator=authenticator)
 
     #########################
     # Policies
     #########################
 
-
-    def list_policies(self,
+    def list_policies(
+        self,
         account_id: str,
         *,
         accept_language: str = None,
@@ -144,12 +142,10 @@ class IamPolicyManagementV1(BaseService):
 
         if not account_id:
             raise ValueError('account_id must be provided')
-        headers = {
-            'Accept-Language': accept_language
-        }
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V1',
-                                      operation_id='list_policies')
+        headers = {'Accept-Language': accept_language}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='list_policies'
+        )
         headers.update(sdk_headers)
 
         params = {
@@ -162,7 +158,7 @@ class IamPolicyManagementV1(BaseService):
             'tag_value': tag_value,
             'sort': sort,
             'format': format,
-            'state': state
+            'state': state,
         }
 
         if 'headers' in kwargs:
@@ -171,16 +167,13 @@ class IamPolicyManagementV1(BaseService):
         headers['Accept'] = 'application/json'
 
         url = '/v1/policies'
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers,
-                                       params=params)
+        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def create_policy(self,
+    def create_policy(
+        self,
         type: str,
         subjects: List['PolicySubject'],
         roles: List['PolicyRole'],
@@ -272,21 +265,13 @@ class IamPolicyManagementV1(BaseService):
         subjects = [convert_model(x) for x in subjects]
         roles = [convert_model(x) for x in roles]
         resources = [convert_model(x) for x in resources]
-        headers = {
-            'Accept-Language': accept_language
-        }
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V1',
-                                      operation_id='create_policy')
+        headers = {'Accept-Language': accept_language}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='create_policy'
+        )
         headers.update(sdk_headers)
 
-        data = {
-            'type': type,
-            'subjects': subjects,
-            'roles': roles,
-            'resources': resources,
-            'description': description
-        }
+        data = {'type': type, 'subjects': subjects, 'roles': roles, 'resources': resources, 'description': description}
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
         headers['content-type'] = 'application/json'
@@ -297,16 +282,13 @@ class IamPolicyManagementV1(BaseService):
         headers['Accept'] = 'application/json'
 
         url = '/v1/policies'
-        request = self.prepare_request(method='POST',
-                                       url=url,
-                                       headers=headers,
-                                       data=data)
+        request = self.prepare_request(method='POST', url=url, headers=headers, data=data)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def update_policy(self,
+    def update_policy(
+        self,
         policy_id: str,
         if_match: str,
         type: str,
@@ -389,21 +371,13 @@ class IamPolicyManagementV1(BaseService):
         subjects = [convert_model(x) for x in subjects]
         roles = [convert_model(x) for x in roles]
         resources = [convert_model(x) for x in resources]
-        headers = {
-            'If-Match': if_match
-        }
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V1',
-                                      operation_id='update_policy')
+        headers = {'If-Match': if_match}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='update_policy'
+        )
         headers.update(sdk_headers)
 
-        data = {
-            'type': type,
-            'subjects': subjects,
-            'roles': roles,
-            'resources': resources,
-            'description': description
-        }
+        data = {'type': type, 'subjects': subjects, 'roles': roles, 'resources': resources, 'description': description}
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
         headers['content-type'] = 'application/json'
@@ -417,19 +391,12 @@ class IamPolicyManagementV1(BaseService):
         path_param_values = self.encode_path_vars(policy_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v1/policies/{policy_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='PUT',
-                                       url=url,
-                                       headers=headers,
-                                       data=data)
+        request = self.prepare_request(method='PUT', url=url, headers=headers, data=data)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def get_policy(self,
-        policy_id: str,
-        **kwargs
-    ) -> DetailedResponse:
+    def get_policy(self, policy_id: str, **kwargs) -> DetailedResponse:
         """
         Retrieve a policy by ID.
 
@@ -444,9 +411,9 @@ class IamPolicyManagementV1(BaseService):
         if not policy_id:
             raise ValueError('policy_id must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V1',
-                                      operation_id='get_policy')
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='get_policy'
+        )
         headers.update(sdk_headers)
 
         if 'headers' in kwargs:
@@ -458,18 +425,12 @@ class IamPolicyManagementV1(BaseService):
         path_param_values = self.encode_path_vars(policy_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v1/policies/{policy_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers)
+        request = self.prepare_request(method='GET', url=url, headers=headers)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def delete_policy(self,
-        policy_id: str,
-        **kwargs
-    ) -> DetailedResponse:
+    def delete_policy(self, policy_id: str, **kwargs) -> DetailedResponse:
         """
         Delete a policy by ID.
 
@@ -486,9 +447,9 @@ class IamPolicyManagementV1(BaseService):
         if not policy_id:
             raise ValueError('policy_id must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V1',
-                                      operation_id='delete_policy')
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='delete_policy'
+        )
         headers.update(sdk_headers)
 
         if 'headers' in kwargs:
@@ -499,21 +460,12 @@ class IamPolicyManagementV1(BaseService):
         path_param_values = self.encode_path_vars(policy_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v1/policies/{policy_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='DELETE',
-                                       url=url,
-                                       headers=headers)
+        request = self.prepare_request(method='DELETE', url=url, headers=headers)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def patch_policy(self,
-        policy_id: str,
-        if_match: str,
-        *,
-        state: str = None,
-        **kwargs
-    ) -> DetailedResponse:
+    def patch_policy(self, policy_id: str, if_match: str, *, state: str = None, **kwargs) -> DetailedResponse:
         """
         Restore a deleted policy by ID.
 
@@ -536,17 +488,13 @@ class IamPolicyManagementV1(BaseService):
             raise ValueError('policy_id must be provided')
         if not if_match:
             raise ValueError('if_match must be provided')
-        headers = {
-            'If-Match': if_match
-        }
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V1',
-                                      operation_id='patch_policy')
+        headers = {'If-Match': if_match}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='patch_policy'
+        )
         headers.update(sdk_headers)
 
-        data = {
-            'state': state
-        }
+        data = {'state': state}
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
         headers['content-type'] = 'application/json'
@@ -560,10 +508,7 @@ class IamPolicyManagementV1(BaseService):
         path_param_values = self.encode_path_vars(policy_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v1/policies/{policy_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='PATCH',
-                                       url=url,
-                                       headers=headers,
-                                       data=data)
+        request = self.prepare_request(method='PATCH', url=url, headers=headers, data=data)
 
         response = self.send(request, **kwargs)
         return response
@@ -572,8 +517,8 @@ class IamPolicyManagementV1(BaseService):
     # Roles
     #########################
 
-
-    def list_roles(self,
+    def list_roles(
+        self,
         *,
         accept_language: str = None,
         account_id: str = None,
@@ -615,19 +560,17 @@ class IamPolicyManagementV1(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `RoleList` object
         """
 
-        headers = {
-            'Accept-Language': accept_language
-        }
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V1',
-                                      operation_id='list_roles')
+        headers = {'Accept-Language': accept_language}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='list_roles'
+        )
         headers.update(sdk_headers)
 
         params = {
             'account_id': account_id,
             'service_name': service_name,
             'source_service_name': source_service_name,
-            'policy_type': policy_type
+            'policy_type': policy_type,
         }
 
         if 'headers' in kwargs:
@@ -636,16 +579,13 @@ class IamPolicyManagementV1(BaseService):
         headers['Accept'] = 'application/json'
 
         url = '/v2/roles'
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers,
-                                       params=params)
+        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def create_role(self,
+    def create_role(
+        self,
         display_name: str,
         actions: List[str],
         name: str,
@@ -702,12 +642,10 @@ class IamPolicyManagementV1(BaseService):
             raise ValueError('account_id must be provided')
         if service_name is None:
             raise ValueError('service_name must be provided')
-        headers = {
-            'Accept-Language': accept_language
-        }
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V1',
-                                      operation_id='create_role')
+        headers = {'Accept-Language': accept_language}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='create_role'
+        )
         headers.update(sdk_headers)
 
         data = {
@@ -716,7 +654,7 @@ class IamPolicyManagementV1(BaseService):
             'name': name,
             'account_id': account_id,
             'service_name': service_name,
-            'description': description
+            'description': description,
         }
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
@@ -728,16 +666,13 @@ class IamPolicyManagementV1(BaseService):
         headers['Accept'] = 'application/json'
 
         url = '/v2/roles'
-        request = self.prepare_request(method='POST',
-                                       url=url,
-                                       headers=headers,
-                                       data=data)
+        request = self.prepare_request(method='POST', url=url, headers=headers, data=data)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def update_role(self,
+    def update_role(
+        self,
         role_id: str,
         if_match: str,
         *,
@@ -772,19 +707,13 @@ class IamPolicyManagementV1(BaseService):
             raise ValueError('role_id must be provided')
         if not if_match:
             raise ValueError('if_match must be provided')
-        headers = {
-            'If-Match': if_match
-        }
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V1',
-                                      operation_id='update_role')
+        headers = {'If-Match': if_match}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='update_role'
+        )
         headers.update(sdk_headers)
 
-        data = {
-            'display_name': display_name,
-            'description': description,
-            'actions': actions
-        }
+        data = {'display_name': display_name, 'description': description, 'actions': actions}
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
         headers['content-type'] = 'application/json'
@@ -798,19 +727,12 @@ class IamPolicyManagementV1(BaseService):
         path_param_values = self.encode_path_vars(role_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v2/roles/{role_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='PUT',
-                                       url=url,
-                                       headers=headers,
-                                       data=data)
+        request = self.prepare_request(method='PUT', url=url, headers=headers, data=data)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def get_role(self,
-        role_id: str,
-        **kwargs
-    ) -> DetailedResponse:
+    def get_role(self, role_id: str, **kwargs) -> DetailedResponse:
         """
         Retrieve a role by ID.
 
@@ -825,9 +747,9 @@ class IamPolicyManagementV1(BaseService):
         if not role_id:
             raise ValueError('role_id must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V1',
-                                      operation_id='get_role')
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='get_role'
+        )
         headers.update(sdk_headers)
 
         if 'headers' in kwargs:
@@ -839,18 +761,12 @@ class IamPolicyManagementV1(BaseService):
         path_param_values = self.encode_path_vars(role_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v2/roles/{role_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers)
+        request = self.prepare_request(method='GET', url=url, headers=headers)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def delete_role(self,
-        role_id: str,
-        **kwargs
-    ) -> DetailedResponse:
+    def delete_role(self, role_id: str, **kwargs) -> DetailedResponse:
         """
         Delete a role by ID.
 
@@ -865,9 +781,9 @@ class IamPolicyManagementV1(BaseService):
         if not role_id:
             raise ValueError('role_id must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V1',
-                                      operation_id='delete_role')
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='delete_role'
+        )
         headers.update(sdk_headers)
 
         if 'headers' in kwargs:
@@ -878,9 +794,7 @@ class IamPolicyManagementV1(BaseService):
         path_param_values = self.encode_path_vars(role_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v2/roles/{role_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='DELETE',
-                                       url=url,
-                                       headers=headers)
+        request = self.prepare_request(method='DELETE', url=url, headers=headers)
 
         response = self.send(request, **kwargs)
         return response
@@ -889,8 +803,8 @@ class IamPolicyManagementV1(BaseService):
     # v2Policies
     #########################
 
-
-    def v2_list_policies(self,
+    def v2_list_policies(
+        self,
         account_id: str,
         *,
         accept_language: str = None,
@@ -949,12 +863,10 @@ class IamPolicyManagementV1(BaseService):
 
         if not account_id:
             raise ValueError('account_id must be provided')
-        headers = {
-            'Accept-Language': accept_language
-        }
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V1',
-                                      operation_id='v2_list_policies')
+        headers = {'Accept-Language': accept_language}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='v2_list_policies'
+        )
         headers.update(sdk_headers)
 
         params = {
@@ -966,7 +878,7 @@ class IamPolicyManagementV1(BaseService):
             'service_name': service_name,
             'service_group_id': service_group_id,
             'format': format,
-            'state': state
+            'state': state,
         }
 
         if 'headers' in kwargs:
@@ -975,16 +887,13 @@ class IamPolicyManagementV1(BaseService):
         headers['Accept'] = 'application/json'
 
         url = '/v2/policies'
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers,
-                                       params=params)
+        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def v2_create_policy(self,
+    def v2_create_policy(
+        self,
         type: str,
         control: 'V2PolicyBaseControl',
         *,
@@ -1104,12 +1013,10 @@ class IamPolicyManagementV1(BaseService):
             resource = convert_model(resource)
         if rule is not None:
             rule = convert_model(rule)
-        headers = {
-            'Accept-Language': accept_language
-        }
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V1',
-                                      operation_id='v2_create_policy')
+        headers = {'Accept-Language': accept_language}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='v2_create_policy'
+        )
         headers.update(sdk_headers)
 
         data = {
@@ -1119,7 +1026,7 @@ class IamPolicyManagementV1(BaseService):
             'subject': subject,
             'resource': resource,
             'pattern': pattern,
-            'rule': rule
+            'rule': rule,
         }
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
@@ -1131,16 +1038,13 @@ class IamPolicyManagementV1(BaseService):
         headers['Accept'] = 'application/json'
 
         url = '/v2/policies'
-        request = self.prepare_request(method='POST',
-                                       url=url,
-                                       headers=headers,
-                                       data=data)
+        request = self.prepare_request(method='POST', url=url, headers=headers, data=data)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def v2_update_policy(self,
+    def v2_update_policy(
+        self,
         policy_id: str,
         if_match: str,
         type: str,
@@ -1253,12 +1157,10 @@ class IamPolicyManagementV1(BaseService):
             resource = convert_model(resource)
         if rule is not None:
             rule = convert_model(rule)
-        headers = {
-            'If-Match': if_match
-        }
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V1',
-                                      operation_id='v2_update_policy')
+        headers = {'If-Match': if_match}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='v2_update_policy'
+        )
         headers.update(sdk_headers)
 
         data = {
@@ -1268,7 +1170,7 @@ class IamPolicyManagementV1(BaseService):
             'subject': subject,
             'resource': resource,
             'pattern': pattern,
-            'rule': rule
+            'rule': rule,
         }
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
@@ -1283,19 +1185,12 @@ class IamPolicyManagementV1(BaseService):
         path_param_values = self.encode_path_vars(policy_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v2/policies/{policy_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='PUT',
-                                       url=url,
-                                       headers=headers,
-                                       data=data)
+        request = self.prepare_request(method='PUT', url=url, headers=headers, data=data)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def v2_get_policy(self,
-        policy_id: str,
-        **kwargs
-    ) -> DetailedResponse:
+    def v2_get_policy(self, policy_id: str, **kwargs) -> DetailedResponse:
         """
         Retrieve a policy by ID.
 
@@ -1310,9 +1205,9 @@ class IamPolicyManagementV1(BaseService):
         if not policy_id:
             raise ValueError('policy_id must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V1',
-                                      operation_id='v2_get_policy')
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='v2_get_policy'
+        )
         headers.update(sdk_headers)
 
         if 'headers' in kwargs:
@@ -1324,18 +1219,12 @@ class IamPolicyManagementV1(BaseService):
         path_param_values = self.encode_path_vars(policy_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v2/policies/{policy_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers)
+        request = self.prepare_request(method='GET', url=url, headers=headers)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def v2_delete_policy(self,
-        policy_id: str,
-        **kwargs
-    ) -> DetailedResponse:
+    def v2_delete_policy(self, policy_id: str, **kwargs) -> DetailedResponse:
         """
         Delete a policy by ID.
 
@@ -1352,9 +1241,9 @@ class IamPolicyManagementV1(BaseService):
         if not policy_id:
             raise ValueError('policy_id must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V1',
-                                      operation_id='v2_delete_policy')
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='v2_delete_policy'
+        )
         headers.update(sdk_headers)
 
         if 'headers' in kwargs:
@@ -1365,9 +1254,7 @@ class IamPolicyManagementV1(BaseService):
         path_param_values = self.encode_path_vars(policy_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v2/policies/{policy_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='DELETE',
-                                       url=url,
-                                       headers=headers)
+        request = self.prepare_request(method='DELETE', url=url, headers=headers)
 
         response = self.send(request, **kwargs)
         return response
@@ -1382,19 +1269,24 @@ class ListPoliciesEnums:
         """
         Optional type of policy.
         """
+
         ACCESS = 'access'
         AUTHORIZATION = 'authorization'
+
     class ServiceType(str, Enum):
         """
         Optional type of service.
         """
+
         SERVICE = 'service'
         PLATFORM_SERVICE = 'platform_service'
+
     class Sort(str, Enum):
         """
         Optional top level policy field to sort results. Ascending sort is default.
         Descending sort available by prepending '-' to field. Example '-last_modified_at'.
         """
+
         ID = 'id'
         TYPE = 'type'
         HREF = 'href'
@@ -1403,6 +1295,7 @@ class ListPoliciesEnums:
         LAST_MODIFIED_AT = 'last_modified_at'
         LAST_MODIFIED_BY_ID = 'last_modified_by_id'
         STATE = 'state'
+
     class Format(str, Enum):
         """
         Include additional data per policy returned
@@ -1411,14 +1304,17 @@ class ListPoliciesEnums:
         * `display` - returns the list of all actions included in each of the policy
         roles.
         """
+
         INCLUDE_LAST_PERMIT = 'include_last_permit'
         DISPLAY = 'display'
+
     class State(str, Enum):
         """
         The state of the policy.
         * `active` - returns active policies
         * `deleted` - returns non-active policies.
         """
+
         ACTIVE = 'active'
         DELETED = 'deleted'
 
@@ -1432,14 +1328,18 @@ class V2ListPoliciesEnums:
         """
         Optional type of policy.
         """
+
         ACCESS = 'access'
         AUTHORIZATION = 'authorization'
+
     class ServiceType(str, Enum):
         """
         Optional type of service.
         """
+
         SERVICE = 'service'
         PLATFORM_SERVICE = 'platform_service'
+
     class Format(str, Enum):
         """
         Include additional data per policy returned
@@ -1448,14 +1348,17 @@ class V2ListPoliciesEnums:
         * `display` - returns the list of all actions included in each of the policy roles
         and translations for all relevant fields.
         """
+
         INCLUDE_LAST_PERMIT = 'include_last_permit'
         DISPLAY = 'display'
+
     class State(str, Enum):
         """
         The state of the policy.
         * `active` - returns active policies
         * `deleted` - returns non-active policies.
         """
+
         ACTIVE = 'active'
         DELETED = 'deleted'
 
@@ -1465,15 +1368,14 @@ class V2ListPoliciesEnums:
 ##############################################################################
 
 
-class V2PolicyBaseControl():
+class V2PolicyBaseControl:
     """
     Specifies the type of access granted by the policy.
 
     :attr V2PolicyBaseControlGrant grant: Permission granted by the policy.
     """
 
-    def __init__(self,
-                 grant: 'V2PolicyBaseControlGrant') -> None:
+    def __init__(self, grant: 'V2PolicyBaseControlGrant') -> None:
         """
         Initialize a V2PolicyBaseControl object.
 
@@ -1524,7 +1426,8 @@ class V2PolicyBaseControl():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class V2PolicyBaseControlGrant():
+
+class V2PolicyBaseControlGrant:
     """
     Permission granted by the policy.
 
@@ -1532,8 +1435,7 @@ class V2PolicyBaseControlGrant():
           by the policy.
     """
 
-    def __init__(self,
-                 roles: List['PolicyRole']) -> None:
+    def __init__(self, roles: List['PolicyRole']) -> None:
         """
         Initialize a V2PolicyBaseControlGrant object.
 
@@ -1588,7 +1490,8 @@ class V2PolicyBaseControlGrant():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class V2PolicyBaseResource():
+
+class V2PolicyBaseResource:
     """
     The resource attributes associated with a policy.
 
@@ -1596,9 +1499,7 @@ class V2PolicyBaseResource():
           associated with policy/.
     """
 
-    def __init__(self,
-                 *,
-                 attributes: List['V2PolicyAttribute'] = None) -> None:
+    def __init__(self, *, attributes: List['V2PolicyAttribute'] = None) -> None:
         """
         Initialize a V2PolicyBaseResource object.
 
@@ -1651,7 +1552,8 @@ class V2PolicyBaseResource():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class V2PolicyBaseRule():
+
+class V2PolicyBaseRule:
     """
     Additional access conditions associated with a policy.
 
@@ -1663,10 +1565,12 @@ class V2PolicyBaseRule():
 
         """
         msg = "Cannot instantiate base class. Instead, instantiate one of the defined subclasses: {0}".format(
-                  ", ".join(['V2PolicyBaseRuleV2PolicyAttribute', 'V2PolicyBaseRuleV2RuleWithConditions']))
+            ", ".join(['V2PolicyBaseRuleV2PolicyAttribute', 'V2PolicyBaseRuleV2RuleWithConditions'])
+        )
         raise Exception(msg)
 
-class V2PolicyBaseSubject():
+
+class V2PolicyBaseSubject:
     """
     The subject attributes associated with a policy.
 
@@ -1674,9 +1578,7 @@ class V2PolicyBaseSubject():
           associated with policy/.
     """
 
-    def __init__(self,
-                 *,
-                 attributes: List['V2PolicyAttribute'] = None) -> None:
+    def __init__(self, *, attributes: List['V2PolicyAttribute'] = None) -> None:
         """
         Initialize a V2PolicyBaseSubject object.
 
@@ -1729,7 +1631,8 @@ class V2PolicyBaseSubject():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class CustomRole():
+
+class CustomRole:
     """
     An additional set of properties associated with a role.
 
@@ -1757,21 +1660,23 @@ class CustomRole():
     :attr str href: (optional) The href link back to the role.
     """
 
-    def __init__(self,
-                 *,
-                 id: str = None,
-                 display_name: str = None,
-                 description: str = None,
-                 actions: List[str] = None,
-                 crn: str = None,
-                 name: str = None,
-                 account_id: str = None,
-                 service_name: str = None,
-                 created_at: datetime = None,
-                 created_by_id: str = None,
-                 last_modified_at: datetime = None,
-                 last_modified_by_id: str = None,
-                 href: str = None) -> None:
+    def __init__(
+        self,
+        *,
+        id: str = None,
+        display_name: str = None,
+        description: str = None,
+        actions: List[str] = None,
+        crn: str = None,
+        name: str = None,
+        account_id: str = None,
+        service_name: str = None,
+        created_at: datetime = None,
+        created_by_id: str = None,
+        last_modified_at: datetime = None,
+        last_modified_by_id: str = None,
+        href: str = None
+    ) -> None:
         """
         Initialize a CustomRole object.
 
@@ -1886,7 +1791,8 @@ class CustomRole():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class Policy():
+
+class Policy:
     """
     The core set of properties associated with a policy.
 
@@ -1911,20 +1817,22 @@ class Policy():
     :attr str state: (optional) The policy state.
     """
 
-    def __init__(self,
-                 *,
-                 id: str = None,
-                 type: str = None,
-                 description: str = None,
-                 subjects: List['PolicySubject'] = None,
-                 roles: List['PolicyRole'] = None,
-                 resources: List['PolicyResource'] = None,
-                 href: str = None,
-                 created_at: datetime = None,
-                 created_by_id: str = None,
-                 last_modified_at: datetime = None,
-                 last_modified_by_id: str = None,
-                 state: str = None) -> None:
+    def __init__(
+        self,
+        *,
+        id: str = None,
+        type: str = None,
+        description: str = None,
+        subjects: List['PolicySubject'] = None,
+        roles: List['PolicyRole'] = None,
+        resources: List['PolicyResource'] = None,
+        href: str = None,
+        created_at: datetime = None,
+        created_by_id: str = None,
+        last_modified_at: datetime = None,
+        last_modified_by_id: str = None,
+        state: str = None
+    ) -> None:
         """
         Initialize a Policy object.
 
@@ -2056,20 +1964,19 @@ class Policy():
         """
         The policy state.
         """
+
         ACTIVE = 'active'
         DELETED = 'deleted'
 
 
-class PolicyList():
+class PolicyList:
     """
     A collection of policies.
 
     :attr List[Policy] policies: (optional) List of policies.
     """
 
-    def __init__(self,
-                 *,
-                 policies: List['Policy'] = None) -> None:
+    def __init__(self, *, policies: List['Policy'] = None) -> None:
         """
         Initialize a PolicyList object.
 
@@ -2121,7 +2028,8 @@ class PolicyList():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class PolicyResource():
+
+class PolicyResource:
     """
     The attributes of the resource. Note that only one resource is allowed in a policy.
 
@@ -2130,10 +2038,7 @@ class PolicyResource():
     :attr List[ResourceTag] tags: (optional) List of access management tags.
     """
 
-    def __init__(self,
-                 *,
-                 attributes: List['ResourceAttribute'] = None,
-                 tags: List['ResourceTag'] = None) -> None:
+    def __init__(self, *, attributes: List['ResourceAttribute'] = None, tags: List['ResourceTag'] = None) -> None:
         """
         Initialize a PolicyResource object.
 
@@ -2198,7 +2103,8 @@ class PolicyResource():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class PolicyRole():
+
+class PolicyRole:
     """
     A role associated with a policy.
 
@@ -2208,11 +2114,7 @@ class PolicyRole():
     :attr str description: (optional) The description of the role.
     """
 
-    def __init__(self,
-                 role_id: str,
-                 *,
-                 display_name: str = None,
-                 description: str = None) -> None:
+    def __init__(self, role_id: str, *, display_name: str = None, description: str = None) -> None:
         """
         Initialize a PolicyRole object.
 
@@ -2271,7 +2173,8 @@ class PolicyRole():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class PolicySubject():
+
+class PolicySubject:
     """
     The subject attribute values that must match in order for this policy to apply in a
     permission decision.
@@ -2279,9 +2182,7 @@ class PolicySubject():
     :attr List[SubjectAttribute] attributes: (optional) List of subject attributes.
     """
 
-    def __init__(self,
-                 *,
-                 attributes: List['SubjectAttribute'] = None) -> None:
+    def __init__(self, *, attributes: List['SubjectAttribute'] = None) -> None:
         """
         Initialize a PolicySubject object.
 
@@ -2334,7 +2235,8 @@ class PolicySubject():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class ResourceAttribute():
+
+class ResourceAttribute:
     """
     An attribute associated with a resource.
 
@@ -2343,11 +2245,7 @@ class ResourceAttribute():
     :attr str operator: (optional) The operator of an attribute.
     """
 
-    def __init__(self,
-                 name: str,
-                 value: str,
-                 *,
-                 operator: str = None) -> None:
+    def __init__(self, name: str, value: str, *, operator: str = None) -> None:
         """
         Initialize a ResourceAttribute object.
 
@@ -2409,7 +2307,8 @@ class ResourceAttribute():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class ResourceTag():
+
+class ResourceTag:
     """
     A tag associated with a resource.
 
@@ -2418,11 +2317,7 @@ class ResourceTag():
     :attr str operator: (optional) The operator of an access management tag.
     """
 
-    def __init__(self,
-                 name: str,
-                 value: str,
-                 *,
-                 operator: str = None) -> None:
+    def __init__(self, name: str, value: str, *, operator: str = None) -> None:
         """
         Initialize a ResourceTag object.
 
@@ -2484,7 +2379,8 @@ class ResourceTag():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class Role():
+
+class Role:
     """
     A role resource.
 
@@ -2498,12 +2394,9 @@ class Role():
           'crn:v1:ibmcloud:public:iam-access-management::a/exampleAccountId::customRole:ExampleRoleName'.
     """
 
-    def __init__(self,
-                 *,
-                 display_name: str = None,
-                 description: str = None,
-                 actions: List[str] = None,
-                 crn: str = None) -> None:
+    def __init__(
+        self, *, display_name: str = None, description: str = None, actions: List[str] = None, crn: str = None
+    ) -> None:
         """
         Initialize a Role object.
 
@@ -2569,7 +2462,8 @@ class Role():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class RoleList():
+
+class RoleList:
     """
     A collection of roles returned by the 'list roles' operation.
 
@@ -2578,11 +2472,13 @@ class RoleList():
     :attr List[Role] system_roles: (optional) List of system roles.
     """
 
-    def __init__(self,
-                 *,
-                 custom_roles: List['CustomRole'] = None,
-                 service_roles: List['Role'] = None,
-                 system_roles: List['Role'] = None) -> None:
+    def __init__(
+        self,
+        *,
+        custom_roles: List['CustomRole'] = None,
+        service_roles: List['Role'] = None,
+        system_roles: List['Role'] = None
+    ) -> None:
         """
         Initialize a RoleList object.
 
@@ -2658,7 +2554,8 @@ class RoleList():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class SubjectAttribute():
+
+class SubjectAttribute:
     """
     An attribute associated with a subject.
 
@@ -2666,9 +2563,7 @@ class SubjectAttribute():
     :attr str value: The value of an attribute.
     """
 
-    def __init__(self,
-                 name: str,
-                 value: str) -> None:
+    def __init__(self, name: str, value: str) -> None:
         """
         Initialize a SubjectAttribute object.
 
@@ -2724,7 +2619,8 @@ class SubjectAttribute():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class V2Policy():
+
+class V2Policy:
     """
     The core set of properties associated with a policy.
 
@@ -2752,22 +2648,24 @@ class V2Policy():
     :attr str state: (optional) The policy state.
     """
 
-    def __init__(self,
-                 type: str,
-                 control: 'V2PolicyBaseControl',
-                 *,
-                 id: str = None,
-                 description: str = None,
-                 subject: 'V2PolicyBaseSubject' = None,
-                 resource: 'V2PolicyBaseResource' = None,
-                 pattern: str = None,
-                 rule: 'V2PolicyBaseRule' = None,
-                 href: str = None,
-                 created_at: datetime = None,
-                 created_by_id: str = None,
-                 last_modified_at: datetime = None,
-                 last_modified_by_id: str = None,
-                 state: str = None) -> None:
+    def __init__(
+        self,
+        type: str,
+        control: 'V2PolicyBaseControl',
+        *,
+        id: str = None,
+        description: str = None,
+        subject: 'V2PolicyBaseSubject' = None,
+        resource: 'V2PolicyBaseResource' = None,
+        pattern: str = None,
+        rule: 'V2PolicyBaseRule' = None,
+        href: str = None,
+        created_at: datetime = None,
+        created_by_id: str = None,
+        last_modified_at: datetime = None,
+        last_modified_by_id: str = None,
+        state: str = None
+    ) -> None:
         """
         Initialize a V2Policy object.
 
@@ -2909,11 +2807,12 @@ class V2Policy():
         """
         The policy state.
         """
+
         ACTIVE = 'active'
         DELETED = 'deleted'
 
 
-class V2PolicyAttribute():
+class V2PolicyAttribute:
     """
     Resource/subject attribute associated with policy attributes.
 
@@ -2923,10 +2822,7 @@ class V2PolicyAttribute():
           integer.
     """
 
-    def __init__(self,
-                 key: str,
-                 operator: str,
-                 value: object) -> None:
+    def __init__(self, key: str, operator: str, value: object) -> None:
         """
         Initialize a V2PolicyAttribute object.
 
@@ -2991,16 +2887,15 @@ class V2PolicyAttribute():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class V2PolicyList():
+
+class V2PolicyList:
     """
     A collection of policies.
 
     :attr List[V2Policy] policies: (optional) List of policies.
     """
 
-    def __init__(self,
-                 *,
-                 policies: List['V2Policy'] = None) -> None:
+    def __init__(self, *, policies: List['V2Policy'] = None) -> None:
         """
         Initialize a V2PolicyList object.
 
@@ -3052,6 +2947,7 @@ class V2PolicyList():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
+
 class V2PolicyBaseRuleV2PolicyAttribute(V2PolicyBaseRule):
     """
     Resource/subject attribute associated with policy attributes.
@@ -3062,10 +2958,7 @@ class V2PolicyBaseRuleV2PolicyAttribute(V2PolicyBaseRule):
           integer.
     """
 
-    def __init__(self,
-                 key: str,
-                 operator: str,
-                 value: object) -> None:
+    def __init__(self, key: str, operator: str, value: object) -> None:
         """
         Initialize a V2PolicyBaseRuleV2PolicyAttribute object.
 
@@ -3131,6 +3024,7 @@ class V2PolicyBaseRuleV2PolicyAttribute(V2PolicyBaseRule):
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
+
 class V2PolicyBaseRuleV2RuleWithConditions(V2PolicyBaseRule):
     """
     Policy rule that has 2 to 10 conditions.
@@ -3140,9 +3034,7 @@ class V2PolicyBaseRuleV2RuleWithConditions(V2PolicyBaseRule):
           a policy. Note that conditions can be nested up to 2 levels.
     """
 
-    def __init__(self,
-                 operator: str,
-                 conditions: List['V2PolicyAttribute']) -> None:
+    def __init__(self, operator: str, conditions: List['V2PolicyAttribute']) -> None:
         """
         Initialize a V2PolicyBaseRuleV2RuleWithConditions object.
 
@@ -3165,7 +3057,9 @@ class V2PolicyBaseRuleV2RuleWithConditions(V2PolicyBaseRule):
         if 'conditions' in _dict:
             args['conditions'] = [V2PolicyAttribute.from_dict(v) for v in _dict.get('conditions')]
         else:
-            raise ValueError('Required property \'conditions\' not present in V2PolicyBaseRuleV2RuleWithConditions JSON')
+            raise ValueError(
+                'Required property \'conditions\' not present in V2PolicyBaseRuleV2RuleWithConditions JSON'
+            )
         return cls(**args)
 
     @classmethod
@@ -3210,6 +3104,6 @@ class V2PolicyBaseRuleV2RuleWithConditions(V2PolicyBaseRule):
         """
         Operator to evalute conditions.
         """
+
         AND = 'and'
         OR = 'or'
-

--- a/ibm_platform_services/iam_policy_management_v1.py
+++ b/ibm_platform_services/iam_policy_management_v1.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# (C) Copyright IBM Corp. 2021.
+# (C) Copyright IBM Corp. 2022.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# IBM OpenAPI SDK Code Generator Version: 3.39.0-748eb4ca-20210917-165907
+# IBM OpenAPI SDK Code Generator Version: 3.62.0-a2a22f95-20221115-162524
 
 """
 IAM Policy Management API
@@ -38,7 +38,6 @@ from .common import get_sdk_headers
 # Service
 ##############################################################################
 
-
 class IamPolicyManagementV1(BaseService):
     """The iam_policy_management V1 service."""
 
@@ -46,23 +45,23 @@ class IamPolicyManagementV1(BaseService):
     DEFAULT_SERVICE_NAME = 'iam_policy_management'
 
     @classmethod
-    def new_instance(
-        cls,
-        service_name: str = DEFAULT_SERVICE_NAME,
-    ) -> 'IamPolicyManagementV1':
+    def new_instance(cls,
+                     service_name: str = DEFAULT_SERVICE_NAME,
+                    ) -> 'IamPolicyManagementV1':
         """
         Return a new client for the iam_policy_management service using the
                specified parameters and external configuration.
         """
         authenticator = get_authenticator_from_environment(service_name)
-        service = cls(authenticator)
+        service = cls(
+            authenticator
+            )
         service.configure_service(service_name)
         return service
 
-    def __init__(
-        self,
-        authenticator: Authenticator = None,
-    ) -> None:
+    def __init__(self,
+                 authenticator: Authenticator = None,
+                ) -> None:
         """
         Construct a new client for the iam_policy_management service.
 
@@ -70,14 +69,17 @@ class IamPolicyManagementV1(BaseService):
                Get up to date information from https://github.com/IBM/python-sdk-core/blob/main/README.md
                about initializing the authenticator of your choice.
         """
-        BaseService.__init__(self, service_url=self.DEFAULT_SERVICE_URL, authenticator=authenticator)
+        BaseService.__init__(self,
+                             service_url=self.DEFAULT_SERVICE_URL,
+                             authenticator=authenticator)
+
 
     #########################
     # Policies
     #########################
 
-    def list_policies(
-        self,
+
+    def list_policies(self,
         account_id: str,
         *,
         accept_language: str = None,
@@ -140,12 +142,14 @@ class IamPolicyManagementV1(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `PolicyList` object
         """
 
-        if account_id is None:
+        if not account_id:
             raise ValueError('account_id must be provided')
-        headers = {'Accept-Language': accept_language}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='list_policies'
-        )
+        headers = {
+            'Accept-Language': accept_language
+        }
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='list_policies')
         headers.update(sdk_headers)
 
         params = {
@@ -158,21 +162,25 @@ class IamPolicyManagementV1(BaseService):
             'tag_value': tag_value,
             'sort': sort,
             'format': format,
-            'state': state,
+            'state': state
         }
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         url = '/v1/policies'
-        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
 
         response = self.send(request, **kwargs)
         return response
 
-    def create_policy(
-        self,
+
+    def create_policy(self,
         type: str,
         subjects: List['PolicySubject'],
         roles: List['PolicyRole'],
@@ -198,9 +206,12 @@ class IamPolicyManagementV1(BaseService):
         group. The roles must be a subset of a service's or the platform's supported
         roles. The resource attributes must be a subset of a service's or the platform's
         supported attributes. The policy resource must include either the
-        **`serviceType`**, **`serviceName`**,  or **`resourceGroupId`** attribute and the
-        **`accountId`** attribute.` If the subject is a locked service-id, the request
-        will fail.
+        **`serviceType`**, **`serviceName`**, **`resourceGroupId`** or
+        **`service_group_id`** attribute and the **`accountId`** attribute.` The IAM
+        Services group (`IAM`) is a subset of account management services that includes
+        the IAM platform services IAM Identity, IAM Access Management, IAM Users
+        Management, IAM Groups, and future IAM services. If the subject is a locked
+        service-id, the request will fail.
         ### Authorization
         Authorization policies are supported by services on a case by case basis. Refer to
         service documentation to verify their support of authorization policies. To create
@@ -217,7 +228,7 @@ class IamPolicyManagementV1(BaseService):
         **`accountId`** attributes.
         ### Attribute Operators
         Currently, only the `stringEquals` and the `stringMatch` operators are available.
-        Resource attributes may support one or both operators.  For more information, see
+        Resource attributes may support one or both operators. For more information, see
         [how to assign access by using wildcards
         policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
         ### Attribute Validations
@@ -261,29 +272,41 @@ class IamPolicyManagementV1(BaseService):
         subjects = [convert_model(x) for x in subjects]
         roles = [convert_model(x) for x in roles]
         resources = [convert_model(x) for x in resources]
-        headers = {'Accept-Language': accept_language}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='create_policy'
-        )
+        headers = {
+            'Accept-Language': accept_language
+        }
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='create_policy')
         headers.update(sdk_headers)
 
-        data = {'type': type, 'subjects': subjects, 'roles': roles, 'resources': resources, 'description': description}
+        data = {
+            'type': type,
+            'subjects': subjects,
+            'roles': roles,
+            'resources': resources,
+            'description': description
+        }
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
         headers['content-type'] = 'application/json'
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         url = '/v1/policies'
-        request = self.prepare_request(method='POST', url=url, headers=headers, data=data)
+        request = self.prepare_request(method='POST',
+                                       url=url,
+                                       headers=headers,
+                                       data=data)
 
         response = self.send(request, **kwargs)
         return response
 
-    def update_policy(
-        self,
+
+    def update_policy(self,
         policy_id: str,
         if_match: str,
         type: str,
@@ -325,8 +348,8 @@ class IamPolicyManagementV1(BaseService):
         **`accountId`** attributes.
         ### Attribute Operators
         Currently, only the `stringEquals` and the `stringMatch` operators are available.
-        Resource attributes might support one or both operators.  For more information,
-        see [how to assign access by using wildcards
+        Resource attributes might support one or both operators. For more information, see
+        [how to assign access by using wildcards
         policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
         ### Attribute Validations
         Policy attribute values must be between 1 and 1,000 characters in length. If
@@ -351,9 +374,9 @@ class IamPolicyManagementV1(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `Policy` object
         """
 
-        if policy_id is None:
+        if not policy_id:
             raise ValueError('policy_id must be provided')
-        if if_match is None:
+        if not if_match:
             raise ValueError('if_match must be provided')
         if type is None:
             raise ValueError('type must be provided')
@@ -366,31 +389,47 @@ class IamPolicyManagementV1(BaseService):
         subjects = [convert_model(x) for x in subjects]
         roles = [convert_model(x) for x in roles]
         resources = [convert_model(x) for x in resources]
-        headers = {'If-Match': if_match}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='update_policy'
-        )
+        headers = {
+            'If-Match': if_match
+        }
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='update_policy')
         headers.update(sdk_headers)
 
-        data = {'type': type, 'subjects': subjects, 'roles': roles, 'resources': resources, 'description': description}
+        data = {
+            'type': type,
+            'subjects': subjects,
+            'roles': roles,
+            'resources': resources,
+            'description': description
+        }
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
         headers['content-type'] = 'application/json'
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['policy_id']
         path_param_values = self.encode_path_vars(policy_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v1/policies/{policy_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='PUT', url=url, headers=headers, data=data)
+        request = self.prepare_request(method='PUT',
+                                       url=url,
+                                       headers=headers,
+                                       data=data)
 
         response = self.send(request, **kwargs)
         return response
 
-    def get_policy(self, policy_id: str, **kwargs) -> DetailedResponse:
+
+    def get_policy(self,
+        policy_id: str,
+        **kwargs
+    ) -> DetailedResponse:
         """
         Retrieve a policy by ID.
 
@@ -402,28 +441,35 @@ class IamPolicyManagementV1(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `Policy` object
         """
 
-        if policy_id is None:
+        if not policy_id:
             raise ValueError('policy_id must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='get_policy'
-        )
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='get_policy')
         headers.update(sdk_headers)
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['policy_id']
         path_param_values = self.encode_path_vars(policy_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v1/policies/{policy_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET', url=url, headers=headers)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers)
 
         response = self.send(request, **kwargs)
         return response
 
-    def delete_policy(self, policy_id: str, **kwargs) -> DetailedResponse:
+
+    def delete_policy(self,
+        policy_id: str,
+        **kwargs
+    ) -> DetailedResponse:
         """
         Delete a policy by ID.
 
@@ -437,27 +483,37 @@ class IamPolicyManagementV1(BaseService):
         :rtype: DetailedResponse
         """
 
-        if policy_id is None:
+        if not policy_id:
             raise ValueError('policy_id must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='delete_policy'
-        )
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='delete_policy')
         headers.update(sdk_headers)
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
 
         path_param_keys = ['policy_id']
         path_param_values = self.encode_path_vars(policy_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v1/policies/{policy_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='DELETE', url=url, headers=headers)
+        request = self.prepare_request(method='DELETE',
+                                       url=url,
+                                       headers=headers)
 
         response = self.send(request, **kwargs)
         return response
 
-    def patch_policy(self, policy_id: str, if_match: str, *, state: str = None, **kwargs) -> DetailedResponse:
+
+    def patch_policy(self,
+        policy_id: str,
+        if_match: str,
+        *,
+        state: str = None,
+        **kwargs
+    ) -> DetailedResponse:
         """
         Restore a deleted policy by ID.
 
@@ -476,30 +532,38 @@ class IamPolicyManagementV1(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `Policy` object
         """
 
-        if policy_id is None:
+        if not policy_id:
             raise ValueError('policy_id must be provided')
-        if if_match is None:
+        if not if_match:
             raise ValueError('if_match must be provided')
-        headers = {'If-Match': if_match}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='patch_policy'
-        )
+        headers = {
+            'If-Match': if_match
+        }
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='patch_policy')
         headers.update(sdk_headers)
 
-        data = {'state': state}
+        data = {
+            'state': state
+        }
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
         headers['content-type'] = 'application/json'
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['policy_id']
         path_param_values = self.encode_path_vars(policy_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v1/policies/{policy_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='PATCH', url=url, headers=headers, data=data)
+        request = self.prepare_request(method='PATCH',
+                                       url=url,
+                                       headers=headers,
+                                       data=data)
 
         response = self.send(request, **kwargs)
         return response
@@ -508,8 +572,8 @@ class IamPolicyManagementV1(BaseService):
     # Roles
     #########################
 
-    def list_roles(
-        self,
+
+    def list_roles(self,
         *,
         accept_language: str = None,
         account_id: str = None,
@@ -551,31 +615,37 @@ class IamPolicyManagementV1(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `RoleList` object
         """
 
-        headers = {'Accept-Language': accept_language}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='list_roles'
-        )
+        headers = {
+            'Accept-Language': accept_language
+        }
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='list_roles')
         headers.update(sdk_headers)
 
         params = {
             'account_id': account_id,
             'service_name': service_name,
             'source_service_name': source_service_name,
-            'policy_type': policy_type,
+            'policy_type': policy_type
         }
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         url = '/v2/roles'
-        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
 
         response = self.send(request, **kwargs)
         return response
 
-    def create_role(
-        self,
+
+    def create_role(self,
         display_name: str,
         actions: List[str],
         name: str,
@@ -632,10 +702,12 @@ class IamPolicyManagementV1(BaseService):
             raise ValueError('account_id must be provided')
         if service_name is None:
             raise ValueError('service_name must be provided')
-        headers = {'Accept-Language': accept_language}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='create_role'
-        )
+        headers = {
+            'Accept-Language': accept_language
+        }
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='create_role')
         headers.update(sdk_headers)
 
         data = {
@@ -644,7 +716,7 @@ class IamPolicyManagementV1(BaseService):
             'name': name,
             'account_id': account_id,
             'service_name': service_name,
-            'description': description,
+            'description': description
         }
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
@@ -652,16 +724,20 @@ class IamPolicyManagementV1(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         url = '/v2/roles'
-        request = self.prepare_request(method='POST', url=url, headers=headers, data=data)
+        request = self.prepare_request(method='POST',
+                                       url=url,
+                                       headers=headers,
+                                       data=data)
 
         response = self.send(request, **kwargs)
         return response
 
-    def update_role(
-        self,
+
+    def update_role(self,
         role_id: str,
         if_match: str,
         *,
@@ -692,35 +768,49 @@ class IamPolicyManagementV1(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `CustomRole` object
         """
 
-        if role_id is None:
+        if not role_id:
             raise ValueError('role_id must be provided')
-        if if_match is None:
+        if not if_match:
             raise ValueError('if_match must be provided')
-        headers = {'If-Match': if_match}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='update_role'
-        )
+        headers = {
+            'If-Match': if_match
+        }
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='update_role')
         headers.update(sdk_headers)
 
-        data = {'display_name': display_name, 'description': description, 'actions': actions}
+        data = {
+            'display_name': display_name,
+            'description': description,
+            'actions': actions
+        }
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
         headers['content-type'] = 'application/json'
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['role_id']
         path_param_values = self.encode_path_vars(role_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v2/roles/{role_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='PUT', url=url, headers=headers, data=data)
+        request = self.prepare_request(method='PUT',
+                                       url=url,
+                                       headers=headers,
+                                       data=data)
 
         response = self.send(request, **kwargs)
         return response
 
-    def get_role(self, role_id: str, **kwargs) -> DetailedResponse:
+
+    def get_role(self,
+        role_id: str,
+        **kwargs
+    ) -> DetailedResponse:
         """
         Retrieve a role by ID.
 
@@ -732,28 +822,35 @@ class IamPolicyManagementV1(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `CustomRole` object
         """
 
-        if role_id is None:
+        if not role_id:
             raise ValueError('role_id must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='get_role'
-        )
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='get_role')
         headers.update(sdk_headers)
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['role_id']
         path_param_values = self.encode_path_vars(role_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v2/roles/{role_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET', url=url, headers=headers)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers)
 
         response = self.send(request, **kwargs)
         return response
 
-    def delete_role(self, role_id: str, **kwargs) -> DetailedResponse:
+
+    def delete_role(self,
+        role_id: str,
+        **kwargs
+    ) -> DetailedResponse:
         """
         Delete a role by ID.
 
@@ -765,22 +862,512 @@ class IamPolicyManagementV1(BaseService):
         :rtype: DetailedResponse
         """
 
-        if role_id is None:
+        if not role_id:
             raise ValueError('role_id must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='delete_role'
-        )
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='delete_role')
         headers.update(sdk_headers)
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
 
         path_param_keys = ['role_id']
         path_param_values = self.encode_path_vars(role_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v2/roles/{role_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='DELETE', url=url, headers=headers)
+        request = self.prepare_request(method='DELETE',
+                                       url=url,
+                                       headers=headers)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    #########################
+    # v2Policies
+    #########################
+
+
+    def v2_list_policies(self,
+        account_id: str,
+        *,
+        accept_language: str = None,
+        iam_id: str = None,
+        access_group_id: str = None,
+        type: str = None,
+        service_type: str = None,
+        service_name: str = None,
+        service_group_id: str = None,
+        format: str = None,
+        state: str = None,
+        **kwargs
+    ) -> DetailedResponse:
+        """
+        Get policies by attributes.
+
+        Get policies and filter by attributes. While managing policies, you may want to
+        retrieve policies in the account and filter by attribute values. This can be done
+        through query parameters. Currently, only the following attributes are supported:
+        account_id, iam_id, access_group_id, type, service_type, sort, format and state.
+        account_id is a required query parameter. Only policies that have the specified
+        attributes and that the caller has read access to are returned. If the caller does
+        not have read access to any policies an empty array is returned.
+
+        :param str account_id: The account GUID in which the policies belong to.
+        :param str accept_language: (optional) Language code for translations
+               * `default` - English
+               * `de` -  German (Standard)
+               * `en` - English
+               * `es` - Spanish (Spain)
+               * `fr` - French (Standard)
+               * `it` - Italian (Standard)
+               * `ja` - Japanese
+               * `ko` - Korean
+               * `pt-br` - Portuguese (Brazil)
+               * `zh-cn` - Chinese (Simplified, PRC)
+               * `zh-tw` - (Chinese, Taiwan).
+        :param str iam_id: (optional) Optional IAM ID used to identify the subject.
+        :param str access_group_id: (optional) Optional access group id.
+        :param str type: (optional) Optional type of policy.
+        :param str service_type: (optional) Optional type of service.
+        :param str service_name: (optional) Optional name of service.
+        :param str service_group_id: (optional) Optional ID of service group.
+        :param str format: (optional) Include additional data per policy returned
+               * `include_last_permit` - returns details of when the policy last granted a
+               permit decision and the number of times it has done so
+               * `display` - returns the list of all actions included in each of the
+               policy roles and translations for all relevant fields.
+        :param str state: (optional) The state of the policy.
+               * `active` - returns active policies
+               * `deleted` - returns non-active policies.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `V2PolicyList` object
+        """
+
+        if not account_id:
+            raise ValueError('account_id must be provided')
+        headers = {
+            'Accept-Language': accept_language
+        }
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='v2_list_policies')
+        headers.update(sdk_headers)
+
+        params = {
+            'account_id': account_id,
+            'iam_id': iam_id,
+            'access_group_id': access_group_id,
+            'type': type,
+            'service_type': service_type,
+            'service_name': service_name,
+            'service_group_id': service_group_id,
+            'format': format,
+            'state': state
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v2/policies'
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+
+    def v2_create_policy(self,
+        type: str,
+        control: 'V2PolicyBaseControl',
+        *,
+        description: str = None,
+        subject: 'V2PolicyBaseSubject' = None,
+        resource: 'V2PolicyBaseResource' = None,
+        pattern: str = None,
+        rule: 'V2PolicyBaseRule' = None,
+        accept_language: str = None,
+        **kwargs
+    ) -> DetailedResponse:
+        """
+        Create a policy.
+
+        Creates a policy to grant access between a subject and a resource. Currently,
+        there is one type of a v2/policy: **access**. A policy administrator might want to
+        create an access policy which grants access to a user, service-id, or an access
+        group.
+        ### Access
+        To create an access policy, use **`"type": "access"`** in the body. The possible
+        subject attributes are **`iam_id`** and **`access_group_id`**. Use the
+        **`iam_id`** subject attribute for assigning access for a user or service-id. Use
+        the **`access_group_id`** subject attribute for assigning access for an access
+        group. The roles must be a subset of a service's or the platform's supported
+        roles. The resource attributes must be a subset of a service's or the platform's
+        supported attributes. The policy resource must include either the
+        **`serviceType`**, **`serviceName`**, **`resourceGroupId`** or
+        **`service_group_id`** attribute and the **`accountId`** attribute.` The rule
+        field can either specify single **`key`**, **`value`**, and **`operator`** or be
+        set of **`conditions`** with a combination **`operator`**.  The possible
+        combination operator are **`and`** and **`or`**. The rule field has a maximum of 2
+        levels of nested **`conditions`**. The operator for a rule can be used to specify
+        a time based restriction (e.g., access only during business hours, during the
+        Monday-Friday work week). For example, a policy can grant access Monday-Friday,
+        9:00am-5:00pm using the following rule:
+        ```json
+          "rule": {
+            "operator": "and",
+            "conditions": [{
+              "key": "{{environment.attributes.day_of_week}}",
+              "operator": "dayOfWeekAnyOf",
+              "value": [1, 2, 3, 4, 5]
+            },
+              "key": "{{environment.attributes.current_time}}",
+              "operator": "timeGreaterThanOrEquals",
+              "value": "09:00:00+00:00"
+            },
+              "key": "{{environment.attributes.current_time}}",
+              "operator": "timeLessThanOrEquals",
+              "value": "17:00:00+00:00"
+            }]
+          }
+        ``` Rules and conditions allow the following operators with **`key`**, **`value`**
+        :
+        ```
+          'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan',
+        'timeGreaterThanOrEquals',
+          'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan',
+        'dateGreaterThanOrEquals',
+          'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan',
+        'dateTimeGreaterThanOrEquals',
+          'dayOfWeekEquals', 'dayOfWeekAnyOf',
+          'monthEquals', 'monthAnyOf',
+          'dayOfMonthEquals', 'dayOfMonthAnyOf'
+        ``` The pattern field can be coupled with a rule that matches the pattern. For the
+        business hour rule example above, the **`pattern`** is
+        **`"time-based-restrictions:weekly"`**. The IAM Services group (`IAM`) is a subset
+        of account management services that includes the IAM platform services IAM
+        Identity, IAM Access Management, IAM Users Management, IAM Groups, and future IAM
+        services. If the subject is a locked service-id, the request will fail.
+        ### Attribute Operators
+        Currently, only the `stringEquals`, `stringMatch`, and `stringEquals` operators
+        are available. For more information, see [how to assign access by using wildcards
+        policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
+        ### Attribute Validations
+        Policy attribute values must be between 1 and 1,000 characters in length. If
+        location related attributes like geography, country, metro, region, satellite, and
+        locationvalues are supported by the service, they are validated against Global
+        Catalog locations.
+
+        :param str type: The policy type; either 'access' or 'authorization'.
+        :param V2PolicyBaseControl control: Specifies the type of access granted by
+               the policy.
+        :param str description: (optional) Customer-defined description.
+        :param V2PolicyBaseSubject subject: (optional) The subject attributes
+               associated with a policy.
+        :param V2PolicyBaseResource resource: (optional) The resource attributes
+               associated with a policy.
+        :param str pattern: (optional) Indicates pattern of rule.
+        :param V2PolicyBaseRule rule: (optional) Additional access conditions
+               associated with a policy.
+        :param str accept_language: (optional) Language code for translations
+               * `default` - English
+               * `de` -  German (Standard)
+               * `en` - English
+               * `es` - Spanish (Spain)
+               * `fr` - French (Standard)
+               * `it` - Italian (Standard)
+               * `ja` - Japanese
+               * `ko` - Korean
+               * `pt-br` - Portuguese (Brazil)
+               * `zh-cn` - Chinese (Simplified, PRC)
+               * `zh-tw` - (Chinese, Taiwan).
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `V2Policy` object
+        """
+
+        if type is None:
+            raise ValueError('type must be provided')
+        if control is None:
+            raise ValueError('control must be provided')
+        control = convert_model(control)
+        if subject is not None:
+            subject = convert_model(subject)
+        if resource is not None:
+            resource = convert_model(resource)
+        if rule is not None:
+            rule = convert_model(rule)
+        headers = {
+            'Accept-Language': accept_language
+        }
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='v2_create_policy')
+        headers.update(sdk_headers)
+
+        data = {
+            'type': type,
+            'control': control,
+            'description': description,
+            'subject': subject,
+            'resource': resource,
+            'pattern': pattern,
+            'rule': rule
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v2/policies'
+        request = self.prepare_request(method='POST',
+                                       url=url,
+                                       headers=headers,
+                                       data=data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+
+    def v2_update_policy(self,
+        policy_id: str,
+        if_match: str,
+        type: str,
+        control: 'V2PolicyBaseControl',
+        *,
+        description: str = None,
+        subject: 'V2PolicyBaseSubject' = None,
+        resource: 'V2PolicyBaseResource' = None,
+        pattern: str = None,
+        rule: 'V2PolicyBaseRule' = None,
+        **kwargs
+    ) -> DetailedResponse:
+        """
+        Update a policy.
+
+        Update a policy to grant access between a subject and a resource. A policy
+        administrator might want to update an existing policy.
+        ### Access
+        To update an access policy, use **`"type": "access"`** in the body. The possible
+        subject attributes are **`iam_id`** and **`access_group_id`**. Use the
+        **`iam_id`** subject attribute for assigning access for a user or service-id. Use
+        the **`access_group_id`** subject attribute for assigning access for an access
+        group. The roles must be a subset of a service's or the platform's supported
+        roles. The resource attributes must be a subset of a service's or the platform's
+        supported attributes. The policy resource must include either the
+        **`serviceType`**, **`serviceName`**,  or **`resourceGroupId`** attribute and the
+        **`accountId`** attribute.` The rule field can either specify single **`key`**,
+        **`value`**, and **`operator`** or be set of **`conditions`** with a combination
+        **`operator`**.  The possible combination operator are **`and`** and **`or`**. The
+        rule field has a maximum of 2 levels of nested **`conditions`**. The operator for
+        a rule can be used to specify a time based restriction (e.g., access only during
+        business hours, during the Monday-Friday work week). For example, a policy can
+        grant access Monday-Friday, 9:00am-5:00pm using the following rule:
+        ```json
+          "rule": {
+            "operator": "and",
+            "conditions": [{
+              "key": "{{environment.attributes.day_of_week}}",
+              "operator": "dayOfWeekAnyOf",
+              "value": [1, 2, 3, 4, 5]
+            },
+              "key": "{{environment.attributes.current_time}}",
+              "operator": "timeGreaterThanOrEquals",
+              "value": "09:00:00+00:00"
+            },
+              "key": "{{environment.attributes.current_time}}",
+              "operator": "timeLessThanOrEquals",
+              "value": "17:00:00+00:00"
+            }]
+          }
+        ``` Rules and conditions allow the following operators with **`key`**, **`value`**
+        :
+        ```
+          'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan',
+        'timeGreaterThanOrEquals',
+          'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan',
+        'dateGreaterThanOrEquals',
+          'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan',
+        'dateTimeGreaterThanOrEquals',
+          'dayOfWeekEquals', 'dayOfWeekAnyOf',
+          'monthEquals', 'monthAnyOf',
+          'dayOfMonthEquals', 'dayOfMonthAnyOf'
+        ``` The pattern field can be coupled with a rule that matches the pattern. For the
+        business hour rule example above, the **`pattern`** is
+        **`"time-based-restrictions:weekly"`**. If the subject is a locked service-id, the
+        request will fail.
+        ### Attribute Operators
+        Currently, only the `stringEquals`, `stringMatch`, and `stringEquals` operators
+        are available. For more information, see [how to assign access by using wildcards
+        policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
+        ### Attribute Validations
+        Policy attribute values must be between 1 and 1,000 characters in length. If
+        location related attributes like geography, country, metro, region, satellite, and
+        locationvalues are supported by the service, they are validated against Global
+        Catalog locations.
+
+        :param str policy_id: The policy ID.
+        :param str if_match: The revision number for updating a policy and must
+               match the ETag value of the existing policy. The Etag can be retrieved
+               using the GET /v1/policies/{policy_id} API and looking at the ETag response
+               header.
+        :param str type: The policy type; either 'access' or 'authorization'.
+        :param V2PolicyBaseControl control: Specifies the type of access granted by
+               the policy.
+        :param str description: (optional) Customer-defined description.
+        :param V2PolicyBaseSubject subject: (optional) The subject attributes
+               associated with a policy.
+        :param V2PolicyBaseResource resource: (optional) The resource attributes
+               associated with a policy.
+        :param str pattern: (optional) Indicates pattern of rule.
+        :param V2PolicyBaseRule rule: (optional) Additional access conditions
+               associated with a policy.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `V2Policy` object
+        """
+
+        if not policy_id:
+            raise ValueError('policy_id must be provided')
+        if not if_match:
+            raise ValueError('if_match must be provided')
+        if type is None:
+            raise ValueError('type must be provided')
+        if control is None:
+            raise ValueError('control must be provided')
+        control = convert_model(control)
+        if subject is not None:
+            subject = convert_model(subject)
+        if resource is not None:
+            resource = convert_model(resource)
+        if rule is not None:
+            rule = convert_model(rule)
+        headers = {
+            'If-Match': if_match
+        }
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='v2_update_policy')
+        headers.update(sdk_headers)
+
+        data = {
+            'type': type,
+            'control': control,
+            'description': description,
+            'subject': subject,
+            'resource': resource,
+            'pattern': pattern,
+            'rule': rule
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['policy_id']
+        path_param_values = self.encode_path_vars(policy_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/policies/{policy_id}'.format(**path_param_dict)
+        request = self.prepare_request(method='PUT',
+                                       url=url,
+                                       headers=headers,
+                                       data=data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+
+    def v2_get_policy(self,
+        policy_id: str,
+        **kwargs
+    ) -> DetailedResponse:
+        """
+        Retrieve a policy by ID.
+
+        Retrieve a policy by providing a policy ID.
+
+        :param str policy_id: The policy ID.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `V2Policy` object
+        """
+
+        if not policy_id:
+            raise ValueError('policy_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='v2_get_policy')
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['policy_id']
+        path_param_values = self.encode_path_vars(policy_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/policies/{policy_id}'.format(**path_param_dict)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers)
+
+        response = self.send(request, **kwargs)
+        return response
+
+
+    def v2_delete_policy(self,
+        policy_id: str,
+        **kwargs
+    ) -> DetailedResponse:
+        """
+        Delete a policy by ID.
+
+        Delete a policy by providing a policy ID. A policy cannot be deleted if the
+        subject ID contains a locked service ID. If the subject of the policy is a locked
+        service-id, the request will fail.
+
+        :param str policy_id: The policy ID.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse
+        """
+
+        if not policy_id:
+            raise ValueError('policy_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='v2_delete_policy')
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+
+        path_param_keys = ['policy_id']
+        path_param_values = self.encode_path_vars(policy_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/policies/{policy_id}'.format(**path_param_dict)
+        request = self.prepare_request(method='DELETE',
+                                       url=url,
+                                       headers=headers)
 
         response = self.send(request, **kwargs)
         return response
@@ -795,24 +1382,19 @@ class ListPoliciesEnums:
         """
         Optional type of policy.
         """
-
         ACCESS = 'access'
         AUTHORIZATION = 'authorization'
-
     class ServiceType(str, Enum):
         """
         Optional type of service.
         """
-
         SERVICE = 'service'
         PLATFORM_SERVICE = 'platform_service'
-
     class Sort(str, Enum):
         """
         Optional top level policy field to sort results. Ascending sort is default.
         Descending sort available by prepending '-' to field. Example '-last_modified_at'.
         """
-
         ID = 'id'
         TYPE = 'type'
         HREF = 'href'
@@ -821,7 +1403,6 @@ class ListPoliciesEnums:
         LAST_MODIFIED_AT = 'last_modified_at'
         LAST_MODIFIED_BY_ID = 'last_modified_by_id'
         STATE = 'state'
-
     class Format(str, Enum):
         """
         Include additional data per policy returned
@@ -830,17 +1411,51 @@ class ListPoliciesEnums:
         * `display` - returns the list of all actions included in each of the policy
         roles.
         """
-
         INCLUDE_LAST_PERMIT = 'include_last_permit'
         DISPLAY = 'display'
-
     class State(str, Enum):
         """
         The state of the policy.
         * `active` - returns active policies
         * `deleted` - returns non-active policies.
         """
+        ACTIVE = 'active'
+        DELETED = 'deleted'
 
+
+class V2ListPoliciesEnums:
+    """
+    Enums for v2_list_policies parameters.
+    """
+
+    class Type(str, Enum):
+        """
+        Optional type of policy.
+        """
+        ACCESS = 'access'
+        AUTHORIZATION = 'authorization'
+    class ServiceType(str, Enum):
+        """
+        Optional type of service.
+        """
+        SERVICE = 'service'
+        PLATFORM_SERVICE = 'platform_service'
+    class Format(str, Enum):
+        """
+        Include additional data per policy returned
+        * `include_last_permit` - returns details of when the policy last granted a permit
+        decision and the number of times it has done so
+        * `display` - returns the list of all actions included in each of the policy roles
+        and translations for all relevant fields.
+        """
+        INCLUDE_LAST_PERMIT = 'include_last_permit'
+        DISPLAY = 'display'
+    class State(str, Enum):
+        """
+        The state of the policy.
+        * `active` - returns active policies
+        * `deleted` - returns non-active policies.
+        """
         ACTIVE = 'active'
         DELETED = 'deleted'
 
@@ -850,7 +1465,271 @@ class ListPoliciesEnums:
 ##############################################################################
 
 
-class CustomRole:
+class V2PolicyBaseControl():
+    """
+    Specifies the type of access granted by the policy.
+
+    :attr V2PolicyBaseControlGrant grant: Permission granted by the policy.
+    """
+
+    def __init__(self,
+                 grant: 'V2PolicyBaseControlGrant') -> None:
+        """
+        Initialize a V2PolicyBaseControl object.
+
+        :param V2PolicyBaseControlGrant grant: Permission granted by the policy.
+        """
+        self.grant = grant
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseControl':
+        """Initialize a V2PolicyBaseControl object from a json dictionary."""
+        args = {}
+        if 'grant' in _dict:
+            args['grant'] = V2PolicyBaseControlGrant.from_dict(_dict.get('grant'))
+        else:
+            raise ValueError('Required property \'grant\' not present in V2PolicyBaseControl JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyBaseControl object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'grant') and self.grant is not None:
+            if isinstance(self.grant, dict):
+                _dict['grant'] = self.grant
+            else:
+                _dict['grant'] = self.grant.to_dict()
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyBaseControl object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyBaseControl') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyBaseControl') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+class V2PolicyBaseControlGrant():
+    """
+    Permission granted by the policy.
+
+    :attr List[PolicyRole] roles: A set of role cloud resource names (CRNs) granted
+          by the policy.
+    """
+
+    def __init__(self,
+                 roles: List['PolicyRole']) -> None:
+        """
+        Initialize a V2PolicyBaseControlGrant object.
+
+        :param List[PolicyRole] roles: A set of role cloud resource names (CRNs)
+               granted by the policy.
+        """
+        self.roles = roles
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseControlGrant':
+        """Initialize a V2PolicyBaseControlGrant object from a json dictionary."""
+        args = {}
+        if 'roles' in _dict:
+            args['roles'] = [PolicyRole.from_dict(v) for v in _dict.get('roles')]
+        else:
+            raise ValueError('Required property \'roles\' not present in V2PolicyBaseControlGrant JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyBaseControlGrant object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'roles') and self.roles is not None:
+            roles_list = []
+            for v in self.roles:
+                if isinstance(v, dict):
+                    roles_list.append(v)
+                else:
+                    roles_list.append(v.to_dict())
+            _dict['roles'] = roles_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyBaseControlGrant object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyBaseControlGrant') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyBaseControlGrant') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+class V2PolicyBaseResource():
+    """
+    The resource attributes associated with a policy.
+
+    :attr List[V2PolicyAttribute] attributes: (optional) List of resource attributes
+          associated with policy/.
+    """
+
+    def __init__(self,
+                 *,
+                 attributes: List['V2PolicyAttribute'] = None) -> None:
+        """
+        Initialize a V2PolicyBaseResource object.
+
+        :param List[V2PolicyAttribute] attributes: (optional) List of resource
+               attributes associated with policy/.
+        """
+        self.attributes = attributes
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseResource':
+        """Initialize a V2PolicyBaseResource object from a json dictionary."""
+        args = {}
+        if 'attributes' in _dict:
+            args['attributes'] = [V2PolicyAttribute.from_dict(v) for v in _dict.get('attributes')]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyBaseResource object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'attributes') and self.attributes is not None:
+            attributes_list = []
+            for v in self.attributes:
+                if isinstance(v, dict):
+                    attributes_list.append(v)
+                else:
+                    attributes_list.append(v.to_dict())
+            _dict['attributes'] = attributes_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyBaseResource object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyBaseResource') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyBaseResource') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+class V2PolicyBaseRule():
+    """
+    Additional access conditions associated with a policy.
+
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize a V2PolicyBaseRule object.
+
+        """
+        msg = "Cannot instantiate base class. Instead, instantiate one of the defined subclasses: {0}".format(
+                  ", ".join(['V2PolicyBaseRuleV2PolicyAttribute', 'V2PolicyBaseRuleV2RuleWithConditions']))
+        raise Exception(msg)
+
+class V2PolicyBaseSubject():
+    """
+    The subject attributes associated with a policy.
+
+    :attr List[V2PolicyAttribute] attributes: (optional) List of subject attributes
+          associated with policy/.
+    """
+
+    def __init__(self,
+                 *,
+                 attributes: List['V2PolicyAttribute'] = None) -> None:
+        """
+        Initialize a V2PolicyBaseSubject object.
+
+        :param List[V2PolicyAttribute] attributes: (optional) List of subject
+               attributes associated with policy/.
+        """
+        self.attributes = attributes
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseSubject':
+        """Initialize a V2PolicyBaseSubject object from a json dictionary."""
+        args = {}
+        if 'attributes' in _dict:
+            args['attributes'] = [V2PolicyAttribute.from_dict(v) for v in _dict.get('attributes')]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyBaseSubject object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'attributes') and self.attributes is not None:
+            attributes_list = []
+            for v in self.attributes:
+                if isinstance(v, dict):
+                    attributes_list.append(v)
+                else:
+                    attributes_list.append(v.to_dict())
+            _dict['attributes'] = attributes_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyBaseSubject object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyBaseSubject') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyBaseSubject') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+class CustomRole():
     """
     An additional set of properties associated with a role.
 
@@ -878,23 +1757,21 @@ class CustomRole:
     :attr str href: (optional) The href link back to the role.
     """
 
-    def __init__(
-        self,
-        *,
-        id: str = None,
-        display_name: str = None,
-        description: str = None,
-        actions: List[str] = None,
-        crn: str = None,
-        name: str = None,
-        account_id: str = None,
-        service_name: str = None,
-        created_at: datetime = None,
-        created_by_id: str = None,
-        last_modified_at: datetime = None,
-        last_modified_by_id: str = None,
-        href: str = None
-    ) -> None:
+    def __init__(self,
+                 *,
+                 id: str = None,
+                 display_name: str = None,
+                 description: str = None,
+                 actions: List[str] = None,
+                 crn: str = None,
+                 name: str = None,
+                 account_id: str = None,
+                 service_name: str = None,
+                 created_at: datetime = None,
+                 created_by_id: str = None,
+                 last_modified_at: datetime = None,
+                 last_modified_by_id: str = None,
+                 href: str = None) -> None:
         """
         Initialize a CustomRole object.
 
@@ -1009,8 +1886,7 @@ class CustomRole:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class Policy:
+class Policy():
     """
     The core set of properties associated with a policy.
 
@@ -1035,22 +1911,20 @@ class Policy:
     :attr str state: (optional) The policy state.
     """
 
-    def __init__(
-        self,
-        *,
-        id: str = None,
-        type: str = None,
-        description: str = None,
-        subjects: List['PolicySubject'] = None,
-        roles: List['PolicyRole'] = None,
-        resources: List['PolicyResource'] = None,
-        href: str = None,
-        created_at: datetime = None,
-        created_by_id: str = None,
-        last_modified_at: datetime = None,
-        last_modified_by_id: str = None,
-        state: str = None
-    ) -> None:
+    def __init__(self,
+                 *,
+                 id: str = None,
+                 type: str = None,
+                 description: str = None,
+                 subjects: List['PolicySubject'] = None,
+                 roles: List['PolicyRole'] = None,
+                 resources: List['PolicyResource'] = None,
+                 href: str = None,
+                 created_at: datetime = None,
+                 created_by_id: str = None,
+                 last_modified_at: datetime = None,
+                 last_modified_by_id: str = None,
+                 state: str = None) -> None:
         """
         Initialize a Policy object.
 
@@ -1089,11 +1963,11 @@ class Policy:
         if 'description' in _dict:
             args['description'] = _dict.get('description')
         if 'subjects' in _dict:
-            args['subjects'] = [PolicySubject.from_dict(x) for x in _dict.get('subjects')]
+            args['subjects'] = [PolicySubject.from_dict(v) for v in _dict.get('subjects')]
         if 'roles' in _dict:
-            args['roles'] = [PolicyRole.from_dict(x) for x in _dict.get('roles')]
+            args['roles'] = [PolicyRole.from_dict(v) for v in _dict.get('roles')]
         if 'resources' in _dict:
-            args['resources'] = [PolicyResource.from_dict(x) for x in _dict.get('resources')]
+            args['resources'] = [PolicyResource.from_dict(v) for v in _dict.get('resources')]
         if 'href' in _dict:
             args['href'] = _dict.get('href')
         if 'created_at' in _dict:
@@ -1123,11 +1997,29 @@ class Policy:
         if hasattr(self, 'description') and self.description is not None:
             _dict['description'] = self.description
         if hasattr(self, 'subjects') and self.subjects is not None:
-            _dict['subjects'] = [x.to_dict() for x in self.subjects]
+            subjects_list = []
+            for v in self.subjects:
+                if isinstance(v, dict):
+                    subjects_list.append(v)
+                else:
+                    subjects_list.append(v.to_dict())
+            _dict['subjects'] = subjects_list
         if hasattr(self, 'roles') and self.roles is not None:
-            _dict['roles'] = [x.to_dict() for x in self.roles]
+            roles_list = []
+            for v in self.roles:
+                if isinstance(v, dict):
+                    roles_list.append(v)
+                else:
+                    roles_list.append(v.to_dict())
+            _dict['roles'] = roles_list
         if hasattr(self, 'resources') and self.resources is not None:
-            _dict['resources'] = [x.to_dict() for x in self.resources]
+            resources_list = []
+            for v in self.resources:
+                if isinstance(v, dict):
+                    resources_list.append(v)
+                else:
+                    resources_list.append(v.to_dict())
+            _dict['resources'] = resources_list
         if hasattr(self, 'href') and getattr(self, 'href') is not None:
             _dict['href'] = getattr(self, 'href')
         if hasattr(self, 'created_at') and getattr(self, 'created_at') is not None:
@@ -1164,19 +2056,20 @@ class Policy:
         """
         The policy state.
         """
-
         ACTIVE = 'active'
         DELETED = 'deleted'
 
 
-class PolicyList:
+class PolicyList():
     """
     A collection of policies.
 
     :attr List[Policy] policies: (optional) List of policies.
     """
 
-    def __init__(self, *, policies: List['Policy'] = None) -> None:
+    def __init__(self,
+                 *,
+                 policies: List['Policy'] = None) -> None:
         """
         Initialize a PolicyList object.
 
@@ -1189,7 +2082,7 @@ class PolicyList:
         """Initialize a PolicyList object from a json dictionary."""
         args = {}
         if 'policies' in _dict:
-            args['policies'] = [Policy.from_dict(x) for x in _dict.get('policies')]
+            args['policies'] = [Policy.from_dict(v) for v in _dict.get('policies')]
         return cls(**args)
 
     @classmethod
@@ -1201,7 +2094,13 @@ class PolicyList:
         """Return a json dictionary representing this model."""
         _dict = {}
         if hasattr(self, 'policies') and self.policies is not None:
-            _dict['policies'] = [x.to_dict() for x in self.policies]
+            policies_list = []
+            for v in self.policies:
+                if isinstance(v, dict):
+                    policies_list.append(v)
+                else:
+                    policies_list.append(v.to_dict())
+            _dict['policies'] = policies_list
         return _dict
 
     def _to_dict(self):
@@ -1222,8 +2121,7 @@ class PolicyList:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class PolicyResource:
+class PolicyResource():
     """
     The attributes of the resource. Note that only one resource is allowed in a policy.
 
@@ -1232,7 +2130,10 @@ class PolicyResource:
     :attr List[ResourceTag] tags: (optional) List of access management tags.
     """
 
-    def __init__(self, *, attributes: List['ResourceAttribute'] = None, tags: List['ResourceTag'] = None) -> None:
+    def __init__(self,
+                 *,
+                 attributes: List['ResourceAttribute'] = None,
+                 tags: List['ResourceTag'] = None) -> None:
         """
         Initialize a PolicyResource object.
 
@@ -1248,9 +2149,9 @@ class PolicyResource:
         """Initialize a PolicyResource object from a json dictionary."""
         args = {}
         if 'attributes' in _dict:
-            args['attributes'] = [ResourceAttribute.from_dict(x) for x in _dict.get('attributes')]
+            args['attributes'] = [ResourceAttribute.from_dict(v) for v in _dict.get('attributes')]
         if 'tags' in _dict:
-            args['tags'] = [ResourceTag.from_dict(x) for x in _dict.get('tags')]
+            args['tags'] = [ResourceTag.from_dict(v) for v in _dict.get('tags')]
         return cls(**args)
 
     @classmethod
@@ -1262,9 +2163,21 @@ class PolicyResource:
         """Return a json dictionary representing this model."""
         _dict = {}
         if hasattr(self, 'attributes') and self.attributes is not None:
-            _dict['attributes'] = [x.to_dict() for x in self.attributes]
+            attributes_list = []
+            for v in self.attributes:
+                if isinstance(v, dict):
+                    attributes_list.append(v)
+                else:
+                    attributes_list.append(v.to_dict())
+            _dict['attributes'] = attributes_list
         if hasattr(self, 'tags') and self.tags is not None:
-            _dict['tags'] = [x.to_dict() for x in self.tags]
+            tags_list = []
+            for v in self.tags:
+                if isinstance(v, dict):
+                    tags_list.append(v)
+                else:
+                    tags_list.append(v.to_dict())
+            _dict['tags'] = tags_list
         return _dict
 
     def _to_dict(self):
@@ -1285,8 +2198,7 @@ class PolicyResource:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class PolicyRole:
+class PolicyRole():
     """
     A role associated with a policy.
 
@@ -1296,7 +2208,11 @@ class PolicyRole:
     :attr str description: (optional) The description of the role.
     """
 
-    def __init__(self, role_id: str, *, display_name: str = None, description: str = None) -> None:
+    def __init__(self,
+                 role_id: str,
+                 *,
+                 display_name: str = None,
+                 description: str = None) -> None:
         """
         Initialize a PolicyRole object.
 
@@ -1355,8 +2271,7 @@ class PolicyRole:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class PolicySubject:
+class PolicySubject():
     """
     The subject attribute values that must match in order for this policy to apply in a
     permission decision.
@@ -1364,7 +2279,9 @@ class PolicySubject:
     :attr List[SubjectAttribute] attributes: (optional) List of subject attributes.
     """
 
-    def __init__(self, *, attributes: List['SubjectAttribute'] = None) -> None:
+    def __init__(self,
+                 *,
+                 attributes: List['SubjectAttribute'] = None) -> None:
         """
         Initialize a PolicySubject object.
 
@@ -1378,7 +2295,7 @@ class PolicySubject:
         """Initialize a PolicySubject object from a json dictionary."""
         args = {}
         if 'attributes' in _dict:
-            args['attributes'] = [SubjectAttribute.from_dict(x) for x in _dict.get('attributes')]
+            args['attributes'] = [SubjectAttribute.from_dict(v) for v in _dict.get('attributes')]
         return cls(**args)
 
     @classmethod
@@ -1390,7 +2307,13 @@ class PolicySubject:
         """Return a json dictionary representing this model."""
         _dict = {}
         if hasattr(self, 'attributes') and self.attributes is not None:
-            _dict['attributes'] = [x.to_dict() for x in self.attributes]
+            attributes_list = []
+            for v in self.attributes:
+                if isinstance(v, dict):
+                    attributes_list.append(v)
+                else:
+                    attributes_list.append(v.to_dict())
+            _dict['attributes'] = attributes_list
         return _dict
 
     def _to_dict(self):
@@ -1411,8 +2334,7 @@ class PolicySubject:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class ResourceAttribute:
+class ResourceAttribute():
     """
     An attribute associated with a resource.
 
@@ -1421,7 +2343,11 @@ class ResourceAttribute:
     :attr str operator: (optional) The operator of an attribute.
     """
 
-    def __init__(self, name: str, value: str, *, operator: str = None) -> None:
+    def __init__(self,
+                 name: str,
+                 value: str,
+                 *,
+                 operator: str = None) -> None:
         """
         Initialize a ResourceAttribute object.
 
@@ -1483,8 +2409,7 @@ class ResourceAttribute:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class ResourceTag:
+class ResourceTag():
     """
     A tag associated with a resource.
 
@@ -1493,7 +2418,11 @@ class ResourceTag:
     :attr str operator: (optional) The operator of an access management tag.
     """
 
-    def __init__(self, name: str, value: str, *, operator: str = None) -> None:
+    def __init__(self,
+                 name: str,
+                 value: str,
+                 *,
+                 operator: str = None) -> None:
         """
         Initialize a ResourceTag object.
 
@@ -1555,8 +2484,7 @@ class ResourceTag:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class Role:
+class Role():
     """
     A role resource.
 
@@ -1570,9 +2498,12 @@ class Role:
           'crn:v1:ibmcloud:public:iam-access-management::a/exampleAccountId::customRole:ExampleRoleName'.
     """
 
-    def __init__(
-        self, *, display_name: str = None, description: str = None, actions: List[str] = None, crn: str = None
-    ) -> None:
+    def __init__(self,
+                 *,
+                 display_name: str = None,
+                 description: str = None,
+                 actions: List[str] = None,
+                 crn: str = None) -> None:
         """
         Initialize a Role object.
 
@@ -1638,8 +2569,7 @@ class Role:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class RoleList:
+class RoleList():
     """
     A collection of roles returned by the 'list roles' operation.
 
@@ -1648,13 +2578,11 @@ class RoleList:
     :attr List[Role] system_roles: (optional) List of system roles.
     """
 
-    def __init__(
-        self,
-        *,
-        custom_roles: List['CustomRole'] = None,
-        service_roles: List['Role'] = None,
-        system_roles: List['Role'] = None
-    ) -> None:
+    def __init__(self,
+                 *,
+                 custom_roles: List['CustomRole'] = None,
+                 service_roles: List['Role'] = None,
+                 system_roles: List['Role'] = None) -> None:
         """
         Initialize a RoleList object.
 
@@ -1671,11 +2599,11 @@ class RoleList:
         """Initialize a RoleList object from a json dictionary."""
         args = {}
         if 'custom_roles' in _dict:
-            args['custom_roles'] = [CustomRole.from_dict(x) for x in _dict.get('custom_roles')]
+            args['custom_roles'] = [CustomRole.from_dict(v) for v in _dict.get('custom_roles')]
         if 'service_roles' in _dict:
-            args['service_roles'] = [Role.from_dict(x) for x in _dict.get('service_roles')]
+            args['service_roles'] = [Role.from_dict(v) for v in _dict.get('service_roles')]
         if 'system_roles' in _dict:
-            args['system_roles'] = [Role.from_dict(x) for x in _dict.get('system_roles')]
+            args['system_roles'] = [Role.from_dict(v) for v in _dict.get('system_roles')]
         return cls(**args)
 
     @classmethod
@@ -1687,11 +2615,29 @@ class RoleList:
         """Return a json dictionary representing this model."""
         _dict = {}
         if hasattr(self, 'custom_roles') and self.custom_roles is not None:
-            _dict['custom_roles'] = [x.to_dict() for x in self.custom_roles]
+            custom_roles_list = []
+            for v in self.custom_roles:
+                if isinstance(v, dict):
+                    custom_roles_list.append(v)
+                else:
+                    custom_roles_list.append(v.to_dict())
+            _dict['custom_roles'] = custom_roles_list
         if hasattr(self, 'service_roles') and self.service_roles is not None:
-            _dict['service_roles'] = [x.to_dict() for x in self.service_roles]
+            service_roles_list = []
+            for v in self.service_roles:
+                if isinstance(v, dict):
+                    service_roles_list.append(v)
+                else:
+                    service_roles_list.append(v.to_dict())
+            _dict['service_roles'] = service_roles_list
         if hasattr(self, 'system_roles') and self.system_roles is not None:
-            _dict['system_roles'] = [x.to_dict() for x in self.system_roles]
+            system_roles_list = []
+            for v in self.system_roles:
+                if isinstance(v, dict):
+                    system_roles_list.append(v)
+                else:
+                    system_roles_list.append(v.to_dict())
+            _dict['system_roles'] = system_roles_list
         return _dict
 
     def _to_dict(self):
@@ -1712,8 +2658,7 @@ class RoleList:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class SubjectAttribute:
+class SubjectAttribute():
     """
     An attribute associated with a subject.
 
@@ -1721,7 +2666,9 @@ class SubjectAttribute:
     :attr str value: The value of an attribute.
     """
 
-    def __init__(self, name: str, value: str) -> None:
+    def __init__(self,
+                 name: str,
+                 value: str) -> None:
         """
         Initialize a SubjectAttribute object.
 
@@ -1776,3 +2723,493 @@ class SubjectAttribute:
     def __ne__(self, other: 'SubjectAttribute') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
+
+class V2Policy():
+    """
+    The core set of properties associated with a policy.
+
+    :attr str id: (optional) The policy ID.
+    :attr str type: The policy type; either 'access' or 'authorization'.
+    :attr str description: (optional) Customer-defined description.
+    :attr V2PolicyBaseSubject subject: (optional) The subject attributes associated
+          with a policy.
+    :attr V2PolicyBaseControl control: Specifies the type of access granted by the
+          policy.
+    :attr V2PolicyBaseResource resource: (optional) The resource attributes
+          associated with a policy.
+    :attr str pattern: (optional) Indicates pattern of rule.
+    :attr V2PolicyBaseRule rule: (optional) Additional access conditions associated
+          with a policy.
+    :attr str href: (optional) The href link back to the policy.
+    :attr datetime created_at: (optional) The UTC timestamp when the policy was
+          created.
+    :attr str created_by_id: (optional) The iam ID of the entity that created the
+          policy.
+    :attr datetime last_modified_at: (optional) The UTC timestamp when the policy
+          was last modified.
+    :attr str last_modified_by_id: (optional) The iam ID of the entity that last
+          modified the policy.
+    :attr str state: (optional) The policy state.
+    """
+
+    def __init__(self,
+                 type: str,
+                 control: 'V2PolicyBaseControl',
+                 *,
+                 id: str = None,
+                 description: str = None,
+                 subject: 'V2PolicyBaseSubject' = None,
+                 resource: 'V2PolicyBaseResource' = None,
+                 pattern: str = None,
+                 rule: 'V2PolicyBaseRule' = None,
+                 href: str = None,
+                 created_at: datetime = None,
+                 created_by_id: str = None,
+                 last_modified_at: datetime = None,
+                 last_modified_by_id: str = None,
+                 state: str = None) -> None:
+        """
+        Initialize a V2Policy object.
+
+        :param str type: The policy type; either 'access' or 'authorization'.
+        :param V2PolicyBaseControl control: Specifies the type of access granted by
+               the policy.
+        :param str description: (optional) Customer-defined description.
+        :param V2PolicyBaseSubject subject: (optional) The subject attributes
+               associated with a policy.
+        :param V2PolicyBaseResource resource: (optional) The resource attributes
+               associated with a policy.
+        :param str pattern: (optional) Indicates pattern of rule.
+        :param V2PolicyBaseRule rule: (optional) Additional access conditions
+               associated with a policy.
+        :param str state: (optional) The policy state.
+        """
+        self.id = id
+        self.type = type
+        self.description = description
+        self.subject = subject
+        self.control = control
+        self.resource = resource
+        self.pattern = pattern
+        self.rule = rule
+        self.href = href
+        self.created_at = created_at
+        self.created_by_id = created_by_id
+        self.last_modified_at = last_modified_at
+        self.last_modified_by_id = last_modified_by_id
+        self.state = state
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2Policy':
+        """Initialize a V2Policy object from a json dictionary."""
+        args = {}
+        if 'id' in _dict:
+            args['id'] = _dict.get('id')
+        if 'type' in _dict:
+            args['type'] = _dict.get('type')
+        else:
+            raise ValueError('Required property \'type\' not present in V2Policy JSON')
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
+        if 'subject' in _dict:
+            args['subject'] = V2PolicyBaseSubject.from_dict(_dict.get('subject'))
+        if 'control' in _dict:
+            args['control'] = V2PolicyBaseControl.from_dict(_dict.get('control'))
+        else:
+            raise ValueError('Required property \'control\' not present in V2Policy JSON')
+        if 'resource' in _dict:
+            args['resource'] = V2PolicyBaseResource.from_dict(_dict.get('resource'))
+        if 'pattern' in _dict:
+            args['pattern'] = _dict.get('pattern')
+        if 'rule' in _dict:
+            args['rule'] = _dict.get('rule')
+        if 'href' in _dict:
+            args['href'] = _dict.get('href')
+        if 'created_at' in _dict:
+            args['created_at'] = string_to_datetime(_dict.get('created_at'))
+        if 'created_by_id' in _dict:
+            args['created_by_id'] = _dict.get('created_by_id')
+        if 'last_modified_at' in _dict:
+            args['last_modified_at'] = string_to_datetime(_dict.get('last_modified_at'))
+        if 'last_modified_by_id' in _dict:
+            args['last_modified_by_id'] = _dict.get('last_modified_by_id')
+        if 'state' in _dict:
+            args['state'] = _dict.get('state')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2Policy object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'id') and getattr(self, 'id') is not None:
+            _dict['id'] = getattr(self, 'id')
+        if hasattr(self, 'type') and self.type is not None:
+            _dict['type'] = self.type
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'subject') and self.subject is not None:
+            if isinstance(self.subject, dict):
+                _dict['subject'] = self.subject
+            else:
+                _dict['subject'] = self.subject.to_dict()
+        if hasattr(self, 'control') and self.control is not None:
+            if isinstance(self.control, dict):
+                _dict['control'] = self.control
+            else:
+                _dict['control'] = self.control.to_dict()
+        if hasattr(self, 'resource') and self.resource is not None:
+            if isinstance(self.resource, dict):
+                _dict['resource'] = self.resource
+            else:
+                _dict['resource'] = self.resource.to_dict()
+        if hasattr(self, 'pattern') and self.pattern is not None:
+            _dict['pattern'] = self.pattern
+        if hasattr(self, 'rule') and self.rule is not None:
+            if isinstance(self.rule, dict):
+                _dict['rule'] = self.rule
+            else:
+                _dict['rule'] = self.rule.to_dict()
+        if hasattr(self, 'href') and getattr(self, 'href') is not None:
+            _dict['href'] = getattr(self, 'href')
+        if hasattr(self, 'created_at') and getattr(self, 'created_at') is not None:
+            _dict['created_at'] = datetime_to_string(getattr(self, 'created_at'))
+        if hasattr(self, 'created_by_id') and getattr(self, 'created_by_id') is not None:
+            _dict['created_by_id'] = getattr(self, 'created_by_id')
+        if hasattr(self, 'last_modified_at') and getattr(self, 'last_modified_at') is not None:
+            _dict['last_modified_at'] = datetime_to_string(getattr(self, 'last_modified_at'))
+        if hasattr(self, 'last_modified_by_id') and getattr(self, 'last_modified_by_id') is not None:
+            _dict['last_modified_by_id'] = getattr(self, 'last_modified_by_id')
+        if hasattr(self, 'state') and self.state is not None:
+            _dict['state'] = self.state
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2Policy object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2Policy') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2Policy') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class StateEnum(str, Enum):
+        """
+        The policy state.
+        """
+        ACTIVE = 'active'
+        DELETED = 'deleted'
+
+
+class V2PolicyAttribute():
+    """
+    Resource/subject attribute associated with policy attributes.
+
+    :attr str key: The name of an attribute.
+    :attr str operator: The operator of an attribute.
+    :attr object value: The value of an attribute; can be array, boolean, string, or
+          integer.
+    """
+
+    def __init__(self,
+                 key: str,
+                 operator: str,
+                 value: object) -> None:
+        """
+        Initialize a V2PolicyAttribute object.
+
+        :param str key: The name of an attribute.
+        :param str operator: The operator of an attribute.
+        :param object value: The value of an attribute; can be array, boolean,
+               string, or integer.
+        """
+        self.key = key
+        self.operator = operator
+        self.value = value
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyAttribute':
+        """Initialize a V2PolicyAttribute object from a json dictionary."""
+        args = {}
+        if 'key' in _dict:
+            args['key'] = _dict.get('key')
+        else:
+            raise ValueError('Required property \'key\' not present in V2PolicyAttribute JSON')
+        if 'operator' in _dict:
+            args['operator'] = _dict.get('operator')
+        else:
+            raise ValueError('Required property \'operator\' not present in V2PolicyAttribute JSON')
+        if 'value' in _dict:
+            args['value'] = _dict.get('value')
+        else:
+            raise ValueError('Required property \'value\' not present in V2PolicyAttribute JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyAttribute object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'key') and self.key is not None:
+            _dict['key'] = self.key
+        if hasattr(self, 'operator') and self.operator is not None:
+            _dict['operator'] = self.operator
+        if hasattr(self, 'value') and self.value is not None:
+            _dict['value'] = self.value
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyAttribute object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyAttribute') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyAttribute') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+class V2PolicyList():
+    """
+    A collection of policies.
+
+    :attr List[V2Policy] policies: (optional) List of policies.
+    """
+
+    def __init__(self,
+                 *,
+                 policies: List['V2Policy'] = None) -> None:
+        """
+        Initialize a V2PolicyList object.
+
+        :param List[V2Policy] policies: (optional) List of policies.
+        """
+        self.policies = policies
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyList':
+        """Initialize a V2PolicyList object from a json dictionary."""
+        args = {}
+        if 'policies' in _dict:
+            args['policies'] = [V2Policy.from_dict(v) for v in _dict.get('policies')]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyList object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'policies') and self.policies is not None:
+            policies_list = []
+            for v in self.policies:
+                if isinstance(v, dict):
+                    policies_list.append(v)
+                else:
+                    policies_list.append(v.to_dict())
+            _dict['policies'] = policies_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyList object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyList') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyList') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+class V2PolicyBaseRuleV2PolicyAttribute(V2PolicyBaseRule):
+    """
+    Resource/subject attribute associated with policy attributes.
+
+    :attr str key: The name of an attribute.
+    :attr str operator: The operator of an attribute.
+    :attr object value: The value of an attribute; can be array, boolean, string, or
+          integer.
+    """
+
+    def __init__(self,
+                 key: str,
+                 operator: str,
+                 value: object) -> None:
+        """
+        Initialize a V2PolicyBaseRuleV2PolicyAttribute object.
+
+        :param str key: The name of an attribute.
+        :param str operator: The operator of an attribute.
+        :param object value: The value of an attribute; can be array, boolean,
+               string, or integer.
+        """
+        # pylint: disable=super-init-not-called
+        self.key = key
+        self.operator = operator
+        self.value = value
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseRuleV2PolicyAttribute':
+        """Initialize a V2PolicyBaseRuleV2PolicyAttribute object from a json dictionary."""
+        args = {}
+        if 'key' in _dict:
+            args['key'] = _dict.get('key')
+        else:
+            raise ValueError('Required property \'key\' not present in V2PolicyBaseRuleV2PolicyAttribute JSON')
+        if 'operator' in _dict:
+            args['operator'] = _dict.get('operator')
+        else:
+            raise ValueError('Required property \'operator\' not present in V2PolicyBaseRuleV2PolicyAttribute JSON')
+        if 'value' in _dict:
+            args['value'] = _dict.get('value')
+        else:
+            raise ValueError('Required property \'value\' not present in V2PolicyBaseRuleV2PolicyAttribute JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyBaseRuleV2PolicyAttribute object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'key') and self.key is not None:
+            _dict['key'] = self.key
+        if hasattr(self, 'operator') and self.operator is not None:
+            _dict['operator'] = self.operator
+        if hasattr(self, 'value') and self.value is not None:
+            _dict['value'] = self.value
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyBaseRuleV2PolicyAttribute object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyBaseRuleV2PolicyAttribute') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyBaseRuleV2PolicyAttribute') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+class V2PolicyBaseRuleV2RuleWithConditions(V2PolicyBaseRule):
+    """
+    Policy rule that has 2 to 10 conditions.
+
+    :attr str operator: Operator to evalute conditions.
+    :attr List[V2PolicyAttribute] conditions: List of conditions to associated with
+          a policy. Note that conditions can be nested up to 2 levels.
+    """
+
+    def __init__(self,
+                 operator: str,
+                 conditions: List['V2PolicyAttribute']) -> None:
+        """
+        Initialize a V2PolicyBaseRuleV2RuleWithConditions object.
+
+        :param str operator: Operator to evalute conditions.
+        :param List[V2PolicyAttribute] conditions: List of conditions to associated
+               with a policy. Note that conditions can be nested up to 2 levels.
+        """
+        # pylint: disable=super-init-not-called
+        self.operator = operator
+        self.conditions = conditions
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseRuleV2RuleWithConditions':
+        """Initialize a V2PolicyBaseRuleV2RuleWithConditions object from a json dictionary."""
+        args = {}
+        if 'operator' in _dict:
+            args['operator'] = _dict.get('operator')
+        else:
+            raise ValueError('Required property \'operator\' not present in V2PolicyBaseRuleV2RuleWithConditions JSON')
+        if 'conditions' in _dict:
+            args['conditions'] = [V2PolicyAttribute.from_dict(v) for v in _dict.get('conditions')]
+        else:
+            raise ValueError('Required property \'conditions\' not present in V2PolicyBaseRuleV2RuleWithConditions JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyBaseRuleV2RuleWithConditions object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'operator') and self.operator is not None:
+            _dict['operator'] = self.operator
+        if hasattr(self, 'conditions') and self.conditions is not None:
+            conditions_list = []
+            for v in self.conditions:
+                if isinstance(v, dict):
+                    conditions_list.append(v)
+                else:
+                    conditions_list.append(v.to_dict())
+            _dict['conditions'] = conditions_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyBaseRuleV2RuleWithConditions object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyBaseRuleV2RuleWithConditions') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyBaseRuleV2RuleWithConditions') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class OperatorEnum(str, Enum):
+        """
+        Operator to evalute conditions.
+        """
+        AND = 'and'
+        OR = 'or'
+

--- a/test/integration/test_iam_policy_management_v1.py
+++ b/test/integration/test_iam_policy_management_v1.py
@@ -72,27 +72,32 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         )
 
         cls.testV2PolicySubject = V2PolicyBaseSubject(
-            attributes=[
-                V2PolicyAttribute(key='iam_id', value=cls.testUserId, operator='stringEquals')
-            ])
+            attributes=[V2PolicyAttribute(key='iam_id', value=cls.testUserId, operator='stringEquals')]
+        )
         cls.testV2PolicyResource = V2PolicyBaseResource(
             attributes=[
                 V2PolicyAttribute(key='accountId', value=cls.testAccountId, operator='stringEquals'),
                 V2PolicyAttribute(key='serviceType', value='service', operator='stringEquals'),
             ],
         )
-        cls.testV2PolicyControl = V2PolicyBaseControl(
-            grant=V2PolicyBaseControlGrant(
-                roles=[cls.testPolicyRole]
-            )
-        )
+        cls.testV2PolicyControl = V2PolicyBaseControl(grant=V2PolicyBaseControlGrant(roles=[cls.testPolicyRole]))
         cls.testV2PolicyRule = V2PolicyBaseRuleV2RuleWithConditions(
             operator='and',
             conditions=[
-                V2PolicyAttribute(key='{{environment.attributes.day_of_week}}', operator='dayOfWeekAnyOf', value=[1, 2, 3, 4, 5]),
-                V2PolicyAttribute(key='{{environment.attributes.current_time}}', operator='timeGreaterThanOrEquals', value='09:00:00+00:00'),
-                V2PolicyAttribute(key='{{environment.attributes.current_time}}', operator='timeLessThanOrEquals', value='17:00:00+00:00'),
-            ]
+                V2PolicyAttribute(
+                    key='{{environment.attributes.day_of_week}}', operator='dayOfWeekAnyOf', value=[1, 2, 3, 4, 5]
+                ),
+                V2PolicyAttribute(
+                    key='{{environment.attributes.current_time}}',
+                    operator='timeGreaterThanOrEquals',
+                    value='09:00:00+00:00',
+                ),
+                V2PolicyAttribute(
+                    key='{{environment.attributes.current_time}}',
+                    operator='timeLessThanOrEquals',
+                    value='17:00:00+00:00',
+                ),
+            ],
         )
 
         cls.testCustomRoleId = ""
@@ -463,4 +468,3 @@ class TestIamPolicyManagementV1(unittest.TestCase):
                 foundTestPolicy = True
                 break
         assert foundTestPolicy
-

--- a/test/integration/test_iam_policy_management_v1.py
+++ b/test/integration/test_iam_policy_management_v1.py
@@ -71,6 +71,30 @@ class TestIamPolicyManagementV1(unittest.TestCase):
             tags=[resource_tag],
         )
 
+        cls.testV2PolicySubject = V2PolicyBaseSubject(
+            attributes=[
+                V2PolicyAttribute(key='iam_id', value=cls.testUserId, operator='stringEquals')
+            ])
+        cls.testV2PolicyResource = V2PolicyBaseResource(
+            attributes=[
+                V2PolicyAttribute(key='accountId', value=cls.testAccountId, operator='stringEquals'),
+                V2PolicyAttribute(key='serviceType', value='service', operator='stringEquals'),
+            ],
+        )
+        cls.testV2PolicyControl = V2PolicyBaseControl(
+            grant=V2PolicyBaseControlGrant(
+                roles=[cls.testPolicyRole]
+            )
+        )
+        cls.testV2PolicyRule = V2PolicyBaseRuleV2RuleWithConditions(
+            operator='and',
+            conditions=[
+                V2PolicyAttribute(key='{{environment.attributes.day_of_week}}', operator='dayOfWeekAnyOf', value=[1, 2, 3, 4, 5]),
+                V2PolicyAttribute(key='{{environment.attributes.current_time}}', operator='timeGreaterThanOrEquals', value='09:00:00+00:00'),
+                V2PolicyAttribute(key='{{environment.attributes.current_time}}', operator='timeLessThanOrEquals', value='17:00:00+00:00'),
+            ]
+        )
+
         cls.testCustomRoleId = ""
         cls.testCustomRoleETag = ""
         cls.testCustomRoleName = 'TestPythonRole' + str(random.randint(0, 99999))
@@ -105,10 +129,16 @@ class TestIamPolicyManagementV1(unittest.TestCase):
             now = datetime.now(timezone.utc)
             minutesDifference = (now - policy.created_at).seconds / 60
 
-            if policy.id == cls.testPolicyId or minutesDifference < 5:
-                response = cls.service.delete_policy(policy_id=policy.id)
-                assert response is not None
-                assert response.get_status_code() == 204
+            if "v2/policies" in policy.href:
+                if policy.id == cls.testPolicyId or minutesDifference < 5:
+                    response = cls.service.v2_delete_policy(policy_id=policy.id)
+                    assert response is not None
+                    assert response.get_status_code() == 204
+            else:
+                if policy.id == cls.testPolicyId or minutesDifference < 5:
+                    response = cls.service.delete_policy(policy_id=policy.id)
+                    assert response is not None
+                    assert response.get_status_code() == 204
 
         # cleanup custon role
         assert cls.testCustomRoleId is not None
@@ -334,3 +364,103 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert result is not None
         assert result.id == self.testPolicyId
         assert result.state == 'active'
+
+    def test_10_create_v2_access_policy(self):
+        self.testV2PolicyControl.grant.roles[0].role_id = self.testViewerRoleCrn
+        response = self.service.v2_create_policy(
+            type='access',
+            subject=self.testV2PolicySubject,
+            control=self.testV2PolicyControl,
+            resource=self.testV2PolicyResource,
+            pattern='time-based-restrictions:weekly',
+            rule=self.testV2PolicyRule,
+        )
+        assert response is not None
+        assert response.get_status_code() == 201
+
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        result = V2Policy.from_dict(result_dict)
+        assert result is not None
+        assert result.subject == self.testV2PolicySubject
+        assert result.resource == self.testV2PolicyResource
+        assert result.control == self.testV2PolicyControl
+
+        print('\nTest policy: ', result)
+
+        self.__class__.testPolicyId = result.id
+
+    def test_11_get_v2_access_policy(self):
+        assert self.testPolicyId
+        print("Policy ID: ", self.testPolicyId)
+
+        response = self.service.v2_get_policy(policy_id=self.testPolicyId)
+        assert response is not None
+        assert response.get_status_code() == 200
+
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        result = V2Policy.from_dict(result_dict)
+        assert result is not None
+        assert result.subject == self.testV2PolicySubject
+        assert result.resource == self.testV2PolicyResource
+        assert result.control.grant.roles[0].role_id == self.testViewerRoleCrn
+        assert result.state == 'active'
+
+        self.__class__.testPolicyETag = response.get_headers().get(self.etagHeader)
+
+    def test_12_update_v2_access_policy(self):
+        assert self.testPolicyId
+        assert self.testPolicyETag
+        print("Policy ID: ", self.testPolicyId)
+
+        self.testV2PolicyControl.grant.roles[0].role_id = self.testEditorRoleCrn
+
+        response = self.service.v2_update_policy(
+            policy_id=self.testPolicyId,
+            if_match=self.testPolicyETag,
+            type='access',
+            subject=self.testV2PolicySubject,
+            control=self.testV2PolicyControl,
+            resource=self.testV2PolicyResource,
+        )
+        assert response is not None
+        assert response.get_status_code() == 200
+
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        result = V2Policy.from_dict(result_dict)
+        assert result is not None
+        assert result.id == self.testPolicyId
+        assert result.subject == self.testV2PolicySubject
+        assert result.resource == self.testV2PolicyResource
+        assert result.control.grant.roles[0].role_id == self.testEditorRoleCrn
+
+        self.__class__.testPolicyETag = response.get_headers().get(self.etagHeader)
+
+    def test_13_list_v2_access_policies(self):
+        print("Policy ID: ", self.testPolicyId)
+
+        response = self.service.v2_list_policies(account_id=self.testAccountId, iam_id=self.testUserId)
+        assert response is not None
+        assert response.get_status_code() == 200
+
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        result = V2PolicyList.from_dict(result_dict)
+        assert result is not None
+
+        print("Policy list: ", result)
+
+        # Confirm the test policy is present
+        foundTestPolicy = False
+        for policy in result.policies:
+            if policy.id == self.testPolicyId:
+                foundTestPolicy = True
+                break
+        assert foundTestPolicy
+

--- a/test/unit/test_iam_policy_management_v1.py
+++ b/test/unit/test_iam_policy_management_v1.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (C) Copyright IBM Corp. 2021.
+# (C) Copyright IBM Corp. 2022.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,18 +31,46 @@ import urllib
 from ibm_platform_services.iam_policy_management_v1 import *
 
 
-_service = IamPolicyManagementV1(authenticator=NoAuthAuthenticator())
+_service = IamPolicyManagementV1(
+    authenticator=NoAuthAuthenticator()
+)
 
 _base_url = 'https://iam.cloud.ibm.com'
 _service.set_service_url(_base_url)
+
+
+def preprocess_url(operation_path: str):
+    """
+    Returns the request url associated with the specified operation path.
+    This will be base_url concatenated with a quoted version of operation_path.
+    The returned request URL is used to register the mock response so it needs
+    to match the request URL that is formed by the requests library.
+    """
+    # First, unquote the path since it might have some quoted/escaped characters in it
+    # due to how the generator inserts the operation paths into the unit test code.
+    operation_path = urllib.parse.unquote(operation_path)
+
+    # Next, quote the path using urllib so that we approximate what will
+    # happen during request processing.
+    operation_path = urllib.parse.quote(operation_path, safe='/')
+
+    # Finally, form the request URL from the base URL and operation path.
+    request_url = _base_url + operation_path
+
+    # If the request url does NOT end with a /, then just return it as-is.
+    # Otherwise, return a regular expression that matches one or more trailing /.
+    if re.fullmatch('.*/+', request_url) is None:
+        return request_url
+    else:
+        return re.compile(request_url.rstrip('/') + '/+')
+
 
 ##############################################################################
 # Start of Service: Policies
 ##############################################################################
 # region
 
-
-class TestNewInstance:
+class TestNewInstance():
     """
     Test Class for new_instance
     """
@@ -65,24 +93,14 @@ class TestNewInstance:
         new_instance_without_authenticator()
         """
         with pytest.raises(ValueError, match='authenticator must be provided'):
-            service = IamPolicyManagementV1.new_instance()
+            service = IamPolicyManagementV1.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
 
-
-class TestListPolicies:
+class TestListPolicies():
     """
     Test Class for list_policies
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_list_policies_all_params(self):
@@ -90,9 +108,13 @@ class TestListPolicies:
         list_policies()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v1/policies')
+        url = preprocess_url('/v1/policies')
         mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -120,14 +142,14 @@ class TestListPolicies:
             sort=sort,
             format=format,
             state=state,
-            headers={},
+            headers={}
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = responses.calls[0].request.url.split('?',1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'account_id={}'.format(account_id) in query_string
         assert 'iam_id={}'.format(iam_id) in query_string
@@ -155,21 +177,28 @@ class TestListPolicies:
         test_list_policies_required_params()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v1/policies')
+        url = preprocess_url('/v1/policies')
         mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
 
         # Invoke method
-        response = _service.list_policies(account_id, headers={})
+        response = _service.list_policies(
+            account_id,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = responses.calls[0].request.url.split('?',1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'account_id={}'.format(account_id) in query_string
 
@@ -188,9 +217,13 @@ class TestListPolicies:
         test_list_policies_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v1/policies')
+        url = preprocess_url('/v1/policies')
         mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -200,7 +233,7 @@ class TestListPolicies:
             "account_id": account_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.list_policies(**req_copy)
 
@@ -213,22 +246,10 @@ class TestListPolicies:
         _service.disable_retries()
         self.test_list_policies_value_error()
 
-
-class TestCreatePolicy:
+class TestCreatePolicy():
     """
     Test Class for create_policy
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_create_policy_all_params(self):
@@ -236,9 +257,13 @@ class TestCreatePolicy:
         create_policy()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v1/policies')
+        url = preprocess_url('/v1/policies')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
 
         # Construct a dict representation of a SubjectAttribute model
         subject_attribute_model = {}
@@ -280,7 +305,13 @@ class TestCreatePolicy:
 
         # Invoke method
         response = _service.create_policy(
-            type, subjects, roles, resources, description=description, accept_language=accept_language, headers={}
+            type,
+            subjects,
+            roles,
+            resources,
+            description=description,
+            accept_language=accept_language,
+            headers={}
         )
 
         # Check for correct operation
@@ -309,9 +340,13 @@ class TestCreatePolicy:
         test_create_policy_required_params()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v1/policies')
+        url = preprocess_url('/v1/policies')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
 
         # Construct a dict representation of a SubjectAttribute model
         subject_attribute_model = {}
@@ -351,7 +386,14 @@ class TestCreatePolicy:
         description = 'testString'
 
         # Invoke method
-        response = _service.create_policy(type, subjects, roles, resources, description=description, headers={})
+        response = _service.create_policy(
+            type,
+            subjects,
+            roles,
+            resources,
+            description=description,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -379,9 +421,13 @@ class TestCreatePolicy:
         test_create_policy_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v1/policies')
+        url = preprocess_url('/v1/policies')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
 
         # Construct a dict representation of a SubjectAttribute model
         subject_attribute_model = {}
@@ -428,7 +474,7 @@ class TestCreatePolicy:
             "resources": resources,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.create_policy(**req_copy)
 
@@ -441,22 +487,10 @@ class TestCreatePolicy:
         _service.disable_retries()
         self.test_create_policy_value_error()
 
-
-class TestUpdatePolicy:
+class TestUpdatePolicy():
     """
     Test Class for update_policy
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_update_policy_all_params(self):
@@ -464,9 +498,13 @@ class TestUpdatePolicy:
         update_policy()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v1/policies/testString')
+        url = preprocess_url('/v1/policies/testString')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.PUT,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Construct a dict representation of a SubjectAttribute model
         subject_attribute_model = {}
@@ -509,7 +547,14 @@ class TestUpdatePolicy:
 
         # Invoke method
         response = _service.update_policy(
-            policy_id, if_match, type, subjects, roles, resources, description=description, headers={}
+            policy_id,
+            if_match,
+            type,
+            subjects,
+            roles,
+            resources,
+            description=description,
+            headers={}
         )
 
         # Check for correct operation
@@ -538,9 +583,13 @@ class TestUpdatePolicy:
         test_update_policy_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v1/policies/testString')
+        url = preprocess_url('/v1/policies/testString')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.PUT,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Construct a dict representation of a SubjectAttribute model
         subject_attribute_model = {}
@@ -591,7 +640,7 @@ class TestUpdatePolicy:
             "resources": resources,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.update_policy(**req_copy)
 
@@ -604,22 +653,10 @@ class TestUpdatePolicy:
         _service.disable_retries()
         self.test_update_policy_value_error()
 
-
-class TestGetPolicy:
+class TestGetPolicy():
     """
     Test Class for get_policy
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_get_policy_all_params(self):
@@ -627,15 +664,22 @@ class TestGetPolicy:
         get_policy()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v1/policies/testString')
+        url = preprocess_url('/v1/policies/testString')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         policy_id = 'testString'
 
         # Invoke method
-        response = _service.get_policy(policy_id, headers={})
+        response = _service.get_policy(
+            policy_id,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -656,9 +700,13 @@ class TestGetPolicy:
         test_get_policy_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v1/policies/testString')
+        url = preprocess_url('/v1/policies/testString')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         policy_id = 'testString'
@@ -668,7 +716,7 @@ class TestGetPolicy:
             "policy_id": policy_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_policy(**req_copy)
 
@@ -681,22 +729,10 @@ class TestGetPolicy:
         _service.disable_retries()
         self.test_get_policy_value_error()
 
-
-class TestDeletePolicy:
+class TestDeletePolicy():
     """
     Test Class for delete_policy
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_delete_policy_all_params(self):
@@ -704,14 +740,19 @@ class TestDeletePolicy:
         delete_policy()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v1/policies/testString')
-        responses.add(responses.DELETE, url, status=204)
+        url = preprocess_url('/v1/policies/testString')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
 
         # Set up parameter values
         policy_id = 'testString'
 
         # Invoke method
-        response = _service.delete_policy(policy_id, headers={})
+        response = _service.delete_policy(
+            policy_id,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -732,8 +773,10 @@ class TestDeletePolicy:
         test_delete_policy_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v1/policies/testString')
-        responses.add(responses.DELETE, url, status=204)
+        url = preprocess_url('/v1/policies/testString')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
 
         # Set up parameter values
         policy_id = 'testString'
@@ -743,7 +786,7 @@ class TestDeletePolicy:
             "policy_id": policy_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.delete_policy(**req_copy)
 
@@ -756,22 +799,10 @@ class TestDeletePolicy:
         _service.disable_retries()
         self.test_delete_policy_value_error()
 
-
-class TestPatchPolicy:
+class TestPatchPolicy():
     """
     Test Class for patch_policy
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_patch_policy_all_params(self):
@@ -779,9 +810,13 @@ class TestPatchPolicy:
         patch_policy()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v1/policies/testString')
+        url = preprocess_url('/v1/policies/testString')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.PATCH, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.PATCH,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         policy_id = 'testString'
@@ -789,7 +824,12 @@ class TestPatchPolicy:
         state = 'active'
 
         # Invoke method
-        response = _service.patch_policy(policy_id, if_match, state=state, headers={})
+        response = _service.patch_policy(
+            policy_id,
+            if_match,
+            state=state,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -813,9 +853,13 @@ class TestPatchPolicy:
         test_patch_policy_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v1/policies/testString')
+        url = preprocess_url('/v1/policies/testString')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.PATCH, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.PATCH,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         policy_id = 'testString'
@@ -828,7 +872,7 @@ class TestPatchPolicy:
             "if_match": if_match,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.patch_policy(**req_copy)
 
@@ -841,7 +885,6 @@ class TestPatchPolicy:
         _service.disable_retries()
         self.test_patch_policy_value_error()
 
-
 # endregion
 ##############################################################################
 # End of Service: Policies
@@ -852,8 +895,7 @@ class TestPatchPolicy:
 ##############################################################################
 # region
 
-
-class TestNewInstance:
+class TestNewInstance():
     """
     Test Class for new_instance
     """
@@ -876,24 +918,14 @@ class TestNewInstance:
         new_instance_without_authenticator()
         """
         with pytest.raises(ValueError, match='authenticator must be provided'):
-            service = IamPolicyManagementV1.new_instance()
+            service = IamPolicyManagementV1.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
 
-
-class TestListRoles:
+class TestListRoles():
     """
     Test Class for list_roles
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_list_roles_all_params(self):
@@ -901,9 +933,13 @@ class TestListRoles:
         list_roles()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/roles')
+        url = preprocess_url('/v2/roles')
         mock_response = '{"custom_roles": [{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}], "service_roles": [{"display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn"}], "system_roles": [{"display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn"}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         accept_language = 'default'
@@ -919,14 +955,14 @@ class TestListRoles:
             service_name=service_name,
             source_service_name=source_service_name,
             policy_type=policy_type,
-            headers={},
+            headers={}
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = responses.calls[0].request.url.split('?',1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'account_id={}'.format(account_id) in query_string
         assert 'service_name={}'.format(service_name) in query_string
@@ -948,12 +984,17 @@ class TestListRoles:
         test_list_roles_required_params()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/roles')
+        url = preprocess_url('/v2/roles')
         mock_response = '{"custom_roles": [{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}], "service_roles": [{"display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn"}], "system_roles": [{"display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn"}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Invoke method
         response = _service.list_roles()
+
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -968,22 +1009,10 @@ class TestListRoles:
         _service.disable_retries()
         self.test_list_roles_required_params()
 
-
-class TestCreateRole:
+class TestCreateRole():
     """
     Test Class for create_role
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_create_role_all_params(self):
@@ -991,9 +1020,13 @@ class TestCreateRole:
         create_role()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/roles')
+        url = preprocess_url('/v2/roles')
         mock_response = '{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}'
-        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
 
         # Set up parameter values
         display_name = 'testString'
@@ -1013,7 +1046,7 @@ class TestCreateRole:
             service_name,
             description=description,
             accept_language=accept_language,
-            headers={},
+            headers={}
         )
 
         # Check for correct operation
@@ -1043,9 +1076,13 @@ class TestCreateRole:
         test_create_role_required_params()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/roles')
+        url = preprocess_url('/v2/roles')
         mock_response = '{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}'
-        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
 
         # Set up parameter values
         display_name = 'testString'
@@ -1057,7 +1094,13 @@ class TestCreateRole:
 
         # Invoke method
         response = _service.create_role(
-            display_name, actions, name, account_id, service_name, description=description, headers={}
+            display_name,
+            actions,
+            name,
+            account_id,
+            service_name,
+            description=description,
+            headers={}
         )
 
         # Check for correct operation
@@ -1087,9 +1130,13 @@ class TestCreateRole:
         test_create_role_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/roles')
+        url = preprocess_url('/v2/roles')
         mock_response = '{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}'
-        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
 
         # Set up parameter values
         display_name = 'testString'
@@ -1108,7 +1155,7 @@ class TestCreateRole:
             "service_name": service_name,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.create_role(**req_copy)
 
@@ -1121,22 +1168,10 @@ class TestCreateRole:
         _service.disable_retries()
         self.test_create_role_value_error()
 
-
-class TestUpdateRole:
+class TestUpdateRole():
     """
     Test Class for update_role
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_update_role_all_params(self):
@@ -1144,9 +1179,13 @@ class TestUpdateRole:
         update_role()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/roles/testString')
+        url = preprocess_url('/v2/roles/testString')
         mock_response = '{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}'
-        responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.PUT,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         role_id = 'testString'
@@ -1157,7 +1196,12 @@ class TestUpdateRole:
 
         # Invoke method
         response = _service.update_role(
-            role_id, if_match, display_name=display_name, description=description, actions=actions, headers={}
+            role_id,
+            if_match,
+            display_name=display_name,
+            description=description,
+            actions=actions,
+            headers={}
         )
 
         # Check for correct operation
@@ -1184,9 +1228,13 @@ class TestUpdateRole:
         test_update_role_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/roles/testString')
+        url = preprocess_url('/v2/roles/testString')
         mock_response = '{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}'
-        responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.PUT,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         role_id = 'testString'
@@ -1201,7 +1249,7 @@ class TestUpdateRole:
             "if_match": if_match,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.update_role(**req_copy)
 
@@ -1214,22 +1262,10 @@ class TestUpdateRole:
         _service.disable_retries()
         self.test_update_role_value_error()
 
-
-class TestGetRole:
+class TestGetRole():
     """
     Test Class for get_role
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_get_role_all_params(self):
@@ -1237,15 +1273,22 @@ class TestGetRole:
         get_role()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/roles/testString')
+        url = preprocess_url('/v2/roles/testString')
         mock_response = '{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         role_id = 'testString'
 
         # Invoke method
-        response = _service.get_role(role_id, headers={})
+        response = _service.get_role(
+            role_id,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1266,9 +1309,13 @@ class TestGetRole:
         test_get_role_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/roles/testString')
+        url = preprocess_url('/v2/roles/testString')
         mock_response = '{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         role_id = 'testString'
@@ -1278,7 +1325,7 @@ class TestGetRole:
             "role_id": role_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_role(**req_copy)
 
@@ -1291,22 +1338,10 @@ class TestGetRole:
         _service.disable_retries()
         self.test_get_role_value_error()
 
-
-class TestDeleteRole:
+class TestDeleteRole():
     """
     Test Class for delete_role
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_delete_role_all_params(self):
@@ -1314,14 +1349,19 @@ class TestDeleteRole:
         delete_role()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/roles/testString')
-        responses.add(responses.DELETE, url, status=204)
+        url = preprocess_url('/v2/roles/testString')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
 
         # Set up parameter values
         role_id = 'testString'
 
         # Invoke method
-        response = _service.delete_role(role_id, headers={})
+        response = _service.delete_role(
+            role_id,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1342,8 +1382,10 @@ class TestDeleteRole:
         test_delete_role_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/roles/testString')
-        responses.add(responses.DELETE, url, status=204)
+        url = preprocess_url('/v2/roles/testString')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
 
         # Set up parameter values
         role_id = 'testString'
@@ -1353,7 +1395,7 @@ class TestDeleteRole:
             "role_id": role_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.delete_role(**req_copy)
 
@@ -1366,10 +1408,773 @@ class TestDeleteRole:
         _service.disable_retries()
         self.test_delete_role_value_error()
 
-
 # endregion
 ##############################################################################
 # End of Service: Roles
+##############################################################################
+
+##############################################################################
+# Start of Service: V2Policies
+##############################################################################
+# region
+
+class TestNewInstance():
+    """
+    Test Class for new_instance
+    """
+
+    def test_new_instance(self):
+        """
+        new_instance()
+        """
+        os.environ['TEST_SERVICE_AUTH_TYPE'] = 'noAuth'
+
+        service = IamPolicyManagementV1.new_instance(
+            service_name='TEST_SERVICE',
+        )
+
+        assert service is not None
+        assert isinstance(service, IamPolicyManagementV1)
+
+    def test_new_instance_without_authenticator(self):
+        """
+        new_instance_without_authenticator()
+        """
+        with pytest.raises(ValueError, match='authenticator must be provided'):
+            service = IamPolicyManagementV1.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
+
+class TestV2ListPolicies():
+    """
+    Test Class for v2_list_policies
+    """
+
+    @responses.activate
+    def test_v2_list_policies_all_params(self):
+        """
+        v2_list_policies()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies')
+        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        account_id = 'testString'
+        accept_language = 'default'
+        iam_id = 'testString'
+        access_group_id = 'testString'
+        type = 'access'
+        service_type = 'service'
+        service_name = 'testString'
+        service_group_id = 'testString'
+        format = 'include_last_permit'
+        state = 'active'
+
+        # Invoke method
+        response = _service.v2_list_policies(
+            account_id,
+            accept_language=accept_language,
+            iam_id=iam_id,
+            access_group_id=access_group_id,
+            type=type,
+            service_type=service_type,
+            service_name=service_name,
+            service_group_id=service_group_id,
+            format=format,
+            state=state,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'account_id={}'.format(account_id) in query_string
+        assert 'iam_id={}'.format(iam_id) in query_string
+        assert 'access_group_id={}'.format(access_group_id) in query_string
+        assert 'type={}'.format(type) in query_string
+        assert 'service_type={}'.format(service_type) in query_string
+        assert 'service_name={}'.format(service_name) in query_string
+        assert 'service_group_id={}'.format(service_group_id) in query_string
+        assert 'format={}'.format(format) in query_string
+        assert 'state={}'.format(state) in query_string
+
+    def test_v2_list_policies_all_params_with_retries(self):
+        # Enable retries and run test_v2_list_policies_all_params.
+        _service.enable_retries()
+        self.test_v2_list_policies_all_params()
+
+        # Disable retries and run test_v2_list_policies_all_params.
+        _service.disable_retries()
+        self.test_v2_list_policies_all_params()
+
+    @responses.activate
+    def test_v2_list_policies_required_params(self):
+        """
+        test_v2_list_policies_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies')
+        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        account_id = 'testString'
+
+        # Invoke method
+        response = _service.v2_list_policies(
+            account_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'account_id={}'.format(account_id) in query_string
+
+    def test_v2_list_policies_required_params_with_retries(self):
+        # Enable retries and run test_v2_list_policies_required_params.
+        _service.enable_retries()
+        self.test_v2_list_policies_required_params()
+
+        # Disable retries and run test_v2_list_policies_required_params.
+        _service.disable_retries()
+        self.test_v2_list_policies_required_params()
+
+    @responses.activate
+    def test_v2_list_policies_value_error(self):
+        """
+        test_v2_list_policies_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies')
+        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        account_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "account_id": account_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.v2_list_policies(**req_copy)
+
+    def test_v2_list_policies_value_error_with_retries(self):
+        # Enable retries and run test_v2_list_policies_value_error.
+        _service.enable_retries()
+        self.test_v2_list_policies_value_error()
+
+        # Disable retries and run test_v2_list_policies_value_error.
+        _service.disable_retries()
+        self.test_v2_list_policies_value_error()
+
+class TestV2CreatePolicy():
+    """
+    Test Class for v2_create_policy
+    """
+
+    @responses.activate
+    def test_v2_create_policy_all_params(self):
+        """
+        v2_create_policy()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies')
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a PolicyRole model
+        policy_role_model = {}
+        policy_role_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseControlGrant model
+        v2_policy_base_control_grant_model = {}
+        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+
+        # Construct a dict representation of a V2PolicyBaseControl model
+        v2_policy_base_control_model = {}
+        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+
+        # Construct a dict representation of a V2PolicyAttribute model
+        v2_policy_attribute_model = {}
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseSubject model
+        v2_policy_base_subject_model = {}
+        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseResource model
+        v2_policy_base_resource_model = {}
+        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseRuleV2PolicyAttribute model
+        v2_policy_base_rule_model = {}
+        v2_policy_base_rule_model['key'] = 'testString'
+        v2_policy_base_rule_model['operator'] = 'testString'
+        v2_policy_base_rule_model['value'] = 'testString'
+
+        # Set up parameter values
+        type = 'testString'
+        control = v2_policy_base_control_model
+        description = 'testString'
+        subject = v2_policy_base_subject_model
+        resource = v2_policy_base_resource_model
+        pattern = 'testString'
+        rule = v2_policy_base_rule_model
+        accept_language = 'default'
+
+        # Invoke method
+        response = _service.v2_create_policy(
+            type,
+            control,
+            description=description,
+            subject=subject,
+            resource=resource,
+            pattern=pattern,
+            rule=rule,
+            accept_language=accept_language,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['type'] == 'testString'
+        assert req_body['control'] == v2_policy_base_control_model
+        assert req_body['description'] == 'testString'
+        assert req_body['subject'] == v2_policy_base_subject_model
+        assert req_body['resource'] == v2_policy_base_resource_model
+        assert req_body['pattern'] == 'testString'
+        assert req_body['rule'] == v2_policy_base_rule_model
+
+    def test_v2_create_policy_all_params_with_retries(self):
+        # Enable retries and run test_v2_create_policy_all_params.
+        _service.enable_retries()
+        self.test_v2_create_policy_all_params()
+
+        # Disable retries and run test_v2_create_policy_all_params.
+        _service.disable_retries()
+        self.test_v2_create_policy_all_params()
+
+    @responses.activate
+    def test_v2_create_policy_required_params(self):
+        """
+        test_v2_create_policy_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies')
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a PolicyRole model
+        policy_role_model = {}
+        policy_role_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseControlGrant model
+        v2_policy_base_control_grant_model = {}
+        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+
+        # Construct a dict representation of a V2PolicyBaseControl model
+        v2_policy_base_control_model = {}
+        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+
+        # Construct a dict representation of a V2PolicyAttribute model
+        v2_policy_attribute_model = {}
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseSubject model
+        v2_policy_base_subject_model = {}
+        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseResource model
+        v2_policy_base_resource_model = {}
+        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseRuleV2PolicyAttribute model
+        v2_policy_base_rule_model = {}
+        v2_policy_base_rule_model['key'] = 'testString'
+        v2_policy_base_rule_model['operator'] = 'testString'
+        v2_policy_base_rule_model['value'] = 'testString'
+
+        # Set up parameter values
+        type = 'testString'
+        control = v2_policy_base_control_model
+        description = 'testString'
+        subject = v2_policy_base_subject_model
+        resource = v2_policy_base_resource_model
+        pattern = 'testString'
+        rule = v2_policy_base_rule_model
+
+        # Invoke method
+        response = _service.v2_create_policy(
+            type,
+            control,
+            description=description,
+            subject=subject,
+            resource=resource,
+            pattern=pattern,
+            rule=rule,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['type'] == 'testString'
+        assert req_body['control'] == v2_policy_base_control_model
+        assert req_body['description'] == 'testString'
+        assert req_body['subject'] == v2_policy_base_subject_model
+        assert req_body['resource'] == v2_policy_base_resource_model
+        assert req_body['pattern'] == 'testString'
+        assert req_body['rule'] == v2_policy_base_rule_model
+
+    def test_v2_create_policy_required_params_with_retries(self):
+        # Enable retries and run test_v2_create_policy_required_params.
+        _service.enable_retries()
+        self.test_v2_create_policy_required_params()
+
+        # Disable retries and run test_v2_create_policy_required_params.
+        _service.disable_retries()
+        self.test_v2_create_policy_required_params()
+
+    @responses.activate
+    def test_v2_create_policy_value_error(self):
+        """
+        test_v2_create_policy_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies')
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a PolicyRole model
+        policy_role_model = {}
+        policy_role_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseControlGrant model
+        v2_policy_base_control_grant_model = {}
+        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+
+        # Construct a dict representation of a V2PolicyBaseControl model
+        v2_policy_base_control_model = {}
+        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+
+        # Construct a dict representation of a V2PolicyAttribute model
+        v2_policy_attribute_model = {}
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseSubject model
+        v2_policy_base_subject_model = {}
+        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseResource model
+        v2_policy_base_resource_model = {}
+        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseRuleV2PolicyAttribute model
+        v2_policy_base_rule_model = {}
+        v2_policy_base_rule_model['key'] = 'testString'
+        v2_policy_base_rule_model['operator'] = 'testString'
+        v2_policy_base_rule_model['value'] = 'testString'
+
+        # Set up parameter values
+        type = 'testString'
+        control = v2_policy_base_control_model
+        description = 'testString'
+        subject = v2_policy_base_subject_model
+        resource = v2_policy_base_resource_model
+        pattern = 'testString'
+        rule = v2_policy_base_rule_model
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "type": type,
+            "control": control,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.v2_create_policy(**req_copy)
+
+    def test_v2_create_policy_value_error_with_retries(self):
+        # Enable retries and run test_v2_create_policy_value_error.
+        _service.enable_retries()
+        self.test_v2_create_policy_value_error()
+
+        # Disable retries and run test_v2_create_policy_value_error.
+        _service.disable_retries()
+        self.test_v2_create_policy_value_error()
+
+class TestV2UpdatePolicy():
+    """
+    Test Class for v2_update_policy
+    """
+
+    @responses.activate
+    def test_v2_update_policy_all_params(self):
+        """
+        v2_update_policy()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies/testString')
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        responses.add(responses.PUT,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Construct a dict representation of a PolicyRole model
+        policy_role_model = {}
+        policy_role_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseControlGrant model
+        v2_policy_base_control_grant_model = {}
+        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+
+        # Construct a dict representation of a V2PolicyBaseControl model
+        v2_policy_base_control_model = {}
+        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+
+        # Construct a dict representation of a V2PolicyAttribute model
+        v2_policy_attribute_model = {}
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseSubject model
+        v2_policy_base_subject_model = {}
+        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseResource model
+        v2_policy_base_resource_model = {}
+        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseRuleV2PolicyAttribute model
+        v2_policy_base_rule_model = {}
+        v2_policy_base_rule_model['key'] = 'testString'
+        v2_policy_base_rule_model['operator'] = 'testString'
+        v2_policy_base_rule_model['value'] = 'testString'
+
+        # Set up parameter values
+        policy_id = 'testString'
+        if_match = 'testString'
+        type = 'testString'
+        control = v2_policy_base_control_model
+        description = 'testString'
+        subject = v2_policy_base_subject_model
+        resource = v2_policy_base_resource_model
+        pattern = 'testString'
+        rule = v2_policy_base_rule_model
+
+        # Invoke method
+        response = _service.v2_update_policy(
+            policy_id,
+            if_match,
+            type,
+            control,
+            description=description,
+            subject=subject,
+            resource=resource,
+            pattern=pattern,
+            rule=rule,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['type'] == 'testString'
+        assert req_body['control'] == v2_policy_base_control_model
+        assert req_body['description'] == 'testString'
+        assert req_body['subject'] == v2_policy_base_subject_model
+        assert req_body['resource'] == v2_policy_base_resource_model
+        assert req_body['pattern'] == 'testString'
+        assert req_body['rule'] == v2_policy_base_rule_model
+
+    def test_v2_update_policy_all_params_with_retries(self):
+        # Enable retries and run test_v2_update_policy_all_params.
+        _service.enable_retries()
+        self.test_v2_update_policy_all_params()
+
+        # Disable retries and run test_v2_update_policy_all_params.
+        _service.disable_retries()
+        self.test_v2_update_policy_all_params()
+
+    @responses.activate
+    def test_v2_update_policy_value_error(self):
+        """
+        test_v2_update_policy_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies/testString')
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        responses.add(responses.PUT,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Construct a dict representation of a PolicyRole model
+        policy_role_model = {}
+        policy_role_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseControlGrant model
+        v2_policy_base_control_grant_model = {}
+        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+
+        # Construct a dict representation of a V2PolicyBaseControl model
+        v2_policy_base_control_model = {}
+        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+
+        # Construct a dict representation of a V2PolicyAttribute model
+        v2_policy_attribute_model = {}
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseSubject model
+        v2_policy_base_subject_model = {}
+        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseResource model
+        v2_policy_base_resource_model = {}
+        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseRuleV2PolicyAttribute model
+        v2_policy_base_rule_model = {}
+        v2_policy_base_rule_model['key'] = 'testString'
+        v2_policy_base_rule_model['operator'] = 'testString'
+        v2_policy_base_rule_model['value'] = 'testString'
+
+        # Set up parameter values
+        policy_id = 'testString'
+        if_match = 'testString'
+        type = 'testString'
+        control = v2_policy_base_control_model
+        description = 'testString'
+        subject = v2_policy_base_subject_model
+        resource = v2_policy_base_resource_model
+        pattern = 'testString'
+        rule = v2_policy_base_rule_model
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "policy_id": policy_id,
+            "if_match": if_match,
+            "type": type,
+            "control": control,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.v2_update_policy(**req_copy)
+
+    def test_v2_update_policy_value_error_with_retries(self):
+        # Enable retries and run test_v2_update_policy_value_error.
+        _service.enable_retries()
+        self.test_v2_update_policy_value_error()
+
+        # Disable retries and run test_v2_update_policy_value_error.
+        _service.disable_retries()
+        self.test_v2_update_policy_value_error()
+
+class TestV2GetPolicy():
+    """
+    Test Class for v2_get_policy
+    """
+
+    @responses.activate
+    def test_v2_get_policy_all_params(self):
+        """
+        v2_get_policy()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies/testString')
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        policy_id = 'testString'
+
+        # Invoke method
+        response = _service.v2_get_policy(
+            policy_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_v2_get_policy_all_params_with_retries(self):
+        # Enable retries and run test_v2_get_policy_all_params.
+        _service.enable_retries()
+        self.test_v2_get_policy_all_params()
+
+        # Disable retries and run test_v2_get_policy_all_params.
+        _service.disable_retries()
+        self.test_v2_get_policy_all_params()
+
+    @responses.activate
+    def test_v2_get_policy_value_error(self):
+        """
+        test_v2_get_policy_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies/testString')
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        policy_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "policy_id": policy_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.v2_get_policy(**req_copy)
+
+    def test_v2_get_policy_value_error_with_retries(self):
+        # Enable retries and run test_v2_get_policy_value_error.
+        _service.enable_retries()
+        self.test_v2_get_policy_value_error()
+
+        # Disable retries and run test_v2_get_policy_value_error.
+        _service.disable_retries()
+        self.test_v2_get_policy_value_error()
+
+class TestV2DeletePolicy():
+    """
+    Test Class for v2_delete_policy
+    """
+
+    @responses.activate
+    def test_v2_delete_policy_all_params(self):
+        """
+        v2_delete_policy()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies/testString')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        policy_id = 'testString'
+
+        # Invoke method
+        response = _service.v2_delete_policy(
+            policy_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_v2_delete_policy_all_params_with_retries(self):
+        # Enable retries and run test_v2_delete_policy_all_params.
+        _service.enable_retries()
+        self.test_v2_delete_policy_all_params()
+
+        # Disable retries and run test_v2_delete_policy_all_params.
+        _service.disable_retries()
+        self.test_v2_delete_policy_all_params()
+
+    @responses.activate
+    def test_v2_delete_policy_value_error(self):
+        """
+        test_v2_delete_policy_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies/testString')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        policy_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "policy_id": policy_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.v2_delete_policy(**req_copy)
+
+    def test_v2_delete_policy_value_error_with_retries(self):
+        # Enable retries and run test_v2_delete_policy_value_error.
+        _service.enable_retries()
+        self.test_v2_delete_policy_value_error()
+
+        # Disable retries and run test_v2_delete_policy_value_error.
+        _service.disable_retries()
+        self.test_v2_delete_policy_value_error()
+
+# endregion
+##############################################################################
+# End of Service: V2Policies
 ##############################################################################
 
 
@@ -1377,7 +2182,150 @@ class TestDeleteRole:
 # Start of Model Tests
 ##############################################################################
 # region
-class TestModel_CustomRole:
+class TestModel_V2PolicyBaseControl():
+    """
+    Test Class for V2PolicyBaseControl
+    """
+
+    def test_v2_policy_base_control_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyBaseControl
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        policy_role_model = {} # PolicyRole
+        policy_role_model['role_id'] = 'testString'
+
+        v2_policy_base_control_grant_model = {} # V2PolicyBaseControlGrant
+        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+
+        # Construct a json representation of a V2PolicyBaseControl model
+        v2_policy_base_control_model_json = {}
+        v2_policy_base_control_model_json['grant'] = v2_policy_base_control_grant_model
+
+        # Construct a model instance of V2PolicyBaseControl by calling from_dict on the json representation
+        v2_policy_base_control_model = V2PolicyBaseControl.from_dict(v2_policy_base_control_model_json)
+        assert v2_policy_base_control_model != False
+
+        # Construct a model instance of V2PolicyBaseControl by calling from_dict on the json representation
+        v2_policy_base_control_model_dict = V2PolicyBaseControl.from_dict(v2_policy_base_control_model_json).__dict__
+        v2_policy_base_control_model2 = V2PolicyBaseControl(**v2_policy_base_control_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_base_control_model == v2_policy_base_control_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_base_control_model_json2 = v2_policy_base_control_model.to_dict()
+        assert v2_policy_base_control_model_json2 == v2_policy_base_control_model_json
+
+class TestModel_V2PolicyBaseControlGrant():
+    """
+    Test Class for V2PolicyBaseControlGrant
+    """
+
+    def test_v2_policy_base_control_grant_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyBaseControlGrant
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        policy_role_model = {} # PolicyRole
+        policy_role_model['role_id'] = 'testString'
+
+        # Construct a json representation of a V2PolicyBaseControlGrant model
+        v2_policy_base_control_grant_model_json = {}
+        v2_policy_base_control_grant_model_json['roles'] = [policy_role_model]
+
+        # Construct a model instance of V2PolicyBaseControlGrant by calling from_dict on the json representation
+        v2_policy_base_control_grant_model = V2PolicyBaseControlGrant.from_dict(v2_policy_base_control_grant_model_json)
+        assert v2_policy_base_control_grant_model != False
+
+        # Construct a model instance of V2PolicyBaseControlGrant by calling from_dict on the json representation
+        v2_policy_base_control_grant_model_dict = V2PolicyBaseControlGrant.from_dict(v2_policy_base_control_grant_model_json).__dict__
+        v2_policy_base_control_grant_model2 = V2PolicyBaseControlGrant(**v2_policy_base_control_grant_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_base_control_grant_model == v2_policy_base_control_grant_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_base_control_grant_model_json2 = v2_policy_base_control_grant_model.to_dict()
+        assert v2_policy_base_control_grant_model_json2 == v2_policy_base_control_grant_model_json
+
+class TestModel_V2PolicyBaseResource():
+    """
+    Test Class for V2PolicyBaseResource
+    """
+
+    def test_v2_policy_base_resource_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyBaseResource
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_attribute_model = {} # V2PolicyAttribute
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        # Construct a json representation of a V2PolicyBaseResource model
+        v2_policy_base_resource_model_json = {}
+        v2_policy_base_resource_model_json['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a model instance of V2PolicyBaseResource by calling from_dict on the json representation
+        v2_policy_base_resource_model = V2PolicyBaseResource.from_dict(v2_policy_base_resource_model_json)
+        assert v2_policy_base_resource_model != False
+
+        # Construct a model instance of V2PolicyBaseResource by calling from_dict on the json representation
+        v2_policy_base_resource_model_dict = V2PolicyBaseResource.from_dict(v2_policy_base_resource_model_json).__dict__
+        v2_policy_base_resource_model2 = V2PolicyBaseResource(**v2_policy_base_resource_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_base_resource_model == v2_policy_base_resource_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_base_resource_model_json2 = v2_policy_base_resource_model.to_dict()
+        assert v2_policy_base_resource_model_json2 == v2_policy_base_resource_model_json
+
+class TestModel_V2PolicyBaseSubject():
+    """
+    Test Class for V2PolicyBaseSubject
+    """
+
+    def test_v2_policy_base_subject_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyBaseSubject
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_attribute_model = {} # V2PolicyAttribute
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        # Construct a json representation of a V2PolicyBaseSubject model
+        v2_policy_base_subject_model_json = {}
+        v2_policy_base_subject_model_json['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a model instance of V2PolicyBaseSubject by calling from_dict on the json representation
+        v2_policy_base_subject_model = V2PolicyBaseSubject.from_dict(v2_policy_base_subject_model_json)
+        assert v2_policy_base_subject_model != False
+
+        # Construct a model instance of V2PolicyBaseSubject by calling from_dict on the json representation
+        v2_policy_base_subject_model_dict = V2PolicyBaseSubject.from_dict(v2_policy_base_subject_model_json).__dict__
+        v2_policy_base_subject_model2 = V2PolicyBaseSubject(**v2_policy_base_subject_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_base_subject_model == v2_policy_base_subject_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_base_subject_model_json2 = v2_policy_base_subject_model.to_dict()
+        assert v2_policy_base_subject_model_json2 == v2_policy_base_subject_model_json
+
+class TestModel_CustomRole():
     """
     Test Class for CustomRole
     """
@@ -1389,19 +2337,12 @@ class TestModel_CustomRole:
 
         # Construct a json representation of a CustomRole model
         custom_role_model_json = {}
-        custom_role_model_json['id'] = 'testString'
         custom_role_model_json['display_name'] = 'testString'
         custom_role_model_json['description'] = 'testString'
         custom_role_model_json['actions'] = ['testString']
-        custom_role_model_json['crn'] = 'testString'
         custom_role_model_json['name'] = 'Developer'
         custom_role_model_json['account_id'] = 'testString'
         custom_role_model_json['service_name'] = 'iam-groups'
-        custom_role_model_json['created_at'] = "2019-01-01T12:00:00Z"
-        custom_role_model_json['created_by_id'] = 'testString'
-        custom_role_model_json['last_modified_at'] = "2019-01-01T12:00:00Z"
-        custom_role_model_json['last_modified_by_id'] = 'testString'
-        custom_role_model_json['href'] = 'testString'
 
         # Construct a model instance of CustomRole by calling from_dict on the json representation
         custom_role_model = CustomRole.from_dict(custom_role_model_json)
@@ -1418,8 +2359,7 @@ class TestModel_CustomRole:
         custom_role_model_json2 = custom_role_model.to_dict()
         assert custom_role_model_json2 == custom_role_model_json
 
-
-class TestModel_Policy:
+class TestModel_Policy():
     """
     Test Class for Policy
     """
@@ -1431,45 +2371,37 @@ class TestModel_Policy:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        subject_attribute_model = {}  # SubjectAttribute
+        subject_attribute_model = {} # SubjectAttribute
         subject_attribute_model['name'] = 'testString'
         subject_attribute_model['value'] = 'testString'
 
-        policy_subject_model = {}  # PolicySubject
+        policy_subject_model = {} # PolicySubject
         policy_subject_model['attributes'] = [subject_attribute_model]
 
-        policy_role_model = {}  # PolicyRole
+        policy_role_model = {} # PolicyRole
         policy_role_model['role_id'] = 'testString'
-        policy_role_model['display_name'] = 'testString'
-        policy_role_model['description'] = 'testString'
 
-        resource_attribute_model = {}  # ResourceAttribute
+        resource_attribute_model = {} # ResourceAttribute
         resource_attribute_model['name'] = 'testString'
         resource_attribute_model['value'] = 'testString'
         resource_attribute_model['operator'] = 'testString'
 
-        resource_tag_model = {}  # ResourceTag
+        resource_tag_model = {} # ResourceTag
         resource_tag_model['name'] = 'testString'
         resource_tag_model['value'] = 'testString'
         resource_tag_model['operator'] = 'testString'
 
-        policy_resource_model = {}  # PolicyResource
+        policy_resource_model = {} # PolicyResource
         policy_resource_model['attributes'] = [resource_attribute_model]
         policy_resource_model['tags'] = [resource_tag_model]
 
         # Construct a json representation of a Policy model
         policy_model_json = {}
-        policy_model_json['id'] = 'testString'
         policy_model_json['type'] = 'testString'
         policy_model_json['description'] = 'testString'
         policy_model_json['subjects'] = [policy_subject_model]
         policy_model_json['roles'] = [policy_role_model]
         policy_model_json['resources'] = [policy_resource_model]
-        policy_model_json['href'] = 'testString'
-        policy_model_json['created_at'] = "2019-01-01T12:00:00Z"
-        policy_model_json['created_by_id'] = 'testString'
-        policy_model_json['last_modified_at'] = "2019-01-01T12:00:00Z"
-        policy_model_json['last_modified_by_id'] = 'testString'
         policy_model_json['state'] = 'active'
 
         # Construct a model instance of Policy by calling from_dict on the json representation
@@ -1487,8 +2419,7 @@ class TestModel_Policy:
         policy_model_json2 = policy_model.to_dict()
         assert policy_model_json2 == policy_model_json
 
-
-class TestModel_PolicyList:
+class TestModel_PolicyList():
     """
     Test Class for PolicyList
     """
@@ -1500,44 +2431,36 @@ class TestModel_PolicyList:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        subject_attribute_model = {}  # SubjectAttribute
+        subject_attribute_model = {} # SubjectAttribute
         subject_attribute_model['name'] = 'testString'
         subject_attribute_model['value'] = 'testString'
 
-        policy_subject_model = {}  # PolicySubject
+        policy_subject_model = {} # PolicySubject
         policy_subject_model['attributes'] = [subject_attribute_model]
 
-        policy_role_model = {}  # PolicyRole
+        policy_role_model = {} # PolicyRole
         policy_role_model['role_id'] = 'testString'
-        policy_role_model['display_name'] = 'testString'
-        policy_role_model['description'] = 'testString'
 
-        resource_attribute_model = {}  # ResourceAttribute
+        resource_attribute_model = {} # ResourceAttribute
         resource_attribute_model['name'] = 'testString'
         resource_attribute_model['value'] = 'testString'
         resource_attribute_model['operator'] = 'testString'
 
-        resource_tag_model = {}  # ResourceTag
+        resource_tag_model = {} # ResourceTag
         resource_tag_model['name'] = 'testString'
         resource_tag_model['value'] = 'testString'
         resource_tag_model['operator'] = 'testString'
 
-        policy_resource_model = {}  # PolicyResource
+        policy_resource_model = {} # PolicyResource
         policy_resource_model['attributes'] = [resource_attribute_model]
         policy_resource_model['tags'] = [resource_tag_model]
 
-        policy_model = {}  # Policy
-        policy_model['id'] = 'testString'
+        policy_model = {} # Policy
         policy_model['type'] = 'testString'
         policy_model['description'] = 'testString'
         policy_model['subjects'] = [policy_subject_model]
         policy_model['roles'] = [policy_role_model]
         policy_model['resources'] = [policy_resource_model]
-        policy_model['href'] = 'testString'
-        policy_model['created_at'] = "2019-01-01T12:00:00Z"
-        policy_model['created_by_id'] = 'testString'
-        policy_model['last_modified_at'] = "2019-01-01T12:00:00Z"
-        policy_model['last_modified_by_id'] = 'testString'
         policy_model['state'] = 'active'
 
         # Construct a json representation of a PolicyList model
@@ -1559,8 +2482,7 @@ class TestModel_PolicyList:
         policy_list_model_json2 = policy_list_model.to_dict()
         assert policy_list_model_json2 == policy_list_model_json
 
-
-class TestModel_PolicyResource:
+class TestModel_PolicyResource():
     """
     Test Class for PolicyResource
     """
@@ -1572,12 +2494,12 @@ class TestModel_PolicyResource:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        resource_attribute_model = {}  # ResourceAttribute
+        resource_attribute_model = {} # ResourceAttribute
         resource_attribute_model['name'] = 'testString'
         resource_attribute_model['value'] = 'testString'
         resource_attribute_model['operator'] = 'testString'
 
-        resource_tag_model = {}  # ResourceTag
+        resource_tag_model = {} # ResourceTag
         resource_tag_model['name'] = 'testString'
         resource_tag_model['value'] = 'testString'
         resource_tag_model['operator'] = 'testString'
@@ -1602,8 +2524,7 @@ class TestModel_PolicyResource:
         policy_resource_model_json2 = policy_resource_model.to_dict()
         assert policy_resource_model_json2 == policy_resource_model_json
 
-
-class TestModel_PolicyRole:
+class TestModel_PolicyRole():
     """
     Test Class for PolicyRole
     """
@@ -1616,8 +2537,6 @@ class TestModel_PolicyRole:
         # Construct a json representation of a PolicyRole model
         policy_role_model_json = {}
         policy_role_model_json['role_id'] = 'testString'
-        policy_role_model_json['display_name'] = 'testString'
-        policy_role_model_json['description'] = 'testString'
 
         # Construct a model instance of PolicyRole by calling from_dict on the json representation
         policy_role_model = PolicyRole.from_dict(policy_role_model_json)
@@ -1634,8 +2553,7 @@ class TestModel_PolicyRole:
         policy_role_model_json2 = policy_role_model.to_dict()
         assert policy_role_model_json2 == policy_role_model_json
 
-
-class TestModel_PolicySubject:
+class TestModel_PolicySubject():
     """
     Test Class for PolicySubject
     """
@@ -1647,7 +2565,7 @@ class TestModel_PolicySubject:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        subject_attribute_model = {}  # SubjectAttribute
+        subject_attribute_model = {} # SubjectAttribute
         subject_attribute_model['name'] = 'testString'
         subject_attribute_model['value'] = 'testString'
 
@@ -1670,8 +2588,7 @@ class TestModel_PolicySubject:
         policy_subject_model_json2 = policy_subject_model.to_dict()
         assert policy_subject_model_json2 == policy_subject_model_json
 
-
-class TestModel_ResourceAttribute:
+class TestModel_ResourceAttribute():
     """
     Test Class for ResourceAttribute
     """
@@ -1702,8 +2619,7 @@ class TestModel_ResourceAttribute:
         resource_attribute_model_json2 = resource_attribute_model.to_dict()
         assert resource_attribute_model_json2 == resource_attribute_model_json
 
-
-class TestModel_ResourceTag:
+class TestModel_ResourceTag():
     """
     Test Class for ResourceTag
     """
@@ -1734,8 +2650,7 @@ class TestModel_ResourceTag:
         resource_tag_model_json2 = resource_tag_model.to_dict()
         assert resource_tag_model_json2 == resource_tag_model_json
 
-
-class TestModel_Role:
+class TestModel_Role():
     """
     Test Class for Role
     """
@@ -1750,7 +2665,6 @@ class TestModel_Role:
         role_model_json['display_name'] = 'testString'
         role_model_json['description'] = 'testString'
         role_model_json['actions'] = ['testString']
-        role_model_json['crn'] = 'testString'
 
         # Construct a model instance of Role by calling from_dict on the json representation
         role_model = Role.from_dict(role_model_json)
@@ -1767,8 +2681,7 @@ class TestModel_Role:
         role_model_json2 = role_model.to_dict()
         assert role_model_json2 == role_model_json
 
-
-class TestModel_RoleList:
+class TestModel_RoleList():
     """
     Test Class for RoleList
     """
@@ -1780,26 +2693,18 @@ class TestModel_RoleList:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        custom_role_model = {}  # CustomRole
-        custom_role_model['id'] = 'testString'
+        custom_role_model = {} # CustomRole
         custom_role_model['display_name'] = 'testString'
         custom_role_model['description'] = 'testString'
         custom_role_model['actions'] = ['testString']
-        custom_role_model['crn'] = 'testString'
         custom_role_model['name'] = 'Developer'
         custom_role_model['account_id'] = 'testString'
         custom_role_model['service_name'] = 'iam-groups'
-        custom_role_model['created_at'] = "2019-01-01T12:00:00Z"
-        custom_role_model['created_by_id'] = 'testString'
-        custom_role_model['last_modified_at'] = "2019-01-01T12:00:00Z"
-        custom_role_model['last_modified_by_id'] = 'testString'
-        custom_role_model['href'] = 'testString'
 
-        role_model = {}  # Role
+        role_model = {} # Role
         role_model['display_name'] = 'testString'
         role_model['description'] = 'testString'
         role_model['actions'] = ['testString']
-        role_model['crn'] = 'testString'
 
         # Construct a json representation of a RoleList model
         role_list_model_json = {}
@@ -1822,8 +2727,7 @@ class TestModel_RoleList:
         role_list_model_json2 = role_list_model.to_dict()
         assert role_list_model_json2 == role_list_model_json
 
-
-class TestModel_SubjectAttribute:
+class TestModel_SubjectAttribute():
     """
     Test Class for SubjectAttribute
     """
@@ -1852,6 +2756,234 @@ class TestModel_SubjectAttribute:
         # Convert model instance back to dict and verify no loss of data
         subject_attribute_model_json2 = subject_attribute_model.to_dict()
         assert subject_attribute_model_json2 == subject_attribute_model_json
+
+class TestModel_V2Policy():
+    """
+    Test Class for V2Policy
+    """
+
+    def test_v2_policy_serialization(self):
+        """
+        Test serialization/deserialization for V2Policy
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_attribute_model = {} # V2PolicyAttribute
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        v2_policy_base_subject_model = {} # V2PolicyBaseSubject
+        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+
+        policy_role_model = {} # PolicyRole
+        policy_role_model['role_id'] = 'testString'
+
+        v2_policy_base_control_grant_model = {} # V2PolicyBaseControlGrant
+        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+
+        v2_policy_base_control_model = {} # V2PolicyBaseControl
+        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+
+        v2_policy_base_resource_model = {} # V2PolicyBaseResource
+        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+
+        v2_policy_base_rule_model = {} # V2PolicyBaseRuleV2PolicyAttribute
+        v2_policy_base_rule_model['key'] = 'testString'
+        v2_policy_base_rule_model['operator'] = 'testString'
+        v2_policy_base_rule_model['value'] = 'testString'
+
+        # Construct a json representation of a V2Policy model
+        v2_policy_model_json = {}
+        v2_policy_model_json['type'] = 'testString'
+        v2_policy_model_json['description'] = 'testString'
+        v2_policy_model_json['subject'] = v2_policy_base_subject_model
+        v2_policy_model_json['control'] = v2_policy_base_control_model
+        v2_policy_model_json['resource'] = v2_policy_base_resource_model
+        v2_policy_model_json['pattern'] = 'testString'
+        v2_policy_model_json['rule'] = v2_policy_base_rule_model
+        v2_policy_model_json['state'] = 'active'
+
+        # Construct a model instance of V2Policy by calling from_dict on the json representation
+        v2_policy_model = V2Policy.from_dict(v2_policy_model_json)
+        assert v2_policy_model != False
+
+        # Construct a model instance of V2Policy by calling from_dict on the json representation
+        v2_policy_model_dict = V2Policy.from_dict(v2_policy_model_json).__dict__
+        v2_policy_model2 = V2Policy(**v2_policy_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_model == v2_policy_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_model_json2 = v2_policy_model.to_dict()
+        assert v2_policy_model_json2 == v2_policy_model_json
+
+class TestModel_V2PolicyAttribute():
+    """
+    Test Class for V2PolicyAttribute
+    """
+
+    def test_v2_policy_attribute_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyAttribute
+        """
+
+        # Construct a json representation of a V2PolicyAttribute model
+        v2_policy_attribute_model_json = {}
+        v2_policy_attribute_model_json['key'] = 'testString'
+        v2_policy_attribute_model_json['operator'] = 'testString'
+        v2_policy_attribute_model_json['value'] = 'testString'
+
+        # Construct a model instance of V2PolicyAttribute by calling from_dict on the json representation
+        v2_policy_attribute_model = V2PolicyAttribute.from_dict(v2_policy_attribute_model_json)
+        assert v2_policy_attribute_model != False
+
+        # Construct a model instance of V2PolicyAttribute by calling from_dict on the json representation
+        v2_policy_attribute_model_dict = V2PolicyAttribute.from_dict(v2_policy_attribute_model_json).__dict__
+        v2_policy_attribute_model2 = V2PolicyAttribute(**v2_policy_attribute_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_attribute_model == v2_policy_attribute_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_attribute_model_json2 = v2_policy_attribute_model.to_dict()
+        assert v2_policy_attribute_model_json2 == v2_policy_attribute_model_json
+
+class TestModel_V2PolicyList():
+    """
+    Test Class for V2PolicyList
+    """
+
+    def test_v2_policy_list_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyList
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_attribute_model = {} # V2PolicyAttribute
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        v2_policy_base_subject_model = {} # V2PolicyBaseSubject
+        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+
+        policy_role_model = {} # PolicyRole
+        policy_role_model['role_id'] = 'testString'
+
+        v2_policy_base_control_grant_model = {} # V2PolicyBaseControlGrant
+        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+
+        v2_policy_base_control_model = {} # V2PolicyBaseControl
+        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+
+        v2_policy_base_resource_model = {} # V2PolicyBaseResource
+        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+
+        v2_policy_base_rule_model = {} # V2PolicyBaseRuleV2PolicyAttribute
+        v2_policy_base_rule_model['key'] = 'testString'
+        v2_policy_base_rule_model['operator'] = 'testString'
+        v2_policy_base_rule_model['value'] = 'testString'
+
+        v2_policy_model = {} # V2Policy
+        v2_policy_model['type'] = 'testString'
+        v2_policy_model['description'] = 'testString'
+        v2_policy_model['subject'] = v2_policy_base_subject_model
+        v2_policy_model['control'] = v2_policy_base_control_model
+        v2_policy_model['resource'] = v2_policy_base_resource_model
+        v2_policy_model['pattern'] = 'testString'
+        v2_policy_model['rule'] = v2_policy_base_rule_model
+        v2_policy_model['state'] = 'active'
+
+        # Construct a json representation of a V2PolicyList model
+        v2_policy_list_model_json = {}
+        v2_policy_list_model_json['policies'] = [v2_policy_model]
+
+        # Construct a model instance of V2PolicyList by calling from_dict on the json representation
+        v2_policy_list_model = V2PolicyList.from_dict(v2_policy_list_model_json)
+        assert v2_policy_list_model != False
+
+        # Construct a model instance of V2PolicyList by calling from_dict on the json representation
+        v2_policy_list_model_dict = V2PolicyList.from_dict(v2_policy_list_model_json).__dict__
+        v2_policy_list_model2 = V2PolicyList(**v2_policy_list_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_list_model == v2_policy_list_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_list_model_json2 = v2_policy_list_model.to_dict()
+        assert v2_policy_list_model_json2 == v2_policy_list_model_json
+
+class TestModel_V2PolicyBaseRuleV2PolicyAttribute():
+    """
+    Test Class for V2PolicyBaseRuleV2PolicyAttribute
+    """
+
+    def test_v2_policy_base_rule_v2_policy_attribute_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyBaseRuleV2PolicyAttribute
+        """
+
+        # Construct a json representation of a V2PolicyBaseRuleV2PolicyAttribute model
+        v2_policy_base_rule_v2_policy_attribute_model_json = {}
+        v2_policy_base_rule_v2_policy_attribute_model_json['key'] = 'testString'
+        v2_policy_base_rule_v2_policy_attribute_model_json['operator'] = 'testString'
+        v2_policy_base_rule_v2_policy_attribute_model_json['value'] = 'testString'
+
+        # Construct a model instance of V2PolicyBaseRuleV2PolicyAttribute by calling from_dict on the json representation
+        v2_policy_base_rule_v2_policy_attribute_model = V2PolicyBaseRuleV2PolicyAttribute.from_dict(v2_policy_base_rule_v2_policy_attribute_model_json)
+        assert v2_policy_base_rule_v2_policy_attribute_model != False
+
+        # Construct a model instance of V2PolicyBaseRuleV2PolicyAttribute by calling from_dict on the json representation
+        v2_policy_base_rule_v2_policy_attribute_model_dict = V2PolicyBaseRuleV2PolicyAttribute.from_dict(v2_policy_base_rule_v2_policy_attribute_model_json).__dict__
+        v2_policy_base_rule_v2_policy_attribute_model2 = V2PolicyBaseRuleV2PolicyAttribute(**v2_policy_base_rule_v2_policy_attribute_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_base_rule_v2_policy_attribute_model == v2_policy_base_rule_v2_policy_attribute_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_base_rule_v2_policy_attribute_model_json2 = v2_policy_base_rule_v2_policy_attribute_model.to_dict()
+        assert v2_policy_base_rule_v2_policy_attribute_model_json2 == v2_policy_base_rule_v2_policy_attribute_model_json
+
+class TestModel_V2PolicyBaseRuleV2RuleWithConditions():
+    """
+    Test Class for V2PolicyBaseRuleV2RuleWithConditions
+    """
+
+    def test_v2_policy_base_rule_v2_rule_with_conditions_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyBaseRuleV2RuleWithConditions
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_attribute_model = {} # V2PolicyAttribute
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        # Construct a json representation of a V2PolicyBaseRuleV2RuleWithConditions model
+        v2_policy_base_rule_v2_rule_with_conditions_model_json = {}
+        v2_policy_base_rule_v2_rule_with_conditions_model_json['operator'] = 'and'
+        v2_policy_base_rule_v2_rule_with_conditions_model_json['conditions'] = [v2_policy_attribute_model]
+
+        # Construct a model instance of V2PolicyBaseRuleV2RuleWithConditions by calling from_dict on the json representation
+        v2_policy_base_rule_v2_rule_with_conditions_model = V2PolicyBaseRuleV2RuleWithConditions.from_dict(v2_policy_base_rule_v2_rule_with_conditions_model_json)
+        assert v2_policy_base_rule_v2_rule_with_conditions_model != False
+
+        # Construct a model instance of V2PolicyBaseRuleV2RuleWithConditions by calling from_dict on the json representation
+        v2_policy_base_rule_v2_rule_with_conditions_model_dict = V2PolicyBaseRuleV2RuleWithConditions.from_dict(v2_policy_base_rule_v2_rule_with_conditions_model_json).__dict__
+        v2_policy_base_rule_v2_rule_with_conditions_model2 = V2PolicyBaseRuleV2RuleWithConditions(**v2_policy_base_rule_v2_rule_with_conditions_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_base_rule_v2_rule_with_conditions_model == v2_policy_base_rule_v2_rule_with_conditions_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_base_rule_v2_rule_with_conditions_model_json2 = v2_policy_base_rule_v2_rule_with_conditions_model.to_dict()
+        assert v2_policy_base_rule_v2_rule_with_conditions_model_json2 == v2_policy_base_rule_v2_rule_with_conditions_model_json
 
 
 # endregion

--- a/test/unit/test_iam_policy_management_v1.py
+++ b/test/unit/test_iam_policy_management_v1.py
@@ -31,9 +31,7 @@ import urllib
 from ibm_platform_services.iam_policy_management_v1 import *
 
 
-_service = IamPolicyManagementV1(
-    authenticator=NoAuthAuthenticator()
-)
+_service = IamPolicyManagementV1(authenticator=NoAuthAuthenticator())
 
 _base_url = 'https://iam.cloud.ibm.com'
 _service.set_service_url(_base_url)
@@ -70,7 +68,8 @@ def preprocess_url(operation_path: str):
 ##############################################################################
 # region
 
-class TestNewInstance():
+
+class TestNewInstance:
     """
     Test Class for new_instance
     """
@@ -97,7 +96,8 @@ class TestNewInstance():
                 service_name='TEST_SERVICE_NOT_FOUND',
             )
 
-class TestListPolicies():
+
+class TestListPolicies:
     """
     Test Class for list_policies
     """
@@ -110,11 +110,7 @@ class TestListPolicies():
         # Set up mock
         url = preprocess_url('/v1/policies')
         mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -142,14 +138,14 @@ class TestListPolicies():
             sort=sort,
             format=format,
             state=state,
-            headers={}
+            headers={},
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'account_id={}'.format(account_id) in query_string
         assert 'iam_id={}'.format(iam_id) in query_string
@@ -179,26 +175,19 @@ class TestListPolicies():
         # Set up mock
         url = preprocess_url('/v1/policies')
         mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
 
         # Invoke method
-        response = _service.list_policies(
-            account_id,
-            headers={}
-        )
+        response = _service.list_policies(account_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'account_id={}'.format(account_id) in query_string
 
@@ -219,11 +208,7 @@ class TestListPolicies():
         # Set up mock
         url = preprocess_url('/v1/policies')
         mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -233,7 +218,7 @@ class TestListPolicies():
             "account_id": account_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.list_policies(**req_copy)
 
@@ -246,7 +231,8 @@ class TestListPolicies():
         _service.disable_retries()
         self.test_list_policies_value_error()
 
-class TestCreatePolicy():
+
+class TestCreatePolicy:
     """
     Test Class for create_policy
     """
@@ -259,11 +245,7 @@ class TestCreatePolicy():
         # Set up mock
         url = preprocess_url('/v1/policies')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=201)
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Construct a dict representation of a SubjectAttribute model
         subject_attribute_model = {}
@@ -305,13 +287,7 @@ class TestCreatePolicy():
 
         # Invoke method
         response = _service.create_policy(
-            type,
-            subjects,
-            roles,
-            resources,
-            description=description,
-            accept_language=accept_language,
-            headers={}
+            type, subjects, roles, resources, description=description, accept_language=accept_language, headers={}
         )
 
         # Check for correct operation
@@ -342,11 +318,7 @@ class TestCreatePolicy():
         # Set up mock
         url = preprocess_url('/v1/policies')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=201)
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Construct a dict representation of a SubjectAttribute model
         subject_attribute_model = {}
@@ -386,14 +358,7 @@ class TestCreatePolicy():
         description = 'testString'
 
         # Invoke method
-        response = _service.create_policy(
-            type,
-            subjects,
-            roles,
-            resources,
-            description=description,
-            headers={}
-        )
+        response = _service.create_policy(type, subjects, roles, resources, description=description, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -423,11 +388,7 @@ class TestCreatePolicy():
         # Set up mock
         url = preprocess_url('/v1/policies')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=201)
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Construct a dict representation of a SubjectAttribute model
         subject_attribute_model = {}
@@ -474,7 +435,7 @@ class TestCreatePolicy():
             "resources": resources,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.create_policy(**req_copy)
 
@@ -487,7 +448,8 @@ class TestCreatePolicy():
         _service.disable_retries()
         self.test_create_policy_value_error()
 
-class TestUpdatePolicy():
+
+class TestUpdatePolicy:
     """
     Test Class for update_policy
     """
@@ -500,11 +462,7 @@ class TestUpdatePolicy():
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.PUT,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
 
         # Construct a dict representation of a SubjectAttribute model
         subject_attribute_model = {}
@@ -547,14 +505,7 @@ class TestUpdatePolicy():
 
         # Invoke method
         response = _service.update_policy(
-            policy_id,
-            if_match,
-            type,
-            subjects,
-            roles,
-            resources,
-            description=description,
-            headers={}
+            policy_id, if_match, type, subjects, roles, resources, description=description, headers={}
         )
 
         # Check for correct operation
@@ -585,11 +536,7 @@ class TestUpdatePolicy():
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.PUT,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
 
         # Construct a dict representation of a SubjectAttribute model
         subject_attribute_model = {}
@@ -640,7 +587,7 @@ class TestUpdatePolicy():
             "resources": resources,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.update_policy(**req_copy)
 
@@ -653,7 +600,8 @@ class TestUpdatePolicy():
         _service.disable_retries()
         self.test_update_policy_value_error()
 
-class TestGetPolicy():
+
+class TestGetPolicy:
     """
     Test Class for get_policy
     """
@@ -666,20 +614,13 @@ class TestGetPolicy():
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         policy_id = 'testString'
 
         # Invoke method
-        response = _service.get_policy(
-            policy_id,
-            headers={}
-        )
+        response = _service.get_policy(policy_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -702,11 +643,7 @@ class TestGetPolicy():
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         policy_id = 'testString'
@@ -716,7 +653,7 @@ class TestGetPolicy():
             "policy_id": policy_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_policy(**req_copy)
 
@@ -729,7 +666,8 @@ class TestGetPolicy():
         _service.disable_retries()
         self.test_get_policy_value_error()
 
-class TestDeletePolicy():
+
+class TestDeletePolicy:
     """
     Test Class for delete_policy
     """
@@ -741,18 +679,13 @@ class TestDeletePolicy():
         """
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         policy_id = 'testString'
 
         # Invoke method
-        response = _service.delete_policy(
-            policy_id,
-            headers={}
-        )
+        response = _service.delete_policy(policy_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -774,9 +707,7 @@ class TestDeletePolicy():
         """
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         policy_id = 'testString'
@@ -786,7 +717,7 @@ class TestDeletePolicy():
             "policy_id": policy_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.delete_policy(**req_copy)
 
@@ -799,7 +730,8 @@ class TestDeletePolicy():
         _service.disable_retries()
         self.test_delete_policy_value_error()
 
-class TestPatchPolicy():
+
+class TestPatchPolicy:
     """
     Test Class for patch_policy
     """
@@ -812,11 +744,7 @@ class TestPatchPolicy():
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.PATCH,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.PATCH, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         policy_id = 'testString'
@@ -824,12 +752,7 @@ class TestPatchPolicy():
         state = 'active'
 
         # Invoke method
-        response = _service.patch_policy(
-            policy_id,
-            if_match,
-            state=state,
-            headers={}
-        )
+        response = _service.patch_policy(policy_id, if_match, state=state, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -855,11 +778,7 @@ class TestPatchPolicy():
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.PATCH,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.PATCH, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         policy_id = 'testString'
@@ -872,7 +791,7 @@ class TestPatchPolicy():
             "if_match": if_match,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.patch_policy(**req_copy)
 
@@ -885,6 +804,7 @@ class TestPatchPolicy():
         _service.disable_retries()
         self.test_patch_policy_value_error()
 
+
 # endregion
 ##############################################################################
 # End of Service: Policies
@@ -895,7 +815,8 @@ class TestPatchPolicy():
 ##############################################################################
 # region
 
-class TestNewInstance():
+
+class TestNewInstance:
     """
     Test Class for new_instance
     """
@@ -922,7 +843,8 @@ class TestNewInstance():
                 service_name='TEST_SERVICE_NOT_FOUND',
             )
 
-class TestListRoles():
+
+class TestListRoles:
     """
     Test Class for list_roles
     """
@@ -935,11 +857,7 @@ class TestListRoles():
         # Set up mock
         url = preprocess_url('/v2/roles')
         mock_response = '{"custom_roles": [{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}], "service_roles": [{"display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn"}], "system_roles": [{"display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         accept_language = 'default'
@@ -955,14 +873,14 @@ class TestListRoles():
             service_name=service_name,
             source_service_name=source_service_name,
             policy_type=policy_type,
-            headers={}
+            headers={},
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'account_id={}'.format(account_id) in query_string
         assert 'service_name={}'.format(service_name) in query_string
@@ -986,15 +904,10 @@ class TestListRoles():
         # Set up mock
         url = preprocess_url('/v2/roles')
         mock_response = '{"custom_roles": [{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}], "service_roles": [{"display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn"}], "system_roles": [{"display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Invoke method
         response = _service.list_roles()
-
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1009,7 +922,8 @@ class TestListRoles():
         _service.disable_retries()
         self.test_list_roles_required_params()
 
-class TestCreateRole():
+
+class TestCreateRole:
     """
     Test Class for create_role
     """
@@ -1022,11 +936,7 @@ class TestCreateRole():
         # Set up mock
         url = preprocess_url('/v2/roles')
         mock_response = '{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=201)
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Set up parameter values
         display_name = 'testString'
@@ -1046,7 +956,7 @@ class TestCreateRole():
             service_name,
             description=description,
             accept_language=accept_language,
-            headers={}
+            headers={},
         )
 
         # Check for correct operation
@@ -1078,11 +988,7 @@ class TestCreateRole():
         # Set up mock
         url = preprocess_url('/v2/roles')
         mock_response = '{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=201)
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Set up parameter values
         display_name = 'testString'
@@ -1094,13 +1000,7 @@ class TestCreateRole():
 
         # Invoke method
         response = _service.create_role(
-            display_name,
-            actions,
-            name,
-            account_id,
-            service_name,
-            description=description,
-            headers={}
+            display_name, actions, name, account_id, service_name, description=description, headers={}
         )
 
         # Check for correct operation
@@ -1132,11 +1032,7 @@ class TestCreateRole():
         # Set up mock
         url = preprocess_url('/v2/roles')
         mock_response = '{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=201)
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Set up parameter values
         display_name = 'testString'
@@ -1155,7 +1051,7 @@ class TestCreateRole():
             "service_name": service_name,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.create_role(**req_copy)
 
@@ -1168,7 +1064,8 @@ class TestCreateRole():
         _service.disable_retries()
         self.test_create_role_value_error()
 
-class TestUpdateRole():
+
+class TestUpdateRole:
     """
     Test Class for update_role
     """
@@ -1181,11 +1078,7 @@ class TestUpdateRole():
         # Set up mock
         url = preprocess_url('/v2/roles/testString')
         mock_response = '{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}'
-        responses.add(responses.PUT,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         role_id = 'testString'
@@ -1196,12 +1089,7 @@ class TestUpdateRole():
 
         # Invoke method
         response = _service.update_role(
-            role_id,
-            if_match,
-            display_name=display_name,
-            description=description,
-            actions=actions,
-            headers={}
+            role_id, if_match, display_name=display_name, description=description, actions=actions, headers={}
         )
 
         # Check for correct operation
@@ -1230,11 +1118,7 @@ class TestUpdateRole():
         # Set up mock
         url = preprocess_url('/v2/roles/testString')
         mock_response = '{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}'
-        responses.add(responses.PUT,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         role_id = 'testString'
@@ -1249,7 +1133,7 @@ class TestUpdateRole():
             "if_match": if_match,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.update_role(**req_copy)
 
@@ -1262,7 +1146,8 @@ class TestUpdateRole():
         _service.disable_retries()
         self.test_update_role_value_error()
 
-class TestGetRole():
+
+class TestGetRole:
     """
     Test Class for get_role
     """
@@ -1275,20 +1160,13 @@ class TestGetRole():
         # Set up mock
         url = preprocess_url('/v2/roles/testString')
         mock_response = '{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         role_id = 'testString'
 
         # Invoke method
-        response = _service.get_role(
-            role_id,
-            headers={}
-        )
+        response = _service.get_role(role_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1311,11 +1189,7 @@ class TestGetRole():
         # Set up mock
         url = preprocess_url('/v2/roles/testString')
         mock_response = '{"id": "id", "display_name": "display_name", "description": "description", "actions": ["actions"], "crn": "crn", "name": "Developer", "account_id": "account_id", "service_name": "iam-groups", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "href": "href"}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         role_id = 'testString'
@@ -1325,7 +1199,7 @@ class TestGetRole():
             "role_id": role_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_role(**req_copy)
 
@@ -1338,7 +1212,8 @@ class TestGetRole():
         _service.disable_retries()
         self.test_get_role_value_error()
 
-class TestDeleteRole():
+
+class TestDeleteRole:
     """
     Test Class for delete_role
     """
@@ -1350,18 +1225,13 @@ class TestDeleteRole():
         """
         # Set up mock
         url = preprocess_url('/v2/roles/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         role_id = 'testString'
 
         # Invoke method
-        response = _service.delete_role(
-            role_id,
-            headers={}
-        )
+        response = _service.delete_role(role_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1383,9 +1253,7 @@ class TestDeleteRole():
         """
         # Set up mock
         url = preprocess_url('/v2/roles/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         role_id = 'testString'
@@ -1395,7 +1263,7 @@ class TestDeleteRole():
             "role_id": role_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.delete_role(**req_copy)
 
@@ -1408,6 +1276,7 @@ class TestDeleteRole():
         _service.disable_retries()
         self.test_delete_role_value_error()
 
+
 # endregion
 ##############################################################################
 # End of Service: Roles
@@ -1418,7 +1287,8 @@ class TestDeleteRole():
 ##############################################################################
 # region
 
-class TestNewInstance():
+
+class TestNewInstance:
     """
     Test Class for new_instance
     """
@@ -1445,7 +1315,8 @@ class TestNewInstance():
                 service_name='TEST_SERVICE_NOT_FOUND',
             )
 
-class TestV2ListPolicies():
+
+class TestV2ListPolicies:
     """
     Test Class for v2_list_policies
     """
@@ -1458,11 +1329,7 @@ class TestV2ListPolicies():
         # Set up mock
         url = preprocess_url('/v2/policies')
         mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -1488,14 +1355,14 @@ class TestV2ListPolicies():
             service_group_id=service_group_id,
             format=format,
             state=state,
-            headers={}
+            headers={},
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'account_id={}'.format(account_id) in query_string
         assert 'iam_id={}'.format(iam_id) in query_string
@@ -1524,26 +1391,19 @@ class TestV2ListPolicies():
         # Set up mock
         url = preprocess_url('/v2/policies')
         mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
 
         # Invoke method
-        response = _service.v2_list_policies(
-            account_id,
-            headers={}
-        )
+        response = _service.v2_list_policies(account_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'account_id={}'.format(account_id) in query_string
 
@@ -1564,11 +1424,7 @@ class TestV2ListPolicies():
         # Set up mock
         url = preprocess_url('/v2/policies')
         mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -1578,7 +1434,7 @@ class TestV2ListPolicies():
             "account_id": account_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.v2_list_policies(**req_copy)
 
@@ -1591,7 +1447,8 @@ class TestV2ListPolicies():
         _service.disable_retries()
         self.test_v2_list_policies_value_error()
 
-class TestV2CreatePolicy():
+
+class TestV2CreatePolicy:
     """
     Test Class for v2_create_policy
     """
@@ -1604,11 +1461,7 @@ class TestV2CreatePolicy():
         # Set up mock
         url = preprocess_url('/v2/policies')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=201)
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Construct a dict representation of a PolicyRole model
         policy_role_model = {}
@@ -1662,7 +1515,7 @@ class TestV2CreatePolicy():
             pattern=pattern,
             rule=rule,
             accept_language=accept_language,
-            headers={}
+            headers={},
         )
 
         # Check for correct operation
@@ -1695,11 +1548,7 @@ class TestV2CreatePolicy():
         # Set up mock
         url = preprocess_url('/v2/policies')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=201)
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Construct a dict representation of a PolicyRole model
         policy_role_model = {}
@@ -1751,7 +1600,7 @@ class TestV2CreatePolicy():
             resource=resource,
             pattern=pattern,
             rule=rule,
-            headers={}
+            headers={},
         )
 
         # Check for correct operation
@@ -1784,11 +1633,7 @@ class TestV2CreatePolicy():
         # Set up mock
         url = preprocess_url('/v2/policies')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=201)
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Construct a dict representation of a PolicyRole model
         policy_role_model = {}
@@ -1837,7 +1682,7 @@ class TestV2CreatePolicy():
             "control": control,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.v2_create_policy(**req_copy)
 
@@ -1850,7 +1695,8 @@ class TestV2CreatePolicy():
         _service.disable_retries()
         self.test_v2_create_policy_value_error()
 
-class TestV2UpdatePolicy():
+
+class TestV2UpdatePolicy:
     """
     Test Class for v2_update_policy
     """
@@ -1863,11 +1709,7 @@ class TestV2UpdatePolicy():
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.PUT,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
 
         # Construct a dict representation of a PolicyRole model
         policy_role_model = {}
@@ -1923,7 +1765,7 @@ class TestV2UpdatePolicy():
             resource=resource,
             pattern=pattern,
             rule=rule,
-            headers={}
+            headers={},
         )
 
         # Check for correct operation
@@ -1956,11 +1798,7 @@ class TestV2UpdatePolicy():
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.PUT,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
 
         # Construct a dict representation of a PolicyRole model
         policy_role_model = {}
@@ -2013,7 +1851,7 @@ class TestV2UpdatePolicy():
             "control": control,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.v2_update_policy(**req_copy)
 
@@ -2026,7 +1864,8 @@ class TestV2UpdatePolicy():
         _service.disable_retries()
         self.test_v2_update_policy_value_error()
 
-class TestV2GetPolicy():
+
+class TestV2GetPolicy:
     """
     Test Class for v2_get_policy
     """
@@ -2039,20 +1878,13 @@ class TestV2GetPolicy():
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         policy_id = 'testString'
 
         # Invoke method
-        response = _service.v2_get_policy(
-            policy_id,
-            headers={}
-        )
+        response = _service.v2_get_policy(policy_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -2075,11 +1907,7 @@ class TestV2GetPolicy():
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
         mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         policy_id = 'testString'
@@ -2089,7 +1917,7 @@ class TestV2GetPolicy():
             "policy_id": policy_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.v2_get_policy(**req_copy)
 
@@ -2102,7 +1930,8 @@ class TestV2GetPolicy():
         _service.disable_retries()
         self.test_v2_get_policy_value_error()
 
-class TestV2DeletePolicy():
+
+class TestV2DeletePolicy:
     """
     Test Class for v2_delete_policy
     """
@@ -2114,18 +1943,13 @@ class TestV2DeletePolicy():
         """
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         policy_id = 'testString'
 
         # Invoke method
-        response = _service.v2_delete_policy(
-            policy_id,
-            headers={}
-        )
+        response = _service.v2_delete_policy(policy_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -2147,9 +1971,7 @@ class TestV2DeletePolicy():
         """
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         policy_id = 'testString'
@@ -2159,7 +1981,7 @@ class TestV2DeletePolicy():
             "policy_id": policy_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.v2_delete_policy(**req_copy)
 
@@ -2172,6 +1994,7 @@ class TestV2DeletePolicy():
         _service.disable_retries()
         self.test_v2_delete_policy_value_error()
 
+
 # endregion
 ##############################################################################
 # End of Service: V2Policies
@@ -2182,7 +2005,7 @@ class TestV2DeletePolicy():
 # Start of Model Tests
 ##############################################################################
 # region
-class TestModel_V2PolicyBaseControl():
+class TestModel_V2PolicyBaseControl:
     """
     Test Class for V2PolicyBaseControl
     """
@@ -2194,10 +2017,10 @@ class TestModel_V2PolicyBaseControl():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        policy_role_model = {} # PolicyRole
+        policy_role_model = {}  # PolicyRole
         policy_role_model['role_id'] = 'testString'
 
-        v2_policy_base_control_grant_model = {} # V2PolicyBaseControlGrant
+        v2_policy_base_control_grant_model = {}  # V2PolicyBaseControlGrant
         v2_policy_base_control_grant_model['roles'] = [policy_role_model]
 
         # Construct a json representation of a V2PolicyBaseControl model
@@ -2219,7 +2042,8 @@ class TestModel_V2PolicyBaseControl():
         v2_policy_base_control_model_json2 = v2_policy_base_control_model.to_dict()
         assert v2_policy_base_control_model_json2 == v2_policy_base_control_model_json
 
-class TestModel_V2PolicyBaseControlGrant():
+
+class TestModel_V2PolicyBaseControlGrant:
     """
     Test Class for V2PolicyBaseControlGrant
     """
@@ -2231,7 +2055,7 @@ class TestModel_V2PolicyBaseControlGrant():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        policy_role_model = {} # PolicyRole
+        policy_role_model = {}  # PolicyRole
         policy_role_model['role_id'] = 'testString'
 
         # Construct a json representation of a V2PolicyBaseControlGrant model
@@ -2243,7 +2067,9 @@ class TestModel_V2PolicyBaseControlGrant():
         assert v2_policy_base_control_grant_model != False
 
         # Construct a model instance of V2PolicyBaseControlGrant by calling from_dict on the json representation
-        v2_policy_base_control_grant_model_dict = V2PolicyBaseControlGrant.from_dict(v2_policy_base_control_grant_model_json).__dict__
+        v2_policy_base_control_grant_model_dict = V2PolicyBaseControlGrant.from_dict(
+            v2_policy_base_control_grant_model_json
+        ).__dict__
         v2_policy_base_control_grant_model2 = V2PolicyBaseControlGrant(**v2_policy_base_control_grant_model_dict)
 
         # Verify the model instances are equivalent
@@ -2253,7 +2079,8 @@ class TestModel_V2PolicyBaseControlGrant():
         v2_policy_base_control_grant_model_json2 = v2_policy_base_control_grant_model.to_dict()
         assert v2_policy_base_control_grant_model_json2 == v2_policy_base_control_grant_model_json
 
-class TestModel_V2PolicyBaseResource():
+
+class TestModel_V2PolicyBaseResource:
     """
     Test Class for V2PolicyBaseResource
     """
@@ -2265,7 +2092,7 @@ class TestModel_V2PolicyBaseResource():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        v2_policy_attribute_model = {} # V2PolicyAttribute
+        v2_policy_attribute_model = {}  # V2PolicyAttribute
         v2_policy_attribute_model['key'] = 'testString'
         v2_policy_attribute_model['operator'] = 'testString'
         v2_policy_attribute_model['value'] = 'testString'
@@ -2289,7 +2116,8 @@ class TestModel_V2PolicyBaseResource():
         v2_policy_base_resource_model_json2 = v2_policy_base_resource_model.to_dict()
         assert v2_policy_base_resource_model_json2 == v2_policy_base_resource_model_json
 
-class TestModel_V2PolicyBaseSubject():
+
+class TestModel_V2PolicyBaseSubject:
     """
     Test Class for V2PolicyBaseSubject
     """
@@ -2301,7 +2129,7 @@ class TestModel_V2PolicyBaseSubject():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        v2_policy_attribute_model = {} # V2PolicyAttribute
+        v2_policy_attribute_model = {}  # V2PolicyAttribute
         v2_policy_attribute_model['key'] = 'testString'
         v2_policy_attribute_model['operator'] = 'testString'
         v2_policy_attribute_model['value'] = 'testString'
@@ -2325,7 +2153,8 @@ class TestModel_V2PolicyBaseSubject():
         v2_policy_base_subject_model_json2 = v2_policy_base_subject_model.to_dict()
         assert v2_policy_base_subject_model_json2 == v2_policy_base_subject_model_json
 
-class TestModel_CustomRole():
+
+class TestModel_CustomRole:
     """
     Test Class for CustomRole
     """
@@ -2359,7 +2188,8 @@ class TestModel_CustomRole():
         custom_role_model_json2 = custom_role_model.to_dict()
         assert custom_role_model_json2 == custom_role_model_json
 
-class TestModel_Policy():
+
+class TestModel_Policy:
     """
     Test Class for Policy
     """
@@ -2371,27 +2201,27 @@ class TestModel_Policy():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        subject_attribute_model = {} # SubjectAttribute
+        subject_attribute_model = {}  # SubjectAttribute
         subject_attribute_model['name'] = 'testString'
         subject_attribute_model['value'] = 'testString'
 
-        policy_subject_model = {} # PolicySubject
+        policy_subject_model = {}  # PolicySubject
         policy_subject_model['attributes'] = [subject_attribute_model]
 
-        policy_role_model = {} # PolicyRole
+        policy_role_model = {}  # PolicyRole
         policy_role_model['role_id'] = 'testString'
 
-        resource_attribute_model = {} # ResourceAttribute
+        resource_attribute_model = {}  # ResourceAttribute
         resource_attribute_model['name'] = 'testString'
         resource_attribute_model['value'] = 'testString'
         resource_attribute_model['operator'] = 'testString'
 
-        resource_tag_model = {} # ResourceTag
+        resource_tag_model = {}  # ResourceTag
         resource_tag_model['name'] = 'testString'
         resource_tag_model['value'] = 'testString'
         resource_tag_model['operator'] = 'testString'
 
-        policy_resource_model = {} # PolicyResource
+        policy_resource_model = {}  # PolicyResource
         policy_resource_model['attributes'] = [resource_attribute_model]
         policy_resource_model['tags'] = [resource_tag_model]
 
@@ -2419,7 +2249,8 @@ class TestModel_Policy():
         policy_model_json2 = policy_model.to_dict()
         assert policy_model_json2 == policy_model_json
 
-class TestModel_PolicyList():
+
+class TestModel_PolicyList:
     """
     Test Class for PolicyList
     """
@@ -2431,31 +2262,31 @@ class TestModel_PolicyList():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        subject_attribute_model = {} # SubjectAttribute
+        subject_attribute_model = {}  # SubjectAttribute
         subject_attribute_model['name'] = 'testString'
         subject_attribute_model['value'] = 'testString'
 
-        policy_subject_model = {} # PolicySubject
+        policy_subject_model = {}  # PolicySubject
         policy_subject_model['attributes'] = [subject_attribute_model]
 
-        policy_role_model = {} # PolicyRole
+        policy_role_model = {}  # PolicyRole
         policy_role_model['role_id'] = 'testString'
 
-        resource_attribute_model = {} # ResourceAttribute
+        resource_attribute_model = {}  # ResourceAttribute
         resource_attribute_model['name'] = 'testString'
         resource_attribute_model['value'] = 'testString'
         resource_attribute_model['operator'] = 'testString'
 
-        resource_tag_model = {} # ResourceTag
+        resource_tag_model = {}  # ResourceTag
         resource_tag_model['name'] = 'testString'
         resource_tag_model['value'] = 'testString'
         resource_tag_model['operator'] = 'testString'
 
-        policy_resource_model = {} # PolicyResource
+        policy_resource_model = {}  # PolicyResource
         policy_resource_model['attributes'] = [resource_attribute_model]
         policy_resource_model['tags'] = [resource_tag_model]
 
-        policy_model = {} # Policy
+        policy_model = {}  # Policy
         policy_model['type'] = 'testString'
         policy_model['description'] = 'testString'
         policy_model['subjects'] = [policy_subject_model]
@@ -2482,7 +2313,8 @@ class TestModel_PolicyList():
         policy_list_model_json2 = policy_list_model.to_dict()
         assert policy_list_model_json2 == policy_list_model_json
 
-class TestModel_PolicyResource():
+
+class TestModel_PolicyResource:
     """
     Test Class for PolicyResource
     """
@@ -2494,12 +2326,12 @@ class TestModel_PolicyResource():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        resource_attribute_model = {} # ResourceAttribute
+        resource_attribute_model = {}  # ResourceAttribute
         resource_attribute_model['name'] = 'testString'
         resource_attribute_model['value'] = 'testString'
         resource_attribute_model['operator'] = 'testString'
 
-        resource_tag_model = {} # ResourceTag
+        resource_tag_model = {}  # ResourceTag
         resource_tag_model['name'] = 'testString'
         resource_tag_model['value'] = 'testString'
         resource_tag_model['operator'] = 'testString'
@@ -2524,7 +2356,8 @@ class TestModel_PolicyResource():
         policy_resource_model_json2 = policy_resource_model.to_dict()
         assert policy_resource_model_json2 == policy_resource_model_json
 
-class TestModel_PolicyRole():
+
+class TestModel_PolicyRole:
     """
     Test Class for PolicyRole
     """
@@ -2553,7 +2386,8 @@ class TestModel_PolicyRole():
         policy_role_model_json2 = policy_role_model.to_dict()
         assert policy_role_model_json2 == policy_role_model_json
 
-class TestModel_PolicySubject():
+
+class TestModel_PolicySubject:
     """
     Test Class for PolicySubject
     """
@@ -2565,7 +2399,7 @@ class TestModel_PolicySubject():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        subject_attribute_model = {} # SubjectAttribute
+        subject_attribute_model = {}  # SubjectAttribute
         subject_attribute_model['name'] = 'testString'
         subject_attribute_model['value'] = 'testString'
 
@@ -2588,7 +2422,8 @@ class TestModel_PolicySubject():
         policy_subject_model_json2 = policy_subject_model.to_dict()
         assert policy_subject_model_json2 == policy_subject_model_json
 
-class TestModel_ResourceAttribute():
+
+class TestModel_ResourceAttribute:
     """
     Test Class for ResourceAttribute
     """
@@ -2619,7 +2454,8 @@ class TestModel_ResourceAttribute():
         resource_attribute_model_json2 = resource_attribute_model.to_dict()
         assert resource_attribute_model_json2 == resource_attribute_model_json
 
-class TestModel_ResourceTag():
+
+class TestModel_ResourceTag:
     """
     Test Class for ResourceTag
     """
@@ -2650,7 +2486,8 @@ class TestModel_ResourceTag():
         resource_tag_model_json2 = resource_tag_model.to_dict()
         assert resource_tag_model_json2 == resource_tag_model_json
 
-class TestModel_Role():
+
+class TestModel_Role:
     """
     Test Class for Role
     """
@@ -2681,7 +2518,8 @@ class TestModel_Role():
         role_model_json2 = role_model.to_dict()
         assert role_model_json2 == role_model_json
 
-class TestModel_RoleList():
+
+class TestModel_RoleList:
     """
     Test Class for RoleList
     """
@@ -2693,7 +2531,7 @@ class TestModel_RoleList():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        custom_role_model = {} # CustomRole
+        custom_role_model = {}  # CustomRole
         custom_role_model['display_name'] = 'testString'
         custom_role_model['description'] = 'testString'
         custom_role_model['actions'] = ['testString']
@@ -2701,7 +2539,7 @@ class TestModel_RoleList():
         custom_role_model['account_id'] = 'testString'
         custom_role_model['service_name'] = 'iam-groups'
 
-        role_model = {} # Role
+        role_model = {}  # Role
         role_model['display_name'] = 'testString'
         role_model['description'] = 'testString'
         role_model['actions'] = ['testString']
@@ -2727,7 +2565,8 @@ class TestModel_RoleList():
         role_list_model_json2 = role_list_model.to_dict()
         assert role_list_model_json2 == role_list_model_json
 
-class TestModel_SubjectAttribute():
+
+class TestModel_SubjectAttribute:
     """
     Test Class for SubjectAttribute
     """
@@ -2757,7 +2596,8 @@ class TestModel_SubjectAttribute():
         subject_attribute_model_json2 = subject_attribute_model.to_dict()
         assert subject_attribute_model_json2 == subject_attribute_model_json
 
-class TestModel_V2Policy():
+
+class TestModel_V2Policy:
     """
     Test Class for V2Policy
     """
@@ -2769,27 +2609,27 @@ class TestModel_V2Policy():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        v2_policy_attribute_model = {} # V2PolicyAttribute
+        v2_policy_attribute_model = {}  # V2PolicyAttribute
         v2_policy_attribute_model['key'] = 'testString'
         v2_policy_attribute_model['operator'] = 'testString'
         v2_policy_attribute_model['value'] = 'testString'
 
-        v2_policy_base_subject_model = {} # V2PolicyBaseSubject
+        v2_policy_base_subject_model = {}  # V2PolicyBaseSubject
         v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
 
-        policy_role_model = {} # PolicyRole
+        policy_role_model = {}  # PolicyRole
         policy_role_model['role_id'] = 'testString'
 
-        v2_policy_base_control_grant_model = {} # V2PolicyBaseControlGrant
+        v2_policy_base_control_grant_model = {}  # V2PolicyBaseControlGrant
         v2_policy_base_control_grant_model['roles'] = [policy_role_model]
 
-        v2_policy_base_control_model = {} # V2PolicyBaseControl
+        v2_policy_base_control_model = {}  # V2PolicyBaseControl
         v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
 
-        v2_policy_base_resource_model = {} # V2PolicyBaseResource
+        v2_policy_base_resource_model = {}  # V2PolicyBaseResource
         v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
 
-        v2_policy_base_rule_model = {} # V2PolicyBaseRuleV2PolicyAttribute
+        v2_policy_base_rule_model = {}  # V2PolicyBaseRuleV2PolicyAttribute
         v2_policy_base_rule_model['key'] = 'testString'
         v2_policy_base_rule_model['operator'] = 'testString'
         v2_policy_base_rule_model['value'] = 'testString'
@@ -2820,7 +2660,8 @@ class TestModel_V2Policy():
         v2_policy_model_json2 = v2_policy_model.to_dict()
         assert v2_policy_model_json2 == v2_policy_model_json
 
-class TestModel_V2PolicyAttribute():
+
+class TestModel_V2PolicyAttribute:
     """
     Test Class for V2PolicyAttribute
     """
@@ -2851,7 +2692,8 @@ class TestModel_V2PolicyAttribute():
         v2_policy_attribute_model_json2 = v2_policy_attribute_model.to_dict()
         assert v2_policy_attribute_model_json2 == v2_policy_attribute_model_json
 
-class TestModel_V2PolicyList():
+
+class TestModel_V2PolicyList:
     """
     Test Class for V2PolicyList
     """
@@ -2863,32 +2705,32 @@ class TestModel_V2PolicyList():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        v2_policy_attribute_model = {} # V2PolicyAttribute
+        v2_policy_attribute_model = {}  # V2PolicyAttribute
         v2_policy_attribute_model['key'] = 'testString'
         v2_policy_attribute_model['operator'] = 'testString'
         v2_policy_attribute_model['value'] = 'testString'
 
-        v2_policy_base_subject_model = {} # V2PolicyBaseSubject
+        v2_policy_base_subject_model = {}  # V2PolicyBaseSubject
         v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
 
-        policy_role_model = {} # PolicyRole
+        policy_role_model = {}  # PolicyRole
         policy_role_model['role_id'] = 'testString'
 
-        v2_policy_base_control_grant_model = {} # V2PolicyBaseControlGrant
+        v2_policy_base_control_grant_model = {}  # V2PolicyBaseControlGrant
         v2_policy_base_control_grant_model['roles'] = [policy_role_model]
 
-        v2_policy_base_control_model = {} # V2PolicyBaseControl
+        v2_policy_base_control_model = {}  # V2PolicyBaseControl
         v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
 
-        v2_policy_base_resource_model = {} # V2PolicyBaseResource
+        v2_policy_base_resource_model = {}  # V2PolicyBaseResource
         v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
 
-        v2_policy_base_rule_model = {} # V2PolicyBaseRuleV2PolicyAttribute
+        v2_policy_base_rule_model = {}  # V2PolicyBaseRuleV2PolicyAttribute
         v2_policy_base_rule_model['key'] = 'testString'
         v2_policy_base_rule_model['operator'] = 'testString'
         v2_policy_base_rule_model['value'] = 'testString'
 
-        v2_policy_model = {} # V2Policy
+        v2_policy_model = {}  # V2Policy
         v2_policy_model['type'] = 'testString'
         v2_policy_model['description'] = 'testString'
         v2_policy_model['subject'] = v2_policy_base_subject_model
@@ -2917,7 +2759,8 @@ class TestModel_V2PolicyList():
         v2_policy_list_model_json2 = v2_policy_list_model.to_dict()
         assert v2_policy_list_model_json2 == v2_policy_list_model_json
 
-class TestModel_V2PolicyBaseRuleV2PolicyAttribute():
+
+class TestModel_V2PolicyBaseRuleV2PolicyAttribute:
     """
     Test Class for V2PolicyBaseRuleV2PolicyAttribute
     """
@@ -2934,12 +2777,18 @@ class TestModel_V2PolicyBaseRuleV2PolicyAttribute():
         v2_policy_base_rule_v2_policy_attribute_model_json['value'] = 'testString'
 
         # Construct a model instance of V2PolicyBaseRuleV2PolicyAttribute by calling from_dict on the json representation
-        v2_policy_base_rule_v2_policy_attribute_model = V2PolicyBaseRuleV2PolicyAttribute.from_dict(v2_policy_base_rule_v2_policy_attribute_model_json)
+        v2_policy_base_rule_v2_policy_attribute_model = V2PolicyBaseRuleV2PolicyAttribute.from_dict(
+            v2_policy_base_rule_v2_policy_attribute_model_json
+        )
         assert v2_policy_base_rule_v2_policy_attribute_model != False
 
         # Construct a model instance of V2PolicyBaseRuleV2PolicyAttribute by calling from_dict on the json representation
-        v2_policy_base_rule_v2_policy_attribute_model_dict = V2PolicyBaseRuleV2PolicyAttribute.from_dict(v2_policy_base_rule_v2_policy_attribute_model_json).__dict__
-        v2_policy_base_rule_v2_policy_attribute_model2 = V2PolicyBaseRuleV2PolicyAttribute(**v2_policy_base_rule_v2_policy_attribute_model_dict)
+        v2_policy_base_rule_v2_policy_attribute_model_dict = V2PolicyBaseRuleV2PolicyAttribute.from_dict(
+            v2_policy_base_rule_v2_policy_attribute_model_json
+        ).__dict__
+        v2_policy_base_rule_v2_policy_attribute_model2 = V2PolicyBaseRuleV2PolicyAttribute(
+            **v2_policy_base_rule_v2_policy_attribute_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert v2_policy_base_rule_v2_policy_attribute_model == v2_policy_base_rule_v2_policy_attribute_model2
@@ -2948,7 +2797,8 @@ class TestModel_V2PolicyBaseRuleV2PolicyAttribute():
         v2_policy_base_rule_v2_policy_attribute_model_json2 = v2_policy_base_rule_v2_policy_attribute_model.to_dict()
         assert v2_policy_base_rule_v2_policy_attribute_model_json2 == v2_policy_base_rule_v2_policy_attribute_model_json
 
-class TestModel_V2PolicyBaseRuleV2RuleWithConditions():
+
+class TestModel_V2PolicyBaseRuleV2RuleWithConditions:
     """
     Test Class for V2PolicyBaseRuleV2RuleWithConditions
     """
@@ -2960,7 +2810,7 @@ class TestModel_V2PolicyBaseRuleV2RuleWithConditions():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        v2_policy_attribute_model = {} # V2PolicyAttribute
+        v2_policy_attribute_model = {}  # V2PolicyAttribute
         v2_policy_attribute_model['key'] = 'testString'
         v2_policy_attribute_model['operator'] = 'testString'
         v2_policy_attribute_model['value'] = 'testString'
@@ -2971,19 +2821,30 @@ class TestModel_V2PolicyBaseRuleV2RuleWithConditions():
         v2_policy_base_rule_v2_rule_with_conditions_model_json['conditions'] = [v2_policy_attribute_model]
 
         # Construct a model instance of V2PolicyBaseRuleV2RuleWithConditions by calling from_dict on the json representation
-        v2_policy_base_rule_v2_rule_with_conditions_model = V2PolicyBaseRuleV2RuleWithConditions.from_dict(v2_policy_base_rule_v2_rule_with_conditions_model_json)
+        v2_policy_base_rule_v2_rule_with_conditions_model = V2PolicyBaseRuleV2RuleWithConditions.from_dict(
+            v2_policy_base_rule_v2_rule_with_conditions_model_json
+        )
         assert v2_policy_base_rule_v2_rule_with_conditions_model != False
 
         # Construct a model instance of V2PolicyBaseRuleV2RuleWithConditions by calling from_dict on the json representation
-        v2_policy_base_rule_v2_rule_with_conditions_model_dict = V2PolicyBaseRuleV2RuleWithConditions.from_dict(v2_policy_base_rule_v2_rule_with_conditions_model_json).__dict__
-        v2_policy_base_rule_v2_rule_with_conditions_model2 = V2PolicyBaseRuleV2RuleWithConditions(**v2_policy_base_rule_v2_rule_with_conditions_model_dict)
+        v2_policy_base_rule_v2_rule_with_conditions_model_dict = V2PolicyBaseRuleV2RuleWithConditions.from_dict(
+            v2_policy_base_rule_v2_rule_with_conditions_model_json
+        ).__dict__
+        v2_policy_base_rule_v2_rule_with_conditions_model2 = V2PolicyBaseRuleV2RuleWithConditions(
+            **v2_policy_base_rule_v2_rule_with_conditions_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert v2_policy_base_rule_v2_rule_with_conditions_model == v2_policy_base_rule_v2_rule_with_conditions_model2
 
         # Convert model instance back to dict and verify no loss of data
-        v2_policy_base_rule_v2_rule_with_conditions_model_json2 = v2_policy_base_rule_v2_rule_with_conditions_model.to_dict()
-        assert v2_policy_base_rule_v2_rule_with_conditions_model_json2 == v2_policy_base_rule_v2_rule_with_conditions_model_json
+        v2_policy_base_rule_v2_rule_with_conditions_model_json2 = (
+            v2_policy_base_rule_v2_rule_with_conditions_model.to_dict()
+        )
+        assert (
+            v2_policy_base_rule_v2_rule_with_conditions_model_json2
+            == v2_policy_base_rule_v2_rule_with_conditions_model_json
+        )
 
 
 # endregion


### PR DESCRIPTION
Signed-off-by: Shaun Colley <shaun.colley@ibm.com>

## PR summary
<!-- please include a brief summary of the changes in this PR -->
Code to support new v2/policies API has been introduced. The new v2/policies API will have new JSON fields and existing v1/fields have been changed.

v1/policies API will continue to be supported.


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
PR's are currently open for staging and production docs. They are not currently merged:
Staging: https://github.ibm.com/cloud-api-docs/iam-access-management/pull/139
Production: https://github.ibm.com/cloud-api-docs/iam-access-management/pull/140

## Current vs new behavior  
Current behavior will remain same (v1 will continue to be supported). New behavior is v2/policies support which allows for time based restriction policies using new rule field (an integration test has been added of this example).

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No


## Other information
See:
Issue: https://github.ibm.com/IAM/AM-issues/issues/925
TRI: https://github.ibm.com/IAM/architecture/blob/master/TRIDocs/Access-Management/Smart-Policies/smart_policies.md