### PR TITLE
fix: rename Account_Summary billing_month property

### DIFF
--- a/ibm_platform_services/usage_reports_v4.py
+++ b/ibm_platform_services/usage_reports_v4.py
@@ -37,6 +37,7 @@ from .common import get_sdk_headers
 # Service
 ##############################################################################
 
+
 class UsageReportsV4(BaseService):
     """The Usage Reports V4 service."""
 
@@ -44,23 +45,23 @@ class UsageReportsV4(BaseService):
     DEFAULT_SERVICE_NAME = 'usage_reports'
 
     @classmethod
-    def new_instance(cls,
-                     service_name: str = DEFAULT_SERVICE_NAME,
-                    ) -> 'UsageReportsV4':
+    def new_instance(
+        cls,
+        service_name: str = DEFAULT_SERVICE_NAME,
+    ) -> 'UsageReportsV4':
         """
         Return a new client for the Usage Reports service using the specified
                parameters and external configuration.
         """
         authenticator = get_authenticator_from_environment(service_name)
-        service = cls(
-            authenticator
-            )
+        service = cls(authenticator)
         service.configure_service(service_name)
         return service
 
-    def __init__(self,
-                 authenticator: Authenticator = None,
-                ) -> None:
+    def __init__(
+        self,
+        authenticator: Authenticator = None,
+    ) -> None:
         """
         Construct a new client for the Usage Reports service.
 
@@ -68,21 +69,13 @@ class UsageReportsV4(BaseService):
                Get up to date information from https://github.com/IBM/python-sdk-core/blob/main/README.md
                about initializing the authenticator of your choice.
         """
-        BaseService.__init__(self,
-                             service_url=self.DEFAULT_SERVICE_URL,
-                             authenticator=authenticator)
-
+        BaseService.__init__(self, service_url=self.DEFAULT_SERVICE_URL, authenticator=authenticator)
 
     #########################
     # Account operations
     #########################
 
-
-    def get_account_summary(self,
-        account_id: str,
-        billingmonth: str,
-        **kwargs
-    ) -> DetailedResponse:
+    def get_account_summary(self, account_id: str, billingmonth: str, **kwargs) -> DetailedResponse:
         """
         Get account summary.
 
@@ -102,9 +95,9 @@ class UsageReportsV4(BaseService):
         if not billingmonth:
             raise ValueError('billingmonth must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V4',
-                                      operation_id='get_account_summary')
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V4', operation_id='get_account_summary'
+        )
         headers.update(sdk_headers)
 
         if 'headers' in kwargs:
@@ -116,21 +109,13 @@ class UsageReportsV4(BaseService):
         path_param_values = self.encode_path_vars(account_id, billingmonth)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v4/accounts/{account_id}/summary/{billingmonth}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers)
+        request = self.prepare_request(method='GET', url=url, headers=headers)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def get_account_usage(self,
-        account_id: str,
-        billingmonth: str,
-        *,
-        names: bool = None,
-        accept_language: str = None,
-        **kwargs
+    def get_account_usage(
+        self, account_id: str, billingmonth: str, *, names: bool = None, accept_language: str = None, **kwargs
     ) -> DetailedResponse:
         """
         Get account usage.
@@ -154,17 +139,13 @@ class UsageReportsV4(BaseService):
             raise ValueError('account_id must be provided')
         if not billingmonth:
             raise ValueError('billingmonth must be provided')
-        headers = {
-            'Accept-Language': accept_language
-        }
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V4',
-                                      operation_id='get_account_usage')
+        headers = {'Accept-Language': accept_language}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V4', operation_id='get_account_usage'
+        )
         headers.update(sdk_headers)
 
-        params = {
-            '_names': names
-        }
+        params = {'_names': names}
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
@@ -175,10 +156,7 @@ class UsageReportsV4(BaseService):
         path_param_values = self.encode_path_vars(account_id, billingmonth)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v4/accounts/{account_id}/usage/{billingmonth}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers,
-                                       params=params)
+        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
 
         response = self.send(request, **kwargs)
         return response
@@ -187,15 +165,15 @@ class UsageReportsV4(BaseService):
     # Resource operations
     #########################
 
-
-    def get_resource_group_usage(self,
+    def get_resource_group_usage(
+        self,
         account_id: str,
         resource_group_id: str,
         billingmonth: str,
         *,
         names: bool = None,
         accept_language: str = None,
-        **kwargs
+        **kwargs,
     ) -> DetailedResponse:
         """
         Get resource group usage.
@@ -224,17 +202,13 @@ class UsageReportsV4(BaseService):
             raise ValueError('resource_group_id must be provided')
         if not billingmonth:
             raise ValueError('billingmonth must be provided')
-        headers = {
-            'Accept-Language': accept_language
-        }
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V4',
-                                      operation_id='get_resource_group_usage')
+        headers = {'Accept-Language': accept_language}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V4', operation_id='get_resource_group_usage'
+        )
         headers.update(sdk_headers)
 
-        params = {
-            '_names': names
-        }
+        params = {'_names': names}
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
@@ -244,17 +218,16 @@ class UsageReportsV4(BaseService):
         path_param_keys = ['account_id', 'resource_group_id', 'billingmonth']
         path_param_values = self.encode_path_vars(account_id, resource_group_id, billingmonth)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v4/accounts/{account_id}/resource_groups/{resource_group_id}/usage/{billingmonth}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers,
-                                       params=params)
+        url = '/v4/accounts/{account_id}/resource_groups/{resource_group_id}/usage/{billingmonth}'.format(
+            **path_param_dict
+        )
+        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def get_resource_usage_account(self,
+    def get_resource_usage_account(
+        self,
         account_id: str,
         billingmonth: str,
         *,
@@ -268,7 +241,7 @@ class UsageReportsV4(BaseService):
         resource_id: str = None,
         plan_id: str = None,
         region: str = None,
-        **kwargs
+        **kwargs,
     ) -> DetailedResponse:
         """
         Get resource instance usage in an account.
@@ -303,12 +276,10 @@ class UsageReportsV4(BaseService):
             raise ValueError('account_id must be provided')
         if not billingmonth:
             raise ValueError('billingmonth must be provided')
-        headers = {
-            'Accept-Language': accept_language
-        }
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V4',
-                                      operation_id='get_resource_usage_account')
+        headers = {'Accept-Language': accept_language}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V4', operation_id='get_resource_usage_account'
+        )
         headers.update(sdk_headers)
 
         params = {
@@ -320,7 +291,7 @@ class UsageReportsV4(BaseService):
             'resource_instance_id': resource_instance_id,
             'resource_id': resource_id,
             'plan_id': plan_id,
-            'region': region
+            'region': region,
         }
 
         if 'headers' in kwargs:
@@ -332,16 +303,13 @@ class UsageReportsV4(BaseService):
         path_param_values = self.encode_path_vars(account_id, billingmonth)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v4/accounts/{account_id}/resource_instances/usage/{billingmonth}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers,
-                                       params=params)
+        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def get_resource_usage_resource_group(self,
+    def get_resource_usage_resource_group(
+        self,
         account_id: str,
         resource_group_id: str,
         billingmonth: str,
@@ -354,7 +322,7 @@ class UsageReportsV4(BaseService):
         resource_id: str = None,
         plan_id: str = None,
         region: str = None,
-        **kwargs
+        **kwargs,
     ) -> DetailedResponse:
         """
         Get resource instance usage in a resource group.
@@ -392,12 +360,12 @@ class UsageReportsV4(BaseService):
             raise ValueError('resource_group_id must be provided')
         if not billingmonth:
             raise ValueError('billingmonth must be provided')
-        headers = {
-            'Accept-Language': accept_language
-        }
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V4',
-                                      operation_id='get_resource_usage_resource_group')
+        headers = {'Accept-Language': accept_language}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V4',
+            operation_id='get_resource_usage_resource_group',
+        )
         headers.update(sdk_headers)
 
         params = {
@@ -407,7 +375,7 @@ class UsageReportsV4(BaseService):
             'resource_instance_id': resource_instance_id,
             'resource_id': resource_id,
             'plan_id': plan_id,
-            'region': region
+            'region': region,
         }
 
         if 'headers' in kwargs:
@@ -418,17 +386,16 @@ class UsageReportsV4(BaseService):
         path_param_keys = ['account_id', 'resource_group_id', 'billingmonth']
         path_param_values = self.encode_path_vars(account_id, resource_group_id, billingmonth)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v4/accounts/{account_id}/resource_groups/{resource_group_id}/resource_instances/usage/{billingmonth}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers,
-                                       params=params)
+        url = '/v4/accounts/{account_id}/resource_groups/{resource_group_id}/resource_instances/usage/{billingmonth}'.format(
+            **path_param_dict
+        )
+        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
 
         response = self.send(request, **kwargs)
         return response
 
-
-    def get_resource_usage_org(self,
+    def get_resource_usage_org(
+        self,
         account_id: str,
         organization_id: str,
         billingmonth: str,
@@ -441,7 +408,7 @@ class UsageReportsV4(BaseService):
         resource_id: str = None,
         plan_id: str = None,
         region: str = None,
-        **kwargs
+        **kwargs,
     ) -> DetailedResponse:
         """
         Get resource instance usage in an organization.
@@ -478,12 +445,10 @@ class UsageReportsV4(BaseService):
             raise ValueError('organization_id must be provided')
         if not billingmonth:
             raise ValueError('billingmonth must be provided')
-        headers = {
-            'Accept-Language': accept_language
-        }
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V4',
-                                      operation_id='get_resource_usage_org')
+        headers = {'Accept-Language': accept_language}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V4', operation_id='get_resource_usage_org'
+        )
         headers.update(sdk_headers)
 
         params = {
@@ -493,7 +458,7 @@ class UsageReportsV4(BaseService):
             'resource_instance_id': resource_instance_id,
             'resource_id': resource_id,
             'plan_id': plan_id,
-            'region': region
+            'region': region,
         }
 
         if 'headers' in kwargs:
@@ -504,11 +469,12 @@ class UsageReportsV4(BaseService):
         path_param_keys = ['account_id', 'organization_id', 'billingmonth']
         path_param_values = self.encode_path_vars(account_id, organization_id, billingmonth)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v4/accounts/{account_id}/organizations/{organization_id}/resource_instances/usage/{billingmonth}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers,
-                                       params=params)
+        url = (
+            '/v4/accounts/{account_id}/organizations/{organization_id}/resource_instances/usage/{billingmonth}'.format(
+                **path_param_dict
+            )
+        )
+        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
 
         response = self.send(request, **kwargs)
         return response
@@ -517,15 +483,15 @@ class UsageReportsV4(BaseService):
     # Organization operations
     #########################
 
-
-    def get_org_usage(self,
+    def get_org_usage(
+        self,
         account_id: str,
         organization_id: str,
         billingmonth: str,
         *,
         names: bool = None,
         accept_language: str = None,
-        **kwargs
+        **kwargs,
     ) -> DetailedResponse:
         """
         Get organization usage.
@@ -553,17 +519,13 @@ class UsageReportsV4(BaseService):
             raise ValueError('organization_id must be provided')
         if not billingmonth:
             raise ValueError('billingmonth must be provided')
-        headers = {
-            'Accept-Language': accept_language
-        }
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V4',
-                                      operation_id='get_org_usage')
+        headers = {'Accept-Language': accept_language}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V4', operation_id='get_org_usage'
+        )
         headers.update(sdk_headers)
 
-        params = {
-            '_names': names
-        }
+        params = {'_names': names}
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
@@ -574,10 +536,7 @@ class UsageReportsV4(BaseService):
         path_param_values = self.encode_path_vars(account_id, organization_id, billingmonth)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v4/accounts/{account_id}/organizations/{organization_id}/usage/{billingmonth}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers,
-                                       params=params)
+        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
 
         response = self.send(request, **kwargs)
         return response
@@ -588,7 +547,7 @@ class UsageReportsV4(BaseService):
 ##############################################################################
 
 
-class AccountSummary():
+class AccountSummary:
     """
     A summary of charges and credits for an account.
 
@@ -605,15 +564,17 @@ class AccountSummary():
           to a subscription.
     """
 
-    def __init__(self,
-                 account_id: str,
-                 month: str,
-                 billing_country_code: str,
-                 billing_currency_code: str,
-                 resources: 'ResourcesSummary',
-                 offers: List['Offer'],
-                 support: List['SupportSummary'],
-                 subscription: 'SubscriptionSummary') -> None:
+    def __init__(
+        self,
+        account_id: str,
+        month: str,
+        billing_country_code: str,
+        billing_currency_code: str,
+        resources: 'ResourcesSummary',
+        offers: List['Offer'],
+        support: List['SupportSummary'],
+        subscription: 'SubscriptionSummary',
+    ) -> None:
         """
         Initialize a AccountSummary object.
 
@@ -739,7 +700,8 @@ class AccountSummary():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class AccountUsage():
+
+class AccountUsage:
     """
     The aggregated usage and charges for all the plans in the account.
 
@@ -751,12 +713,9 @@ class AccountUsage():
     :attr List[Resource] resources: All the resource used in the account.
     """
 
-    def __init__(self,
-                 account_id: str,
-                 pricing_country: str,
-                 currency_code: str,
-                 month: str,
-                 resources: List['Resource']) -> None:
+    def __init__(
+        self, account_id: str, pricing_country: str, currency_code: str, month: str, resources: List['Resource']
+    ) -> None:
         """
         Initialize a AccountUsage object.
 
@@ -843,7 +802,8 @@ class AccountUsage():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class Discount():
+
+class Discount:
     """
     Information about a discount that is associated with a metric.
 
@@ -853,12 +813,7 @@ class Discount():
     :attr float discount: The discount percentage.
     """
 
-    def __init__(self,
-                 ref: str,
-                 discount: float,
-                 *,
-                 name: str = None,
-                 display_name: str = None) -> None:
+    def __init__(self, ref: str, discount: float, *, name: str = None, display_name: str = None) -> None:
         """
         Initialize a Discount object.
 
@@ -926,7 +881,8 @@ class Discount():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class InstanceUsage():
+
+class InstanceUsage:
     """
     The aggregated usage and charges for an instance.
 
@@ -957,29 +913,31 @@ class InstanceUsage():
     :attr List[Metric] usage: All the resource used in the account.
     """
 
-    def __init__(self,
-                 account_id: str,
-                 resource_instance_id: str,
-                 resource_id: str,
-                 pricing_country: str,
-                 currency_code: str,
-                 billable: bool,
-                 plan_id: str,
-                 month: str,
-                 usage: List['Metric'],
-                 *,
-                 resource_instance_name: str = None,
-                 resource_name: str = None,
-                 resource_group_id: str = None,
-                 resource_group_name: str = None,
-                 organization_id: str = None,
-                 organization_name: str = None,
-                 space_id: str = None,
-                 space_name: str = None,
-                 consumer_id: str = None,
-                 region: str = None,
-                 pricing_region: str = None,
-                 plan_name: str = None) -> None:
+    def __init__(
+        self,
+        account_id: str,
+        resource_instance_id: str,
+        resource_id: str,
+        pricing_country: str,
+        currency_code: str,
+        billable: bool,
+        plan_id: str,
+        month: str,
+        usage: List['Metric'],
+        *,
+        resource_instance_name: str = None,
+        resource_name: str = None,
+        resource_group_id: str = None,
+        resource_group_name: str = None,
+        organization_id: str = None,
+        organization_name: str = None,
+        space_id: str = None,
+        space_name: str = None,
+        consumer_id: str = None,
+        region: str = None,
+        pricing_region: str = None,
+        plan_name: str = None,
+    ) -> None:
         """
         Initialize a InstanceUsage object.
 
@@ -1174,16 +1132,15 @@ class InstanceUsage():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class InstancesUsageFirst():
+
+class InstancesUsageFirst:
     """
     The link to the first page of the search query.
 
     :attr str href: (optional) A link to a page of query results.
     """
 
-    def __init__(self,
-                 *,
-                 href: str = None) -> None:
+    def __init__(self, *, href: str = None) -> None:
         """
         Initialize a InstancesUsageFirst object.
 
@@ -1229,7 +1186,8 @@ class InstancesUsageFirst():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class InstancesUsageNext():
+
+class InstancesUsageNext:
     """
     The link to the next page of the search query.
 
@@ -1238,10 +1196,7 @@ class InstancesUsageNext():
           the next page.
     """
 
-    def __init__(self,
-                 *,
-                 href: str = None,
-                 offset: str = None) -> None:
+    def __init__(self, *, href: str = None, offset: str = None) -> None:
         """
         Initialize a InstancesUsageNext object.
 
@@ -1294,7 +1249,8 @@ class InstancesUsageNext():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class InstancesUsage():
+
+class InstancesUsage:
     """
     The list of instance usage reports.
 
@@ -1308,13 +1264,15 @@ class InstancesUsage():
           reports.
     """
 
-    def __init__(self,
-                 *,
-                 limit: int = None,
-                 count: int = None,
-                 first: 'InstancesUsageFirst' = None,
-                 next: 'InstancesUsageNext' = None,
-                 resources: List['InstanceUsage'] = None) -> None:
+    def __init__(
+        self,
+        *,
+        limit: int = None,
+        count: int = None,
+        first: 'InstancesUsageFirst' = None,
+        next: 'InstancesUsageNext' = None,
+        resources: List['InstanceUsage'] = None,
+    ) -> None:
         """
         Initialize a InstancesUsage object.
 
@@ -1399,7 +1357,8 @@ class InstancesUsage():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class Metric():
+
+class Metric:
     """
     Information about a metric.
 
@@ -1419,19 +1378,21 @@ class Metric():
     :attr List[Discount] discounts: All the discounts applicable to the metric.
     """
 
-    def __init__(self,
-                 metric: str,
-                 quantity: float,
-                 cost: float,
-                 rated_cost: float,
-                 discounts: List['Discount'],
-                 *,
-                 metric_name: str = None,
-                 rateable_quantity: float = None,
-                 price: List[object] = None,
-                 unit: str = None,
-                 unit_name: str = None,
-                 non_chargeable: bool = None) -> None:
+    def __init__(
+        self,
+        metric: str,
+        quantity: float,
+        cost: float,
+        rated_cost: float,
+        discounts: List['Discount'],
+        *,
+        metric_name: str = None,
+        rateable_quantity: float = None,
+        price: List[object] = None,
+        unit: str = None,
+        unit_name: str = None,
+        non_chargeable: bool = None,
+    ) -> None:
         """
         Initialize a Metric object.
 
@@ -1558,7 +1519,8 @@ class Metric():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class Offer():
+
+class Offer:
     """
     Information about an individual offer.
 
@@ -1570,13 +1532,15 @@ class Offer():
     :attr OfferCredits credits: Credit information related to an offer.
     """
 
-    def __init__(self,
-                 offer_id: str,
-                 credits_total: float,
-                 offer_template: str,
-                 valid_from: datetime,
-                 expires_on: datetime,
-                 credits: 'OfferCredits') -> None:
+    def __init__(
+        self,
+        offer_id: str,
+        credits_total: float,
+        offer_template: str,
+        valid_from: datetime,
+        expires_on: datetime,
+        credits: 'OfferCredits',
+    ) -> None:
         """
         Initialize a Offer object.
 
@@ -1667,7 +1631,8 @@ class Offer():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class OfferCredits():
+
+class OfferCredits:
     """
     Credit information related to an offer.
 
@@ -1677,10 +1642,7 @@ class OfferCredits():
     :attr float balance: The remaining credits in the offer.
     """
 
-    def __init__(self,
-                 starting_balance: float,
-                 used: float,
-                 balance: float) -> None:
+    def __init__(self, starting_balance: float, used: float, balance: float) -> None:
         """
         Initialize a OfferCredits object.
 
@@ -1745,7 +1707,8 @@ class OfferCredits():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class OrgUsage():
+
+class OrgUsage:
     """
     The aggregated usage and charges for all the plans in the org.
 
@@ -1759,15 +1722,17 @@ class OrgUsage():
     :attr List[Resource] resources: All the resource used in the account.
     """
 
-    def __init__(self,
-                 account_id: str,
-                 organization_id: str,
-                 pricing_country: str,
-                 currency_code: str,
-                 month: str,
-                 resources: List['Resource'],
-                 *,
-                 organization_name: str = None) -> None:
+    def __init__(
+        self,
+        account_id: str,
+        organization_id: str,
+        pricing_country: str,
+        currency_code: str,
+        month: str,
+        resources: List['Resource'],
+        *,
+        organization_name: str = None,
+    ) -> None:
         """
         Initialize a OrgUsage object.
 
@@ -1868,7 +1833,8 @@ class OrgUsage():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class Plan():
+
+class Plan:
     """
     The aggregated values for the plan.
 
@@ -1882,16 +1848,18 @@ class Plan():
     :attr List[Discount] discounts: All the discounts applicable to the plan.
     """
 
-    def __init__(self,
-                 plan_id: str,
-                 billable: bool,
-                 cost: float,
-                 rated_cost: float,
-                 usage: List['Metric'],
-                 discounts: List['Discount'],
-                 *,
-                 plan_name: str = None,
-                 pricing_region: str = None) -> None:
+    def __init__(
+        self,
+        plan_id: str,
+        billable: bool,
+        cost: float,
+        rated_cost: float,
+        usage: List['Metric'],
+        discounts: List['Discount'],
+        *,
+        plan_name: str = None,
+        pricing_region: str = None,
+    ) -> None:
         """
         Initialize a Plan object.
 
@@ -2004,7 +1972,8 @@ class Plan():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class Resource():
+
+class Resource:
     """
     The container for all the plans in the resource.
 
@@ -2020,16 +1989,18 @@ class Resource():
     :attr List[Discount] discounts: All the discounts applicable to the resource.
     """
 
-    def __init__(self,
-                 resource_id: str,
-                 billable_cost: float,
-                 billable_rated_cost: float,
-                 non_billable_cost: float,
-                 non_billable_rated_cost: float,
-                 plans: List['Plan'],
-                 discounts: List['Discount'],
-                 *,
-                 resource_name: str = None) -> None:
+    def __init__(
+        self,
+        resource_id: str,
+        billable_cost: float,
+        billable_rated_cost: float,
+        non_billable_cost: float,
+        non_billable_rated_cost: float,
+        plans: List['Plan'],
+        discounts: List['Discount'],
+        *,
+        resource_name: str = None,
+    ) -> None:
         """
         Initialize a Resource object.
 
@@ -2146,7 +2117,8 @@ class Resource():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class ResourceGroupUsage():
+
+class ResourceGroupUsage:
     """
     The aggregated usage and charges for all the plans in the resource group.
 
@@ -2160,15 +2132,17 @@ class ResourceGroupUsage():
     :attr List[Resource] resources: All the resource used in the account.
     """
 
-    def __init__(self,
-                 account_id: str,
-                 resource_group_id: str,
-                 pricing_country: str,
-                 currency_code: str,
-                 month: str,
-                 resources: List['Resource'],
-                 *,
-                 resource_group_name: str = None) -> None:
+    def __init__(
+        self,
+        account_id: str,
+        resource_group_id: str,
+        pricing_country: str,
+        currency_code: str,
+        month: str,
+        resources: List['Resource'],
+        *,
+        resource_group_name: str = None,
+    ) -> None:
         """
         Initialize a ResourceGroupUsage object.
 
@@ -2269,7 +2243,8 @@ class ResourceGroupUsage():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class ResourcesSummary():
+
+class ResourcesSummary:
     """
     Charges related to cloud resources.
 
@@ -2279,9 +2254,7 @@ class ResourcesSummary():
           in the account.
     """
 
-    def __init__(self,
-                 billable_cost: float,
-                 non_billable_cost: float) -> None:
+    def __init__(self, billable_cost: float, non_billable_cost: float) -> None:
         """
         Initialize a ResourcesSummary object.
 
@@ -2339,7 +2312,8 @@ class ResourcesSummary():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class Subscription():
+
+class Subscription:
     """
     Subscription.
 
@@ -2357,16 +2331,18 @@ class Subscription():
           split into.
     """
 
-    def __init__(self,
-                 subscription_id: str,
-                 charge_agreement_number: str,
-                 type: str,
-                 subscription_amount: float,
-                 start: datetime,
-                 credits_total: float,
-                 terms: List['SubscriptionTerm'],
-                 *,
-                 end: datetime = None) -> None:
+    def __init__(
+        self,
+        subscription_id: str,
+        charge_agreement_number: str,
+        type: str,
+        subscription_amount: float,
+        start: datetime,
+        credits_total: float,
+        terms: List['SubscriptionTerm'],
+        *,
+        end: datetime = None,
+    ) -> None:
         """
         Initialize a Subscription object.
 
@@ -2479,7 +2455,8 @@ class Subscription():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class SubscriptionSummary():
+
+class SubscriptionSummary:
     """
     A summary of charges and credits related to a subscription.
 
@@ -2489,10 +2466,7 @@ class SubscriptionSummary():
           applicable for the month.
     """
 
-    def __init__(self,
-                 *,
-                 overage: float = None,
-                 subscriptions: List['Subscription'] = None) -> None:
+    def __init__(self, *, overage: float = None, subscriptions: List['Subscription'] = None) -> None:
         """
         Initialize a SubscriptionSummary object.
 
@@ -2552,7 +2526,8 @@ class SubscriptionSummary():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class SubscriptionTerm():
+
+class SubscriptionTerm:
     """
     SubscriptionTerm.
 
@@ -2562,10 +2537,7 @@ class SubscriptionTerm():
           subscription.
     """
 
-    def __init__(self,
-                 start: datetime,
-                 end: datetime,
-                 credits: 'SubscriptionTermCredits') -> None:
+    def __init__(self, start: datetime, end: datetime, credits: 'SubscriptionTermCredits') -> None:
         """
         Initialize a SubscriptionTerm object.
 
@@ -2633,7 +2605,8 @@ class SubscriptionTerm():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class SubscriptionTermCredits():
+
+class SubscriptionTermCredits:
     """
     Information about credits related to a subscription.
 
@@ -2644,11 +2617,7 @@ class SubscriptionTermCredits():
     :attr float balance: The remaining credits in this term.
     """
 
-    def __init__(self,
-                 total: float,
-                 starting_balance: float,
-                 used: float,
-                 balance: float) -> None:
+    def __init__(self, total: float, starting_balance: float, used: float, balance: float) -> None:
         """
         Initialize a SubscriptionTermCredits object.
 
@@ -2721,7 +2690,8 @@ class SubscriptionTermCredits():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-class SupportSummary():
+
+class SupportSummary:
     """
     SupportSummary.
 
@@ -2730,10 +2700,7 @@ class SupportSummary():
     :attr float overage: Additional support cost for the month.
     """
 
-    def __init__(self,
-                 cost: float,
-                 type: str,
-                 overage: float) -> None:
+    def __init__(self, cost: float, type: str, overage: float) -> None:
         """
         Initialize a SupportSummary object.
 
@@ -2797,29 +2764,32 @@ class SupportSummary():
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
+
 ##############################################################################
 # Pagers
 ##############################################################################
 
-class GetResourceUsageAccountPager():
+
+class GetResourceUsageAccountPager:
     """
     GetResourceUsageAccountPager can be used to simplify the use of the "get_resource_usage_account" method.
     """
 
-    def __init__(self,
-                 *,
-                 client: UsageReportsV4,
-                 account_id: str,
-                 billingmonth: str,
-                 names: bool = None,
-                 accept_language: str = None,
-                 limit: int = None,
-                 resource_group_id: str = None,
-                 organization_id: str = None,
-                 resource_instance_id: str = None,
-                 resource_id: str = None,
-                 plan_id: str = None,
-                 region: str = None,
+    def __init__(
+        self,
+        *,
+        client: UsageReportsV4,
+        account_id: str,
+        billingmonth: str,
+        names: bool = None,
+        accept_language: str = None,
+        limit: int = None,
+        resource_group_id: str = None,
+        organization_id: str = None,
+        resource_instance_id: str = None,
+        resource_id: str = None,
+        plan_id: str = None,
+        region: str = None,
     ) -> None:
         """
         Initialize a GetResourceUsageAccountPager object.
@@ -2842,7 +2812,7 @@ class GetResourceUsageAccountPager():
         """
         self._has_next = True
         self._client = client
-        self._page_context = { 'next': None }
+        self._page_context = {'next': None}
         self._account_id = account_id
         self._billingmonth = billingmonth
         self._names = names
@@ -2908,24 +2878,26 @@ class GetResourceUsageAccountPager():
             results.extend(next_page)
         return results
 
-class GetResourceUsageResourceGroupPager():
+
+class GetResourceUsageResourceGroupPager:
     """
     GetResourceUsageResourceGroupPager can be used to simplify the use of the "get_resource_usage_resource_group" method.
     """
 
-    def __init__(self,
-                 *,
-                 client: UsageReportsV4,
-                 account_id: str,
-                 resource_group_id: str,
-                 billingmonth: str,
-                 names: bool = None,
-                 accept_language: str = None,
-                 limit: int = None,
-                 resource_instance_id: str = None,
-                 resource_id: str = None,
-                 plan_id: str = None,
-                 region: str = None,
+    def __init__(
+        self,
+        *,
+        client: UsageReportsV4,
+        account_id: str,
+        resource_group_id: str,
+        billingmonth: str,
+        names: bool = None,
+        accept_language: str = None,
+        limit: int = None,
+        resource_instance_id: str = None,
+        resource_id: str = None,
+        plan_id: str = None,
+        region: str = None,
     ) -> None:
         """
         Initialize a GetResourceUsageResourceGroupPager object.
@@ -2948,7 +2920,7 @@ class GetResourceUsageResourceGroupPager():
         """
         self._has_next = True
         self._client = client
-        self._page_context = { 'next': None }
+        self._page_context = {'next': None}
         self._account_id = account_id
         self._resource_group_id = resource_group_id
         self._billingmonth = billingmonth
@@ -3012,24 +2984,26 @@ class GetResourceUsageResourceGroupPager():
             results.extend(next_page)
         return results
 
-class GetResourceUsageOrgPager():
+
+class GetResourceUsageOrgPager:
     """
     GetResourceUsageOrgPager can be used to simplify the use of the "get_resource_usage_org" method.
     """
 
-    def __init__(self,
-                 *,
-                 client: UsageReportsV4,
-                 account_id: str,
-                 organization_id: str,
-                 billingmonth: str,
-                 names: bool = None,
-                 accept_language: str = None,
-                 limit: int = None,
-                 resource_instance_id: str = None,
-                 resource_id: str = None,
-                 plan_id: str = None,
-                 region: str = None,
+    def __init__(
+        self,
+        *,
+        client: UsageReportsV4,
+        account_id: str,
+        organization_id: str,
+        billingmonth: str,
+        names: bool = None,
+        accept_language: str = None,
+        limit: int = None,
+        resource_instance_id: str = None,
+        resource_id: str = None,
+        plan_id: str = None,
+        region: str = None,
     ) -> None:
         """
         Initialize a GetResourceUsageOrgPager object.
@@ -3051,7 +3025,7 @@ class GetResourceUsageOrgPager():
         """
         self._has_next = True
         self._client = client
-        self._page_context = { 'next': None }
+        self._page_context = {'next': None}
         self._account_id = account_id
         self._organization_id = organization_id
         self._billingmonth = billingmonth

--- a/ibm_platform_services/usage_reports_v4.py
+++ b/ibm_platform_services/usage_reports_v4.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# (C) Copyright IBM Corp. 2021.
+# (C) Copyright IBM Corp. 2022.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,17 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# IBM OpenAPI SDK Code Generator Version: 3.36.0-6f5b0381-20210716-180747
+# IBM OpenAPI SDK Code Generator Version: 3.62.0-a2a22f95-20221115-162524
 
 """
 Usage reports for IBM Cloud accounts
+
+API Version: 4.0.6
 """
 
 from datetime import datetime
 from typing import Dict, List
 import json
 
-from ibm_cloud_sdk_core import BaseService, DetailedResponse
+from ibm_cloud_sdk_core import BaseService, DetailedResponse, get_query_param
 from ibm_cloud_sdk_core.authenticators.authenticator import Authenticator
 from ibm_cloud_sdk_core.get_authenticator import get_authenticator_from_environment
 from ibm_cloud_sdk_core.utils import datetime_to_string, string_to_datetime
@@ -35,7 +37,6 @@ from .common import get_sdk_headers
 # Service
 ##############################################################################
 
-
 class UsageReportsV4(BaseService):
     """The Usage Reports V4 service."""
 
@@ -43,37 +44,45 @@ class UsageReportsV4(BaseService):
     DEFAULT_SERVICE_NAME = 'usage_reports'
 
     @classmethod
-    def new_instance(
-        cls,
-        service_name: str = DEFAULT_SERVICE_NAME,
-    ) -> 'UsageReportsV4':
+    def new_instance(cls,
+                     service_name: str = DEFAULT_SERVICE_NAME,
+                    ) -> 'UsageReportsV4':
         """
         Return a new client for the Usage Reports service using the specified
                parameters and external configuration.
         """
         authenticator = get_authenticator_from_environment(service_name)
-        service = cls(authenticator)
+        service = cls(
+            authenticator
+            )
         service.configure_service(service_name)
         return service
 
-    def __init__(
-        self,
-        authenticator: Authenticator = None,
-    ) -> None:
+    def __init__(self,
+                 authenticator: Authenticator = None,
+                ) -> None:
         """
         Construct a new client for the Usage Reports service.
 
         :param Authenticator authenticator: The authenticator specifies the authentication mechanism.
-               Get up to date information from https://github.com/IBM/python-sdk-core/blob/master/README.md
+               Get up to date information from https://github.com/IBM/python-sdk-core/blob/main/README.md
                about initializing the authenticator of your choice.
         """
-        BaseService.__init__(self, service_url=self.DEFAULT_SERVICE_URL, authenticator=authenticator)
+        BaseService.__init__(self,
+                             service_url=self.DEFAULT_SERVICE_URL,
+                             authenticator=authenticator)
+
 
     #########################
     # Account operations
     #########################
 
-    def get_account_summary(self, account_id: str, billingmonth: str, **kwargs) -> DetailedResponse:
+
+    def get_account_summary(self,
+        account_id: str,
+        billingmonth: str,
+        **kwargs
+    ) -> DetailedResponse:
         """
         Get account summary.
 
@@ -88,31 +97,40 @@ class UsageReportsV4(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `AccountSummary` object
         """
 
-        if account_id is None:
+        if not account_id:
             raise ValueError('account_id must be provided')
-        if billingmonth is None:
+        if not billingmonth:
             raise ValueError('billingmonth must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V4', operation_id='get_account_summary'
-        )
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V4',
+                                      operation_id='get_account_summary')
         headers.update(sdk_headers)
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['account_id', 'billingmonth']
         path_param_values = self.encode_path_vars(account_id, billingmonth)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v4/accounts/{account_id}/summary/{billingmonth}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET', url=url, headers=headers)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers)
 
         response = self.send(request, **kwargs)
         return response
 
-    def get_account_usage(
-        self, account_id: str, billingmonth: str, *, names: bool = None, accept_language: str = None, **kwargs
+
+    def get_account_usage(self,
+        account_id: str,
+        billingmonth: str,
+        *,
+        names: bool = None,
+        accept_language: str = None,
+        **kwargs
     ) -> DetailedResponse:
         """
         Get account usage.
@@ -132,27 +150,35 @@ class UsageReportsV4(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `AccountUsage` object
         """
 
-        if account_id is None:
+        if not account_id:
             raise ValueError('account_id must be provided')
-        if billingmonth is None:
+        if not billingmonth:
             raise ValueError('billingmonth must be provided')
-        headers = {'Accept-Language': accept_language}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V4', operation_id='get_account_usage'
-        )
+        headers = {
+            'Accept-Language': accept_language
+        }
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V4',
+                                      operation_id='get_account_usage')
         headers.update(sdk_headers)
 
-        params = {'_names': names}
+        params = {
+            '_names': names
+        }
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['account_id', 'billingmonth']
         path_param_values = self.encode_path_vars(account_id, billingmonth)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v4/accounts/{account_id}/usage/{billingmonth}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
 
         response = self.send(request, **kwargs)
         return response
@@ -161,8 +187,8 @@ class UsageReportsV4(BaseService):
     # Resource operations
     #########################
 
-    def get_resource_group_usage(
-        self,
+
+    def get_resource_group_usage(self,
         account_id: str,
         resource_group_id: str,
         billingmonth: str,
@@ -192,37 +218,43 @@ class UsageReportsV4(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `ResourceGroupUsage` object
         """
 
-        if account_id is None:
+        if not account_id:
             raise ValueError('account_id must be provided')
-        if resource_group_id is None:
+        if not resource_group_id:
             raise ValueError('resource_group_id must be provided')
-        if billingmonth is None:
+        if not billingmonth:
             raise ValueError('billingmonth must be provided')
-        headers = {'Accept-Language': accept_language}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V4', operation_id='get_resource_group_usage'
-        )
+        headers = {
+            'Accept-Language': accept_language
+        }
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V4',
+                                      operation_id='get_resource_group_usage')
         headers.update(sdk_headers)
 
-        params = {'_names': names}
+        params = {
+            '_names': names
+        }
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['account_id', 'resource_group_id', 'billingmonth']
         path_param_values = self.encode_path_vars(account_id, resource_group_id, billingmonth)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v4/accounts/{account_id}/resource_groups/{resource_group_id}/usage/{billingmonth}'.format(
-            **path_param_dict
-        )
-        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
+        url = '/v4/accounts/{account_id}/resource_groups/{resource_group_id}/usage/{billingmonth}'.format(**path_param_dict)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
 
         response = self.send(request, **kwargs)
         return response
 
-    def get_resource_usage_account(
-        self,
+
+    def get_resource_usage_account(self,
         account_id: str,
         billingmonth: str,
         *,
@@ -252,7 +284,7 @@ class UsageReportsV4(BaseService):
         :param str accept_language: (optional) Prioritize the names returned in the
                order of the specified languages. Language will default to English.
         :param int limit: (optional) Number of usage records returned. The default
-               value is 10. Maximum value is 20.
+               value is 30. Maximum value is 200.
         :param str start: (optional) The offset from which the records must be
                fetched. Offset information is included in the response.
         :param str resource_group_id: (optional) Filter by resource group.
@@ -267,14 +299,16 @@ class UsageReportsV4(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `InstancesUsage` object
         """
 
-        if account_id is None:
+        if not account_id:
             raise ValueError('account_id must be provided')
-        if billingmonth is None:
+        if not billingmonth:
             raise ValueError('billingmonth must be provided')
-        headers = {'Accept-Language': accept_language}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V4', operation_id='get_resource_usage_account'
-        )
+        headers = {
+            'Accept-Language': accept_language
+        }
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V4',
+                                      operation_id='get_resource_usage_account')
         headers.update(sdk_headers)
 
         params = {
@@ -286,24 +320,28 @@ class UsageReportsV4(BaseService):
             'resource_instance_id': resource_instance_id,
             'resource_id': resource_id,
             'plan_id': plan_id,
-            'region': region,
+            'region': region
         }
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['account_id', 'billingmonth']
         path_param_values = self.encode_path_vars(account_id, billingmonth)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v4/accounts/{account_id}/resource_instances/usage/{billingmonth}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
 
         response = self.send(request, **kwargs)
         return response
 
-    def get_resource_usage_resource_group(
-        self,
+
+    def get_resource_usage_resource_group(self,
         account_id: str,
         resource_group_id: str,
         billingmonth: str,
@@ -335,7 +373,7 @@ class UsageReportsV4(BaseService):
         :param str accept_language: (optional) Prioritize the names returned in the
                order of the specified languages. Language will default to English.
         :param int limit: (optional) Number of usage records returned. The default
-               value is 10. Maximum value is 20.
+               value is 30. Maximum value is 200.
         :param str start: (optional) The offset from which the records must be
                fetched. Offset information is included in the response.
         :param str resource_instance_id: (optional) Filter by resource instance id.
@@ -348,18 +386,18 @@ class UsageReportsV4(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `InstancesUsage` object
         """
 
-        if account_id is None:
+        if not account_id:
             raise ValueError('account_id must be provided')
-        if resource_group_id is None:
+        if not resource_group_id:
             raise ValueError('resource_group_id must be provided')
-        if billingmonth is None:
+        if not billingmonth:
             raise ValueError('billingmonth must be provided')
-        headers = {'Accept-Language': accept_language}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME,
-            service_version='V4',
-            operation_id='get_resource_usage_resource_group',
-        )
+        headers = {
+            'Accept-Language': accept_language
+        }
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V4',
+                                      operation_id='get_resource_usage_resource_group')
         headers.update(sdk_headers)
 
         params = {
@@ -369,26 +407,28 @@ class UsageReportsV4(BaseService):
             'resource_instance_id': resource_instance_id,
             'resource_id': resource_id,
             'plan_id': plan_id,
-            'region': region,
+            'region': region
         }
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['account_id', 'resource_group_id', 'billingmonth']
         path_param_values = self.encode_path_vars(account_id, resource_group_id, billingmonth)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v4/accounts/{account_id}/resource_groups/{resource_group_id}/resource_instances/usage/{billingmonth}'.format(
-            **path_param_dict
-        )
-        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
+        url = '/v4/accounts/{account_id}/resource_groups/{resource_group_id}/resource_instances/usage/{billingmonth}'.format(**path_param_dict)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
 
         response = self.send(request, **kwargs)
         return response
 
-    def get_resource_usage_org(
-        self,
+
+    def get_resource_usage_org(self,
         account_id: str,
         organization_id: str,
         billingmonth: str,
@@ -419,7 +459,7 @@ class UsageReportsV4(BaseService):
         :param str accept_language: (optional) Prioritize the names returned in the
                order of the specified languages. Language will default to English.
         :param int limit: (optional) Number of usage records returned. The default
-               value is 10. Maximum value is 20.
+               value is 30. Maximum value is 200.
         :param str start: (optional) The offset from which the records must be
                fetched. Offset information is included in the response.
         :param str resource_instance_id: (optional) Filter by resource instance id.
@@ -432,16 +472,18 @@ class UsageReportsV4(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `InstancesUsage` object
         """
 
-        if account_id is None:
+        if not account_id:
             raise ValueError('account_id must be provided')
-        if organization_id is None:
+        if not organization_id:
             raise ValueError('organization_id must be provided')
-        if billingmonth is None:
+        if not billingmonth:
             raise ValueError('billingmonth must be provided')
-        headers = {'Accept-Language': accept_language}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V4', operation_id='get_resource_usage_org'
-        )
+        headers = {
+            'Accept-Language': accept_language
+        }
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V4',
+                                      operation_id='get_resource_usage_org')
         headers.update(sdk_headers)
 
         params = {
@@ -451,22 +493,22 @@ class UsageReportsV4(BaseService):
             'resource_instance_id': resource_instance_id,
             'resource_id': resource_id,
             'plan_id': plan_id,
-            'region': region,
+            'region': region
         }
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['account_id', 'organization_id', 'billingmonth']
         path_param_values = self.encode_path_vars(account_id, organization_id, billingmonth)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = (
-            '/v4/accounts/{account_id}/organizations/{organization_id}/resource_instances/usage/{billingmonth}'.format(
-                **path_param_dict
-            )
-        )
-        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
+        url = '/v4/accounts/{account_id}/organizations/{organization_id}/resource_instances/usage/{billingmonth}'.format(**path_param_dict)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
 
         response = self.send(request, **kwargs)
         return response
@@ -475,8 +517,8 @@ class UsageReportsV4(BaseService):
     # Organization operations
     #########################
 
-    def get_org_usage(
-        self,
+
+    def get_org_usage(self,
         account_id: str,
         organization_id: str,
         billingmonth: str,
@@ -505,29 +547,37 @@ class UsageReportsV4(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `OrgUsage` object
         """
 
-        if account_id is None:
+        if not account_id:
             raise ValueError('account_id must be provided')
-        if organization_id is None:
+        if not organization_id:
             raise ValueError('organization_id must be provided')
-        if billingmonth is None:
+        if not billingmonth:
             raise ValueError('billingmonth must be provided')
-        headers = {'Accept-Language': accept_language}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V4', operation_id='get_org_usage'
-        )
+        headers = {
+            'Accept-Language': accept_language
+        }
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V4',
+                                      operation_id='get_org_usage')
         headers.update(sdk_headers)
 
-        params = {'_names': names}
+        params = {
+            '_names': names
+        }
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['account_id', 'organization_id', 'billingmonth']
         path_param_values = self.encode_path_vars(account_id, organization_id, billingmonth)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v4/accounts/{account_id}/organizations/{organization_id}/usage/{billingmonth}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
 
         response = self.send(request, **kwargs)
         return response
@@ -538,13 +588,13 @@ class UsageReportsV4(BaseService):
 ##############################################################################
 
 
-class AccountSummary:
+class AccountSummary():
     """
     A summary of charges and credits for an account.
 
     :attr str account_id: The ID of the account.
-    :attr str billing_month: The month in which usages were incurred. Represented in
-          yyyy-mm format.
+    :attr str month: The month in which usages were incurred. Represented in yyyy-mm
+          format.
     :attr str billing_country_code: Country.
     :attr str billing_currency_code: The currency in which the account is billed.
     :attr ResourcesSummary resources: Charges related to cloud resources.
@@ -555,23 +605,21 @@ class AccountSummary:
           to a subscription.
     """
 
-    def __init__(
-        self,
-        account_id: str,
-        billing_month: str,
-        billing_country_code: str,
-        billing_currency_code: str,
-        resources: 'ResourcesSummary',
-        offers: List['Offer'],
-        support: List['SupportSummary'],
-        subscription: 'SubscriptionSummary',
-    ) -> None:
+    def __init__(self,
+                 account_id: str,
+                 month: str,
+                 billing_country_code: str,
+                 billing_currency_code: str,
+                 resources: 'ResourcesSummary',
+                 offers: List['Offer'],
+                 support: List['SupportSummary'],
+                 subscription: 'SubscriptionSummary') -> None:
         """
         Initialize a AccountSummary object.
 
         :param str account_id: The ID of the account.
-        :param str billing_month: The month in which usages were incurred.
-               Represented in yyyy-mm format.
+        :param str month: The month in which usages were incurred. Represented in
+               yyyy-mm format.
         :param str billing_country_code: Country.
         :param str billing_currency_code: The currency in which the account is
                billed.
@@ -583,7 +631,7 @@ class AccountSummary:
                related to a subscription.
         """
         self.account_id = account_id
-        self.billing_month = billing_month
+        self.month = month
         self.billing_country_code = billing_country_code
         self.billing_currency_code = billing_currency_code
         self.resources = resources
@@ -599,10 +647,10 @@ class AccountSummary:
             args['account_id'] = _dict.get('account_id')
         else:
             raise ValueError('Required property \'account_id\' not present in AccountSummary JSON')
-        if 'billing_month' in _dict:
-            args['billing_month'] = _dict.get('billing_month')
+        if 'month' in _dict:
+            args['month'] = _dict.get('month')
         else:
-            raise ValueError('Required property \'billing_month\' not present in AccountSummary JSON')
+            raise ValueError('Required property \'month\' not present in AccountSummary JSON')
         if 'billing_country_code' in _dict:
             args['billing_country_code'] = _dict.get('billing_country_code')
         else:
@@ -616,11 +664,11 @@ class AccountSummary:
         else:
             raise ValueError('Required property \'resources\' not present in AccountSummary JSON')
         if 'offers' in _dict:
-            args['offers'] = [Offer.from_dict(x) for x in _dict.get('offers')]
+            args['offers'] = [Offer.from_dict(v) for v in _dict.get('offers')]
         else:
             raise ValueError('Required property \'offers\' not present in AccountSummary JSON')
         if 'support' in _dict:
-            args['support'] = [SupportSummary.from_dict(x) for x in _dict.get('support')]
+            args['support'] = [SupportSummary.from_dict(v) for v in _dict.get('support')]
         else:
             raise ValueError('Required property \'support\' not present in AccountSummary JSON')
         if 'subscription' in _dict:
@@ -639,20 +687,38 @@ class AccountSummary:
         _dict = {}
         if hasattr(self, 'account_id') and self.account_id is not None:
             _dict['account_id'] = self.account_id
-        if hasattr(self, 'billing_month') and self.billing_month is not None:
-            _dict['billing_month'] = self.billing_month
+        if hasattr(self, 'month') and self.month is not None:
+            _dict['month'] = self.month
         if hasattr(self, 'billing_country_code') and self.billing_country_code is not None:
             _dict['billing_country_code'] = self.billing_country_code
         if hasattr(self, 'billing_currency_code') and self.billing_currency_code is not None:
             _dict['billing_currency_code'] = self.billing_currency_code
         if hasattr(self, 'resources') and self.resources is not None:
-            _dict['resources'] = self.resources.to_dict()
+            if isinstance(self.resources, dict):
+                _dict['resources'] = self.resources
+            else:
+                _dict['resources'] = self.resources.to_dict()
         if hasattr(self, 'offers') and self.offers is not None:
-            _dict['offers'] = [x.to_dict() for x in self.offers]
+            offers_list = []
+            for v in self.offers:
+                if isinstance(v, dict):
+                    offers_list.append(v)
+                else:
+                    offers_list.append(v.to_dict())
+            _dict['offers'] = offers_list
         if hasattr(self, 'support') and self.support is not None:
-            _dict['support'] = [x.to_dict() for x in self.support]
+            support_list = []
+            for v in self.support:
+                if isinstance(v, dict):
+                    support_list.append(v)
+                else:
+                    support_list.append(v.to_dict())
+            _dict['support'] = support_list
         if hasattr(self, 'subscription') and self.subscription is not None:
-            _dict['subscription'] = self.subscription.to_dict()
+            if isinstance(self.subscription, dict):
+                _dict['subscription'] = self.subscription
+            else:
+                _dict['subscription'] = self.subscription.to_dict()
         return _dict
 
     def _to_dict(self):
@@ -673,8 +739,7 @@ class AccountSummary:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class AccountUsage:
+class AccountUsage():
     """
     The aggregated usage and charges for all the plans in the account.
 
@@ -686,9 +751,12 @@ class AccountUsage:
     :attr List[Resource] resources: All the resource used in the account.
     """
 
-    def __init__(
-        self, account_id: str, pricing_country: str, currency_code: str, month: str, resources: List['Resource']
-    ) -> None:
+    def __init__(self,
+                 account_id: str,
+                 pricing_country: str,
+                 currency_code: str,
+                 month: str,
+                 resources: List['Resource']) -> None:
         """
         Initialize a AccountUsage object.
 
@@ -726,7 +794,7 @@ class AccountUsage:
         else:
             raise ValueError('Required property \'month\' not present in AccountUsage JSON')
         if 'resources' in _dict:
-            args['resources'] = [Resource.from_dict(x) for x in _dict.get('resources')]
+            args['resources'] = [Resource.from_dict(v) for v in _dict.get('resources')]
         else:
             raise ValueError('Required property \'resources\' not present in AccountUsage JSON')
         return cls(**args)
@@ -748,7 +816,13 @@ class AccountUsage:
         if hasattr(self, 'month') and self.month is not None:
             _dict['month'] = self.month
         if hasattr(self, 'resources') and self.resources is not None:
-            _dict['resources'] = [x.to_dict() for x in self.resources]
+            resources_list = []
+            for v in self.resources:
+                if isinstance(v, dict):
+                    resources_list.append(v)
+                else:
+                    resources_list.append(v.to_dict())
+            _dict['resources'] = resources_list
         return _dict
 
     def _to_dict(self):
@@ -769,8 +843,7 @@ class AccountUsage:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class Discount:
+class Discount():
     """
     Information about a discount that is associated with a metric.
 
@@ -780,7 +853,12 @@ class Discount:
     :attr float discount: The discount percentage.
     """
 
-    def __init__(self, ref: str, discount: float, *, name: str = None, display_name: str = None) -> None:
+    def __init__(self,
+                 ref: str,
+                 discount: float,
+                 *,
+                 name: str = None,
+                 display_name: str = None) -> None:
         """
         Initialize a Discount object.
 
@@ -848,8 +926,7 @@ class Discount:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class InstanceUsage:
+class InstanceUsage():
     """
     The aggregated usage and charges for an instance.
 
@@ -880,31 +957,29 @@ class InstanceUsage:
     :attr List[Metric] usage: All the resource used in the account.
     """
 
-    def __init__(
-        self,
-        account_id: str,
-        resource_instance_id: str,
-        resource_id: str,
-        pricing_country: str,
-        currency_code: str,
-        billable: bool,
-        plan_id: str,
-        month: str,
-        usage: List['Metric'],
-        *,
-        resource_instance_name: str = None,
-        resource_name: str = None,
-        resource_group_id: str = None,
-        resource_group_name: str = None,
-        organization_id: str = None,
-        organization_name: str = None,
-        space_id: str = None,
-        space_name: str = None,
-        consumer_id: str = None,
-        region: str = None,
-        pricing_region: str = None,
-        plan_name: str = None
-    ) -> None:
+    def __init__(self,
+                 account_id: str,
+                 resource_instance_id: str,
+                 resource_id: str,
+                 pricing_country: str,
+                 currency_code: str,
+                 billable: bool,
+                 plan_id: str,
+                 month: str,
+                 usage: List['Metric'],
+                 *,
+                 resource_instance_name: str = None,
+                 resource_name: str = None,
+                 resource_group_id: str = None,
+                 resource_group_name: str = None,
+                 organization_id: str = None,
+                 organization_name: str = None,
+                 space_id: str = None,
+                 space_name: str = None,
+                 consumer_id: str = None,
+                 region: str = None,
+                 pricing_region: str = None,
+                 plan_name: str = None) -> None:
         """
         Initialize a InstanceUsage object.
 
@@ -1018,7 +1093,7 @@ class InstanceUsage:
         else:
             raise ValueError('Required property \'month\' not present in InstanceUsage JSON')
         if 'usage' in _dict:
-            args['usage'] = [Metric.from_dict(x) for x in _dict.get('usage')]
+            args['usage'] = [Metric.from_dict(v) for v in _dict.get('usage')]
         else:
             raise ValueError('Required property \'usage\' not present in InstanceUsage JSON')
         return cls(**args)
@@ -1072,7 +1147,13 @@ class InstanceUsage:
         if hasattr(self, 'month') and self.month is not None:
             _dict['month'] = self.month
         if hasattr(self, 'usage') and self.usage is not None:
-            _dict['usage'] = [x.to_dict() for x in self.usage]
+            usage_list = []
+            for v in self.usage:
+                if isinstance(v, dict):
+                    usage_list.append(v)
+                else:
+                    usage_list.append(v.to_dict())
+            _dict['usage'] = usage_list
         return _dict
 
     def _to_dict(self):
@@ -1093,15 +1174,16 @@ class InstanceUsage:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class InstancesUsageFirst:
+class InstancesUsageFirst():
     """
     The link to the first page of the search query.
 
     :attr str href: (optional) A link to a page of query results.
     """
 
-    def __init__(self, *, href: str = None) -> None:
+    def __init__(self,
+                 *,
+                 href: str = None) -> None:
         """
         Initialize a InstancesUsageFirst object.
 
@@ -1147,8 +1229,7 @@ class InstancesUsageFirst:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class InstancesUsageNext:
+class InstancesUsageNext():
     """
     The link to the next page of the search query.
 
@@ -1157,7 +1238,10 @@ class InstancesUsageNext:
           the next page.
     """
 
-    def __init__(self, *, href: str = None, offset: str = None) -> None:
+    def __init__(self,
+                 *,
+                 href: str = None,
+                 offset: str = None) -> None:
         """
         Initialize a InstancesUsageNext object.
 
@@ -1210,8 +1294,7 @@ class InstancesUsageNext:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class InstancesUsage:
+class InstancesUsage():
     """
     The list of instance usage reports.
 
@@ -1225,15 +1308,13 @@ class InstancesUsage:
           reports.
     """
 
-    def __init__(
-        self,
-        *,
-        limit: int = None,
-        count: int = None,
-        first: 'InstancesUsageFirst' = None,
-        next: 'InstancesUsageNext' = None,
-        resources: List['InstanceUsage'] = None
-    ) -> None:
+    def __init__(self,
+                 *,
+                 limit: int = None,
+                 count: int = None,
+                 first: 'InstancesUsageFirst' = None,
+                 next: 'InstancesUsageNext' = None,
+                 resources: List['InstanceUsage'] = None) -> None:
         """
         Initialize a InstancesUsage object.
 
@@ -1265,7 +1346,7 @@ class InstancesUsage:
         if 'next' in _dict:
             args['next'] = InstancesUsageNext.from_dict(_dict.get('next'))
         if 'resources' in _dict:
-            args['resources'] = [InstanceUsage.from_dict(x) for x in _dict.get('resources')]
+            args['resources'] = [InstanceUsage.from_dict(v) for v in _dict.get('resources')]
         return cls(**args)
 
     @classmethod
@@ -1281,11 +1362,23 @@ class InstancesUsage:
         if hasattr(self, 'count') and self.count is not None:
             _dict['count'] = self.count
         if hasattr(self, 'first') and self.first is not None:
-            _dict['first'] = self.first.to_dict()
+            if isinstance(self.first, dict):
+                _dict['first'] = self.first
+            else:
+                _dict['first'] = self.first.to_dict()
         if hasattr(self, 'next') and self.next is not None:
-            _dict['next'] = self.next.to_dict()
+            if isinstance(self.next, dict):
+                _dict['next'] = self.next
+            else:
+                _dict['next'] = self.next.to_dict()
         if hasattr(self, 'resources') and self.resources is not None:
-            _dict['resources'] = [x.to_dict() for x in self.resources]
+            resources_list = []
+            for v in self.resources:
+                if isinstance(v, dict):
+                    resources_list.append(v)
+                else:
+                    resources_list.append(v.to_dict())
+            _dict['resources'] = resources_list
         return _dict
 
     def _to_dict(self):
@@ -1306,8 +1399,7 @@ class InstancesUsage:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class Metric:
+class Metric():
     """
     Information about a metric.
 
@@ -1327,21 +1419,19 @@ class Metric:
     :attr List[Discount] discounts: All the discounts applicable to the metric.
     """
 
-    def __init__(
-        self,
-        metric: str,
-        quantity: float,
-        cost: float,
-        rated_cost: float,
-        discounts: List['Discount'],
-        *,
-        metric_name: str = None,
-        rateable_quantity: float = None,
-        price: List[object] = None,
-        unit: str = None,
-        unit_name: str = None,
-        non_chargeable: bool = None
-    ) -> None:
+    def __init__(self,
+                 metric: str,
+                 quantity: float,
+                 cost: float,
+                 rated_cost: float,
+                 discounts: List['Discount'],
+                 *,
+                 metric_name: str = None,
+                 rateable_quantity: float = None,
+                 price: List[object] = None,
+                 unit: str = None,
+                 unit_name: str = None,
+                 non_chargeable: bool = None) -> None:
         """
         Initialize a Metric object.
 
@@ -1407,7 +1497,7 @@ class Metric:
         if 'non_chargeable' in _dict:
             args['non_chargeable'] = _dict.get('non_chargeable')
         if 'discounts' in _dict:
-            args['discounts'] = [Discount.from_dict(x) for x in _dict.get('discounts')]
+            args['discounts'] = [Discount.from_dict(v) for v in _dict.get('discounts')]
         else:
             raise ValueError('Required property \'discounts\' not present in Metric JSON')
         return cls(**args)
@@ -1441,7 +1531,13 @@ class Metric:
         if hasattr(self, 'non_chargeable') and self.non_chargeable is not None:
             _dict['non_chargeable'] = self.non_chargeable
         if hasattr(self, 'discounts') and self.discounts is not None:
-            _dict['discounts'] = [x.to_dict() for x in self.discounts]
+            discounts_list = []
+            for v in self.discounts:
+                if isinstance(v, dict):
+                    discounts_list.append(v)
+                else:
+                    discounts_list.append(v.to_dict())
+            _dict['discounts'] = discounts_list
         return _dict
 
     def _to_dict(self):
@@ -1462,8 +1558,7 @@ class Metric:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class Offer:
+class Offer():
     """
     Information about an individual offer.
 
@@ -1475,15 +1570,13 @@ class Offer:
     :attr OfferCredits credits: Credit information related to an offer.
     """
 
-    def __init__(
-        self,
-        offer_id: str,
-        credits_total: float,
-        offer_template: str,
-        valid_from: datetime,
-        expires_on: datetime,
-        credits: 'OfferCredits',
-    ) -> None:
+    def __init__(self,
+                 offer_id: str,
+                 credits_total: float,
+                 offer_template: str,
+                 valid_from: datetime,
+                 expires_on: datetime,
+                 credits: 'OfferCredits') -> None:
         """
         Initialize a Offer object.
 
@@ -1550,7 +1643,10 @@ class Offer:
         if hasattr(self, 'expires_on') and self.expires_on is not None:
             _dict['expires_on'] = datetime_to_string(self.expires_on)
         if hasattr(self, 'credits') and self.credits is not None:
-            _dict['credits'] = self.credits.to_dict()
+            if isinstance(self.credits, dict):
+                _dict['credits'] = self.credits
+            else:
+                _dict['credits'] = self.credits.to_dict()
         return _dict
 
     def _to_dict(self):
@@ -1571,8 +1667,7 @@ class Offer:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class OfferCredits:
+class OfferCredits():
     """
     Credit information related to an offer.
 
@@ -1582,7 +1677,10 @@ class OfferCredits:
     :attr float balance: The remaining credits in the offer.
     """
 
-    def __init__(self, starting_balance: float, used: float, balance: float) -> None:
+    def __init__(self,
+                 starting_balance: float,
+                 used: float,
+                 balance: float) -> None:
         """
         Initialize a OfferCredits object.
 
@@ -1647,8 +1745,7 @@ class OfferCredits:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class OrgUsage:
+class OrgUsage():
     """
     The aggregated usage and charges for all the plans in the org.
 
@@ -1662,17 +1759,15 @@ class OrgUsage:
     :attr List[Resource] resources: All the resource used in the account.
     """
 
-    def __init__(
-        self,
-        account_id: str,
-        organization_id: str,
-        pricing_country: str,
-        currency_code: str,
-        month: str,
-        resources: List['Resource'],
-        *,
-        organization_name: str = None
-    ) -> None:
+    def __init__(self,
+                 account_id: str,
+                 organization_id: str,
+                 pricing_country: str,
+                 currency_code: str,
+                 month: str,
+                 resources: List['Resource'],
+                 *,
+                 organization_name: str = None) -> None:
         """
         Initialize a OrgUsage object.
 
@@ -1720,7 +1815,7 @@ class OrgUsage:
         else:
             raise ValueError('Required property \'month\' not present in OrgUsage JSON')
         if 'resources' in _dict:
-            args['resources'] = [Resource.from_dict(x) for x in _dict.get('resources')]
+            args['resources'] = [Resource.from_dict(v) for v in _dict.get('resources')]
         else:
             raise ValueError('Required property \'resources\' not present in OrgUsage JSON')
         return cls(**args)
@@ -1746,7 +1841,13 @@ class OrgUsage:
         if hasattr(self, 'month') and self.month is not None:
             _dict['month'] = self.month
         if hasattr(self, 'resources') and self.resources is not None:
-            _dict['resources'] = [x.to_dict() for x in self.resources]
+            resources_list = []
+            for v in self.resources:
+                if isinstance(v, dict):
+                    resources_list.append(v)
+                else:
+                    resources_list.append(v.to_dict())
+            _dict['resources'] = resources_list
         return _dict
 
     def _to_dict(self):
@@ -1767,8 +1868,7 @@ class OrgUsage:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class Plan:
+class Plan():
     """
     The aggregated values for the plan.
 
@@ -1782,18 +1882,16 @@ class Plan:
     :attr List[Discount] discounts: All the discounts applicable to the plan.
     """
 
-    def __init__(
-        self,
-        plan_id: str,
-        billable: bool,
-        cost: float,
-        rated_cost: float,
-        usage: List['Metric'],
-        discounts: List['Discount'],
-        *,
-        plan_name: str = None,
-        pricing_region: str = None
-    ) -> None:
+    def __init__(self,
+                 plan_id: str,
+                 billable: bool,
+                 cost: float,
+                 rated_cost: float,
+                 usage: List['Metric'],
+                 discounts: List['Discount'],
+                 *,
+                 plan_name: str = None,
+                 pricing_region: str = None) -> None:
         """
         Initialize a Plan object.
 
@@ -1841,11 +1939,11 @@ class Plan:
         else:
             raise ValueError('Required property \'rated_cost\' not present in Plan JSON')
         if 'usage' in _dict:
-            args['usage'] = [Metric.from_dict(x) for x in _dict.get('usage')]
+            args['usage'] = [Metric.from_dict(v) for v in _dict.get('usage')]
         else:
             raise ValueError('Required property \'usage\' not present in Plan JSON')
         if 'discounts' in _dict:
-            args['discounts'] = [Discount.from_dict(x) for x in _dict.get('discounts')]
+            args['discounts'] = [Discount.from_dict(v) for v in _dict.get('discounts')]
         else:
             raise ValueError('Required property \'discounts\' not present in Plan JSON')
         return cls(**args)
@@ -1871,9 +1969,21 @@ class Plan:
         if hasattr(self, 'rated_cost') and self.rated_cost is not None:
             _dict['rated_cost'] = self.rated_cost
         if hasattr(self, 'usage') and self.usage is not None:
-            _dict['usage'] = [x.to_dict() for x in self.usage]
+            usage_list = []
+            for v in self.usage:
+                if isinstance(v, dict):
+                    usage_list.append(v)
+                else:
+                    usage_list.append(v.to_dict())
+            _dict['usage'] = usage_list
         if hasattr(self, 'discounts') and self.discounts is not None:
-            _dict['discounts'] = [x.to_dict() for x in self.discounts]
+            discounts_list = []
+            for v in self.discounts:
+                if isinstance(v, dict):
+                    discounts_list.append(v)
+                else:
+                    discounts_list.append(v.to_dict())
+            _dict['discounts'] = discounts_list
         return _dict
 
     def _to_dict(self):
@@ -1894,8 +2004,7 @@ class Plan:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class Resource:
+class Resource():
     """
     The container for all the plans in the resource.
 
@@ -1911,18 +2020,16 @@ class Resource:
     :attr List[Discount] discounts: All the discounts applicable to the resource.
     """
 
-    def __init__(
-        self,
-        resource_id: str,
-        billable_cost: float,
-        billable_rated_cost: float,
-        non_billable_cost: float,
-        non_billable_rated_cost: float,
-        plans: List['Plan'],
-        discounts: List['Discount'],
-        *,
-        resource_name: str = None
-    ) -> None:
+    def __init__(self,
+                 resource_id: str,
+                 billable_cost: float,
+                 billable_rated_cost: float,
+                 non_billable_cost: float,
+                 non_billable_rated_cost: float,
+                 plans: List['Plan'],
+                 discounts: List['Discount'],
+                 *,
+                 resource_name: str = None) -> None:
         """
         Initialize a Resource object.
 
@@ -1974,11 +2081,11 @@ class Resource:
         else:
             raise ValueError('Required property \'non_billable_rated_cost\' not present in Resource JSON')
         if 'plans' in _dict:
-            args['plans'] = [Plan.from_dict(x) for x in _dict.get('plans')]
+            args['plans'] = [Plan.from_dict(v) for v in _dict.get('plans')]
         else:
             raise ValueError('Required property \'plans\' not present in Resource JSON')
         if 'discounts' in _dict:
-            args['discounts'] = [Discount.from_dict(x) for x in _dict.get('discounts')]
+            args['discounts'] = [Discount.from_dict(v) for v in _dict.get('discounts')]
         else:
             raise ValueError('Required property \'discounts\' not present in Resource JSON')
         return cls(**args)
@@ -2004,9 +2111,21 @@ class Resource:
         if hasattr(self, 'non_billable_rated_cost') and self.non_billable_rated_cost is not None:
             _dict['non_billable_rated_cost'] = self.non_billable_rated_cost
         if hasattr(self, 'plans') and self.plans is not None:
-            _dict['plans'] = [x.to_dict() for x in self.plans]
+            plans_list = []
+            for v in self.plans:
+                if isinstance(v, dict):
+                    plans_list.append(v)
+                else:
+                    plans_list.append(v.to_dict())
+            _dict['plans'] = plans_list
         if hasattr(self, 'discounts') and self.discounts is not None:
-            _dict['discounts'] = [x.to_dict() for x in self.discounts]
+            discounts_list = []
+            for v in self.discounts:
+                if isinstance(v, dict):
+                    discounts_list.append(v)
+                else:
+                    discounts_list.append(v.to_dict())
+            _dict['discounts'] = discounts_list
         return _dict
 
     def _to_dict(self):
@@ -2027,8 +2146,7 @@ class Resource:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class ResourceGroupUsage:
+class ResourceGroupUsage():
     """
     The aggregated usage and charges for all the plans in the resource group.
 
@@ -2042,17 +2160,15 @@ class ResourceGroupUsage:
     :attr List[Resource] resources: All the resource used in the account.
     """
 
-    def __init__(
-        self,
-        account_id: str,
-        resource_group_id: str,
-        pricing_country: str,
-        currency_code: str,
-        month: str,
-        resources: List['Resource'],
-        *,
-        resource_group_name: str = None
-    ) -> None:
+    def __init__(self,
+                 account_id: str,
+                 resource_group_id: str,
+                 pricing_country: str,
+                 currency_code: str,
+                 month: str,
+                 resources: List['Resource'],
+                 *,
+                 resource_group_name: str = None) -> None:
         """
         Initialize a ResourceGroupUsage object.
 
@@ -2100,7 +2216,7 @@ class ResourceGroupUsage:
         else:
             raise ValueError('Required property \'month\' not present in ResourceGroupUsage JSON')
         if 'resources' in _dict:
-            args['resources'] = [Resource.from_dict(x) for x in _dict.get('resources')]
+            args['resources'] = [Resource.from_dict(v) for v in _dict.get('resources')]
         else:
             raise ValueError('Required property \'resources\' not present in ResourceGroupUsage JSON')
         return cls(**args)
@@ -2126,7 +2242,13 @@ class ResourceGroupUsage:
         if hasattr(self, 'month') and self.month is not None:
             _dict['month'] = self.month
         if hasattr(self, 'resources') and self.resources is not None:
-            _dict['resources'] = [x.to_dict() for x in self.resources]
+            resources_list = []
+            for v in self.resources:
+                if isinstance(v, dict):
+                    resources_list.append(v)
+                else:
+                    resources_list.append(v.to_dict())
+            _dict['resources'] = resources_list
         return _dict
 
     def _to_dict(self):
@@ -2147,8 +2269,7 @@ class ResourceGroupUsage:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class ResourcesSummary:
+class ResourcesSummary():
     """
     Charges related to cloud resources.
 
@@ -2158,7 +2279,9 @@ class ResourcesSummary:
           in the account.
     """
 
-    def __init__(self, billable_cost: float, non_billable_cost: float) -> None:
+    def __init__(self,
+                 billable_cost: float,
+                 non_billable_cost: float) -> None:
         """
         Initialize a ResourcesSummary object.
 
@@ -2216,8 +2339,7 @@ class ResourcesSummary:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class Subscription:
+class Subscription():
     """
     Subscription.
 
@@ -2235,18 +2357,16 @@ class Subscription:
           split into.
     """
 
-    def __init__(
-        self,
-        subscription_id: str,
-        charge_agreement_number: str,
-        type: str,
-        subscription_amount: float,
-        start: datetime,
-        credits_total: float,
-        terms: List['SubscriptionTerm'],
-        *,
-        end: datetime = None
-    ) -> None:
+    def __init__(self,
+                 subscription_id: str,
+                 charge_agreement_number: str,
+                 type: str,
+                 subscription_amount: float,
+                 start: datetime,
+                 credits_total: float,
+                 terms: List['SubscriptionTerm'],
+                 *,
+                 end: datetime = None) -> None:
         """
         Initialize a Subscription object.
 
@@ -2304,7 +2424,7 @@ class Subscription:
         else:
             raise ValueError('Required property \'credits_total\' not present in Subscription JSON')
         if 'terms' in _dict:
-            args['terms'] = [SubscriptionTerm.from_dict(x) for x in _dict.get('terms')]
+            args['terms'] = [SubscriptionTerm.from_dict(v) for v in _dict.get('terms')]
         else:
             raise ValueError('Required property \'terms\' not present in Subscription JSON')
         return cls(**args)
@@ -2332,7 +2452,13 @@ class Subscription:
         if hasattr(self, 'credits_total') and self.credits_total is not None:
             _dict['credits_total'] = self.credits_total
         if hasattr(self, 'terms') and self.terms is not None:
-            _dict['terms'] = [x.to_dict() for x in self.terms]
+            terms_list = []
+            for v in self.terms:
+                if isinstance(v, dict):
+                    terms_list.append(v)
+                else:
+                    terms_list.append(v.to_dict())
+            _dict['terms'] = terms_list
         return _dict
 
     def _to_dict(self):
@@ -2353,8 +2479,7 @@ class Subscription:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class SubscriptionSummary:
+class SubscriptionSummary():
     """
     A summary of charges and credits related to a subscription.
 
@@ -2364,7 +2489,10 @@ class SubscriptionSummary:
           applicable for the month.
     """
 
-    def __init__(self, *, overage: float = None, subscriptions: List['Subscription'] = None) -> None:
+    def __init__(self,
+                 *,
+                 overage: float = None,
+                 subscriptions: List['Subscription'] = None) -> None:
         """
         Initialize a SubscriptionSummary object.
 
@@ -2383,7 +2511,7 @@ class SubscriptionSummary:
         if 'overage' in _dict:
             args['overage'] = _dict.get('overage')
         if 'subscriptions' in _dict:
-            args['subscriptions'] = [Subscription.from_dict(x) for x in _dict.get('subscriptions')]
+            args['subscriptions'] = [Subscription.from_dict(v) for v in _dict.get('subscriptions')]
         return cls(**args)
 
     @classmethod
@@ -2397,7 +2525,13 @@ class SubscriptionSummary:
         if hasattr(self, 'overage') and self.overage is not None:
             _dict['overage'] = self.overage
         if hasattr(self, 'subscriptions') and self.subscriptions is not None:
-            _dict['subscriptions'] = [x.to_dict() for x in self.subscriptions]
+            subscriptions_list = []
+            for v in self.subscriptions:
+                if isinstance(v, dict):
+                    subscriptions_list.append(v)
+                else:
+                    subscriptions_list.append(v.to_dict())
+            _dict['subscriptions'] = subscriptions_list
         return _dict
 
     def _to_dict(self):
@@ -2418,8 +2552,7 @@ class SubscriptionSummary:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class SubscriptionTerm:
+class SubscriptionTerm():
     """
     SubscriptionTerm.
 
@@ -2429,7 +2562,10 @@ class SubscriptionTerm:
           subscription.
     """
 
-    def __init__(self, start: datetime, end: datetime, credits: 'SubscriptionTermCredits') -> None:
+    def __init__(self,
+                 start: datetime,
+                 end: datetime,
+                 credits: 'SubscriptionTermCredits') -> None:
         """
         Initialize a SubscriptionTerm object.
 
@@ -2473,7 +2609,10 @@ class SubscriptionTerm:
         if hasattr(self, 'end') and self.end is not None:
             _dict['end'] = datetime_to_string(self.end)
         if hasattr(self, 'credits') and self.credits is not None:
-            _dict['credits'] = self.credits.to_dict()
+            if isinstance(self.credits, dict):
+                _dict['credits'] = self.credits
+            else:
+                _dict['credits'] = self.credits.to_dict()
         return _dict
 
     def _to_dict(self):
@@ -2494,8 +2633,7 @@ class SubscriptionTerm:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class SubscriptionTermCredits:
+class SubscriptionTermCredits():
     """
     Information about credits related to a subscription.
 
@@ -2506,7 +2644,11 @@ class SubscriptionTermCredits:
     :attr float balance: The remaining credits in this term.
     """
 
-    def __init__(self, total: float, starting_balance: float, used: float, balance: float) -> None:
+    def __init__(self,
+                 total: float,
+                 starting_balance: float,
+                 used: float,
+                 balance: float) -> None:
         """
         Initialize a SubscriptionTermCredits object.
 
@@ -2579,8 +2721,7 @@ class SubscriptionTermCredits:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class SupportSummary:
+class SupportSummary():
     """
     SupportSummary.
 
@@ -2589,7 +2730,10 @@ class SupportSummary:
     :attr float overage: Additional support cost for the month.
     """
 
-    def __init__(self, cost: float, type: str, overage: float) -> None:
+    def __init__(self,
+                 cost: float,
+                 type: str,
+                 overage: float) -> None:
         """
         Initialize a SupportSummary object.
 
@@ -2652,3 +2796,321 @@ class SupportSummary:
     def __ne__(self, other: 'SupportSummary') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
+
+##############################################################################
+# Pagers
+##############################################################################
+
+class GetResourceUsageAccountPager():
+    """
+    GetResourceUsageAccountPager can be used to simplify the use of the "get_resource_usage_account" method.
+    """
+
+    def __init__(self,
+                 *,
+                 client: UsageReportsV4,
+                 account_id: str,
+                 billingmonth: str,
+                 names: bool = None,
+                 accept_language: str = None,
+                 limit: int = None,
+                 resource_group_id: str = None,
+                 organization_id: str = None,
+                 resource_instance_id: str = None,
+                 resource_id: str = None,
+                 plan_id: str = None,
+                 region: str = None,
+    ) -> None:
+        """
+        Initialize a GetResourceUsageAccountPager object.
+        :param str account_id: Account ID for which the usage report is requested.
+        :param str billingmonth: The billing month for which the usage report is
+               requested.  Format is yyyy-mm.
+        :param bool names: (optional) Include the name of every resource, plan,
+               resource instance, organization, and resource group.
+        :param str accept_language: (optional) Prioritize the names returned in the
+               order of the specified languages. Language will default to English.
+        :param int limit: (optional) Number of usage records returned. The default
+               value is 30. Maximum value is 200.
+        :param str resource_group_id: (optional) Filter by resource group.
+        :param str organization_id: (optional) Filter by organization_id.
+        :param str resource_instance_id: (optional) Filter by resource instance_id.
+        :param str resource_id: (optional) Filter by resource_id.
+        :param str plan_id: (optional) Filter by plan_id.
+        :param str region: (optional) Region in which the resource instance is
+               provisioned.
+        """
+        self._has_next = True
+        self._client = client
+        self._page_context = { 'next': None }
+        self._account_id = account_id
+        self._billingmonth = billingmonth
+        self._names = names
+        self._accept_language = accept_language
+        self._limit = limit
+        self._resource_group_id = resource_group_id
+        self._organization_id = organization_id
+        self._resource_instance_id = resource_instance_id
+        self._resource_id = resource_id
+        self._plan_id = plan_id
+        self._region = region
+
+    def has_next(self) -> bool:
+        """
+        Returns true if there are potentially more results to be retrieved.
+        """
+        return self._has_next
+
+    def get_next(self) -> List[dict]:
+        """
+        Returns the next page of results.
+        :return: A List[dict], where each element is a dict that represents an instance of InstanceUsage.
+        :rtype: List[dict]
+        """
+        if not self.has_next():
+            raise StopIteration(message='No more results available')
+
+        result = self._client.get_resource_usage_account(
+            account_id=self._account_id,
+            billingmonth=self._billingmonth,
+            names=self._names,
+            accept_language=self._accept_language,
+            limit=self._limit,
+            resource_group_id=self._resource_group_id,
+            organization_id=self._organization_id,
+            resource_instance_id=self._resource_instance_id,
+            resource_id=self._resource_id,
+            plan_id=self._plan_id,
+            region=self._region,
+            start=self._page_context.get('next'),
+        ).get_result()
+
+        next = None
+        next_page_link = result.get('next')
+        if next_page_link is not None:
+            next = get_query_param(next_page_link.get('href'), '_start')
+        self._page_context['next'] = next
+        if next is None:
+            self._has_next = False
+
+        return result.get('resources')
+
+    def get_all(self) -> List[dict]:
+        """
+        Returns all results by invoking get_next() repeatedly
+        until all pages of results have been retrieved.
+        :return: A List[dict], where each element is a dict that represents an instance of InstanceUsage.
+        :rtype: List[dict]
+        """
+        results = []
+        while self.has_next():
+            next_page = self.get_next()
+            results.extend(next_page)
+        return results
+
+class GetResourceUsageResourceGroupPager():
+    """
+    GetResourceUsageResourceGroupPager can be used to simplify the use of the "get_resource_usage_resource_group" method.
+    """
+
+    def __init__(self,
+                 *,
+                 client: UsageReportsV4,
+                 account_id: str,
+                 resource_group_id: str,
+                 billingmonth: str,
+                 names: bool = None,
+                 accept_language: str = None,
+                 limit: int = None,
+                 resource_instance_id: str = None,
+                 resource_id: str = None,
+                 plan_id: str = None,
+                 region: str = None,
+    ) -> None:
+        """
+        Initialize a GetResourceUsageResourceGroupPager object.
+        :param str account_id: Account ID for which the usage report is requested.
+        :param str resource_group_id: Resource group for which the usage report is
+               requested.
+        :param str billingmonth: The billing month for which the usage report is
+               requested.  Format is yyyy-mm.
+        :param bool names: (optional) Include the name of every resource, plan,
+               resource instance, organization, and resource group.
+        :param str accept_language: (optional) Prioritize the names returned in the
+               order of the specified languages. Language will default to English.
+        :param int limit: (optional) Number of usage records returned. The default
+               value is 30. Maximum value is 200.
+        :param str resource_instance_id: (optional) Filter by resource instance id.
+        :param str resource_id: (optional) Filter by resource_id.
+        :param str plan_id: (optional) Filter by plan_id.
+        :param str region: (optional) Region in which the resource instance is
+               provisioned.
+        """
+        self._has_next = True
+        self._client = client
+        self._page_context = { 'next': None }
+        self._account_id = account_id
+        self._resource_group_id = resource_group_id
+        self._billingmonth = billingmonth
+        self._names = names
+        self._accept_language = accept_language
+        self._limit = limit
+        self._resource_instance_id = resource_instance_id
+        self._resource_id = resource_id
+        self._plan_id = plan_id
+        self._region = region
+
+    def has_next(self) -> bool:
+        """
+        Returns true if there are potentially more results to be retrieved.
+        """
+        return self._has_next
+
+    def get_next(self) -> List[dict]:
+        """
+        Returns the next page of results.
+        :return: A List[dict], where each element is a dict that represents an instance of InstanceUsage.
+        :rtype: List[dict]
+        """
+        if not self.has_next():
+            raise StopIteration(message='No more results available')
+
+        result = self._client.get_resource_usage_resource_group(
+            account_id=self._account_id,
+            resource_group_id=self._resource_group_id,
+            billingmonth=self._billingmonth,
+            names=self._names,
+            accept_language=self._accept_language,
+            limit=self._limit,
+            resource_instance_id=self._resource_instance_id,
+            resource_id=self._resource_id,
+            plan_id=self._plan_id,
+            region=self._region,
+            start=self._page_context.get('next'),
+        ).get_result()
+
+        next = None
+        next_page_link = result.get('next')
+        if next_page_link is not None:
+            next = get_query_param(next_page_link.get('href'), '_start')
+        self._page_context['next'] = next
+        if next is None:
+            self._has_next = False
+
+        return result.get('resources')
+
+    def get_all(self) -> List[dict]:
+        """
+        Returns all results by invoking get_next() repeatedly
+        until all pages of results have been retrieved.
+        :return: A List[dict], where each element is a dict that represents an instance of InstanceUsage.
+        :rtype: List[dict]
+        """
+        results = []
+        while self.has_next():
+            next_page = self.get_next()
+            results.extend(next_page)
+        return results
+
+class GetResourceUsageOrgPager():
+    """
+    GetResourceUsageOrgPager can be used to simplify the use of the "get_resource_usage_org" method.
+    """
+
+    def __init__(self,
+                 *,
+                 client: UsageReportsV4,
+                 account_id: str,
+                 organization_id: str,
+                 billingmonth: str,
+                 names: bool = None,
+                 accept_language: str = None,
+                 limit: int = None,
+                 resource_instance_id: str = None,
+                 resource_id: str = None,
+                 plan_id: str = None,
+                 region: str = None,
+    ) -> None:
+        """
+        Initialize a GetResourceUsageOrgPager object.
+        :param str account_id: Account ID for which the usage report is requested.
+        :param str organization_id: ID of the organization.
+        :param str billingmonth: The billing month for which the usage report is
+               requested.  Format is yyyy-mm.
+        :param bool names: (optional) Include the name of every resource, plan,
+               resource instance, organization, and resource group.
+        :param str accept_language: (optional) Prioritize the names returned in the
+               order of the specified languages. Language will default to English.
+        :param int limit: (optional) Number of usage records returned. The default
+               value is 30. Maximum value is 200.
+        :param str resource_instance_id: (optional) Filter by resource instance id.
+        :param str resource_id: (optional) Filter by resource_id.
+        :param str plan_id: (optional) Filter by plan_id.
+        :param str region: (optional) Region in which the resource instance is
+               provisioned.
+        """
+        self._has_next = True
+        self._client = client
+        self._page_context = { 'next': None }
+        self._account_id = account_id
+        self._organization_id = organization_id
+        self._billingmonth = billingmonth
+        self._names = names
+        self._accept_language = accept_language
+        self._limit = limit
+        self._resource_instance_id = resource_instance_id
+        self._resource_id = resource_id
+        self._plan_id = plan_id
+        self._region = region
+
+    def has_next(self) -> bool:
+        """
+        Returns true if there are potentially more results to be retrieved.
+        """
+        return self._has_next
+
+    def get_next(self) -> List[dict]:
+        """
+        Returns the next page of results.
+        :return: A List[dict], where each element is a dict that represents an instance of InstanceUsage.
+        :rtype: List[dict]
+        """
+        if not self.has_next():
+            raise StopIteration(message='No more results available')
+
+        result = self._client.get_resource_usage_org(
+            account_id=self._account_id,
+            organization_id=self._organization_id,
+            billingmonth=self._billingmonth,
+            names=self._names,
+            accept_language=self._accept_language,
+            limit=self._limit,
+            resource_instance_id=self._resource_instance_id,
+            resource_id=self._resource_id,
+            plan_id=self._plan_id,
+            region=self._region,
+            start=self._page_context.get('next'),
+        ).get_result()
+
+        next = None
+        next_page_link = result.get('next')
+        if next_page_link is not None:
+            next = get_query_param(next_page_link.get('href'), '_start')
+        self._page_context['next'] = next
+        if next is None:
+            self._has_next = False
+
+        return result.get('resources')
+
+    def get_all(self) -> List[dict]:
+        """
+        Returns all results by invoking get_next() repeatedly
+        until all pages of results have been retrieved.
+        :return: A List[dict], where each element is a dict that represents an instance of InstanceUsage.
+        :rtype: List[dict]
+        """
+        results = []
+        while self.has_next():
+            next_page = self.get_next()
+            results.extend(next_page)
+        return results

--- a/test/unit/test_usage_reports_v4.py
+++ b/test/unit/test_usage_reports_v4.py
@@ -31,9 +31,7 @@ import urllib
 from ibm_platform_services.usage_reports_v4 import *
 
 
-_service = UsageReportsV4(
-    authenticator=NoAuthAuthenticator()
-)
+_service = UsageReportsV4(authenticator=NoAuthAuthenticator())
 
 _base_url = 'https://billing.cloud.ibm.com'
 _service.set_service_url(_base_url)
@@ -70,7 +68,8 @@ def preprocess_url(operation_path: str):
 ##############################################################################
 # region
 
-class TestNewInstance():
+
+class TestNewInstance:
     """
     Test Class for new_instance
     """
@@ -97,7 +96,8 @@ class TestNewInstance():
                 service_name='TEST_SERVICE_NOT_FOUND',
             )
 
-class TestGetAccountSummary():
+
+class TestGetAccountSummary:
     """
     Test Class for get_account_summary
     """
@@ -110,22 +110,14 @@ class TestGetAccountSummary():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/summary/testString')
         mock_response = '{"account_id": "account_id", "month": "month", "billing_country_code": "billing_country_code", "billing_currency_code": "billing_currency_code", "resources": {"billable_cost": 13, "non_billable_cost": 17}, "offers": [{"offer_id": "offer_id", "credits_total": 13, "offer_template": "offer_template", "valid_from": "2019-01-01T12:00:00.000Z", "expires_on": "2019-01-01T12:00:00.000Z", "credits": {"starting_balance": 16, "used": 4, "balance": 7}}], "support": [{"cost": 4, "type": "type", "overage": 7}], "subscription": {"overage": 7, "subscriptions": [{"subscription_id": "subscription_id", "charge_agreement_number": "charge_agreement_number", "type": "type", "subscription_amount": 19, "start": "2019-01-01T12:00:00.000Z", "end": "2019-01-01T12:00:00.000Z", "credits_total": 13, "terms": [{"start": "2019-01-01T12:00:00.000Z", "end": "2019-01-01T12:00:00.000Z", "credits": {"total": 5, "starting_balance": 16, "used": 4, "balance": 7}}]}]}}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
         billingmonth = 'testString'
 
         # Invoke method
-        response = _service.get_account_summary(
-            account_id,
-            billingmonth,
-            headers={}
-        )
+        response = _service.get_account_summary(account_id, billingmonth, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -148,11 +140,7 @@ class TestGetAccountSummary():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/summary/testString')
         mock_response = '{"account_id": "account_id", "month": "month", "billing_country_code": "billing_country_code", "billing_currency_code": "billing_currency_code", "resources": {"billable_cost": 13, "non_billable_cost": 17}, "offers": [{"offer_id": "offer_id", "credits_total": 13, "offer_template": "offer_template", "valid_from": "2019-01-01T12:00:00.000Z", "expires_on": "2019-01-01T12:00:00.000Z", "credits": {"starting_balance": 16, "used": 4, "balance": 7}}], "support": [{"cost": 4, "type": "type", "overage": 7}], "subscription": {"overage": 7, "subscriptions": [{"subscription_id": "subscription_id", "charge_agreement_number": "charge_agreement_number", "type": "type", "subscription_amount": 19, "start": "2019-01-01T12:00:00.000Z", "end": "2019-01-01T12:00:00.000Z", "credits_total": 13, "terms": [{"start": "2019-01-01T12:00:00.000Z", "end": "2019-01-01T12:00:00.000Z", "credits": {"total": 5, "starting_balance": 16, "used": 4, "balance": 7}}]}]}}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -164,7 +152,7 @@ class TestGetAccountSummary():
             "billingmonth": billingmonth,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_account_summary(**req_copy)
 
@@ -177,7 +165,8 @@ class TestGetAccountSummary():
         _service.disable_retries()
         self.test_get_account_summary_value_error()
 
-class TestGetAccountUsage():
+
+class TestGetAccountUsage:
     """
     Test Class for get_account_usage
     """
@@ -190,11 +179,7 @@ class TestGetAccountUsage():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -204,18 +189,14 @@ class TestGetAccountUsage():
 
         # Invoke method
         response = _service.get_account_usage(
-            account_id,
-            billingmonth,
-            names=names,
-            accept_language=accept_language,
-            headers={}
+            account_id, billingmonth, names=names, accept_language=accept_language, headers={}
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert '_names={}'.format('true' if names else 'false') in query_string
 
@@ -236,22 +217,14 @@ class TestGetAccountUsage():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
         billingmonth = 'testString'
 
         # Invoke method
-        response = _service.get_account_usage(
-            account_id,
-            billingmonth,
-            headers={}
-        )
+        response = _service.get_account_usage(account_id, billingmonth, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -274,11 +247,7 @@ class TestGetAccountUsage():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -290,7 +259,7 @@ class TestGetAccountUsage():
             "billingmonth": billingmonth,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_account_usage(**req_copy)
 
@@ -303,6 +272,7 @@ class TestGetAccountUsage():
         _service.disable_retries()
         self.test_get_account_usage_value_error()
 
+
 # endregion
 ##############################################################################
 # End of Service: AccountOperations
@@ -313,7 +283,8 @@ class TestGetAccountUsage():
 ##############################################################################
 # region
 
-class TestNewInstance():
+
+class TestNewInstance:
     """
     Test Class for new_instance
     """
@@ -340,7 +311,8 @@ class TestNewInstance():
                 service_name='TEST_SERVICE_NOT_FOUND',
             )
 
-class TestGetResourceGroupUsage():
+
+class TestGetResourceGroupUsage:
     """
     Test Class for get_resource_group_usage
     """
@@ -353,11 +325,7 @@ class TestGetResourceGroupUsage():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/resource_groups/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -368,19 +336,14 @@ class TestGetResourceGroupUsage():
 
         # Invoke method
         response = _service.get_resource_group_usage(
-            account_id,
-            resource_group_id,
-            billingmonth,
-            names=names,
-            accept_language=accept_language,
-            headers={}
+            account_id, resource_group_id, billingmonth, names=names, accept_language=accept_language, headers={}
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert '_names={}'.format('true' if names else 'false') in query_string
 
@@ -401,11 +364,7 @@ class TestGetResourceGroupUsage():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/resource_groups/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -413,12 +372,7 @@ class TestGetResourceGroupUsage():
         billingmonth = 'testString'
 
         # Invoke method
-        response = _service.get_resource_group_usage(
-            account_id,
-            resource_group_id,
-            billingmonth,
-            headers={}
-        )
+        response = _service.get_resource_group_usage(account_id, resource_group_id, billingmonth, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -441,11 +395,7 @@ class TestGetResourceGroupUsage():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/resource_groups/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -459,7 +409,7 @@ class TestGetResourceGroupUsage():
             "billingmonth": billingmonth,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_resource_group_usage(**req_copy)
 
@@ -472,7 +422,8 @@ class TestGetResourceGroupUsage():
         _service.disable_retries()
         self.test_get_resource_group_usage_value_error()
 
-class TestGetResourceUsageAccount():
+
+class TestGetResourceUsageAccount:
     """
     Test Class for get_resource_usage_account
     """
@@ -485,11 +436,7 @@ class TestGetResourceUsageAccount():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -519,14 +466,14 @@ class TestGetResourceUsageAccount():
             resource_id=resource_id,
             plan_id=plan_id,
             region=region,
-            headers={}
+            headers={},
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert '_names={}'.format('true' if names else 'false') in query_string
         assert '_limit={}'.format(limit) in query_string
@@ -555,22 +502,14 @@ class TestGetResourceUsageAccount():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
         billingmonth = 'testString'
 
         # Invoke method
-        response = _service.get_resource_usage_account(
-            account_id,
-            billingmonth,
-            headers={}
-        )
+        response = _service.get_resource_usage_account(account_id, billingmonth, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -593,11 +532,7 @@ class TestGetResourceUsageAccount():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -609,7 +544,7 @@ class TestGetResourceUsageAccount():
             "billingmonth": billingmonth,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_resource_usage_account(**req_copy)
 
@@ -631,16 +566,8 @@ class TestGetResourceUsageAccount():
         url = preprocess_url('/v4/accounts/testString/resource_instances/usage/testString')
         mock_response1 = '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
         mock_response2 = '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response1,
-                      content_type='application/json',
-                      status=200)
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response2,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response1, content_type='application/json', status=200)
+        responses.add(responses.GET, url, body=mock_response2, content_type='application/json', status=200)
 
         # Exercise the pager class for this operation
         all_results = []
@@ -673,16 +600,8 @@ class TestGetResourceUsageAccount():
         url = preprocess_url('/v4/accounts/testString/resource_instances/usage/testString')
         mock_response1 = '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
         mock_response2 = '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response1,
-                      content_type='application/json',
-                      status=200)
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response2,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response1, content_type='application/json', status=200)
+        responses.add(responses.GET, url, body=mock_response2, content_type='application/json', status=200)
 
         # Exercise the pager class for this operation
         pager = GetResourceUsageAccountPager(
@@ -703,7 +622,8 @@ class TestGetResourceUsageAccount():
         assert all_results is not None
         assert len(all_results) == 2
 
-class TestGetResourceUsageResourceGroup():
+
+class TestGetResourceUsageResourceGroup:
     """
     Test Class for get_resource_usage_resource_group
     """
@@ -716,11 +636,7 @@ class TestGetResourceUsageResourceGroup():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/resource_groups/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -748,14 +664,14 @@ class TestGetResourceUsageResourceGroup():
             resource_id=resource_id,
             plan_id=plan_id,
             region=region,
-            headers={}
+            headers={},
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert '_names={}'.format('true' if names else 'false') in query_string
         assert '_limit={}'.format(limit) in query_string
@@ -782,11 +698,7 @@ class TestGetResourceUsageResourceGroup():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/resource_groups/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -794,12 +706,7 @@ class TestGetResourceUsageResourceGroup():
         billingmonth = 'testString'
 
         # Invoke method
-        response = _service.get_resource_usage_resource_group(
-            account_id,
-            resource_group_id,
-            billingmonth,
-            headers={}
-        )
+        response = _service.get_resource_usage_resource_group(account_id, resource_group_id, billingmonth, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -822,11 +729,7 @@ class TestGetResourceUsageResourceGroup():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/resource_groups/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -840,7 +743,7 @@ class TestGetResourceUsageResourceGroup():
             "billingmonth": billingmonth,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_resource_usage_resource_group(**req_copy)
 
@@ -862,16 +765,8 @@ class TestGetResourceUsageResourceGroup():
         url = preprocess_url('/v4/accounts/testString/resource_groups/testString/resource_instances/usage/testString')
         mock_response1 = '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
         mock_response2 = '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response1,
-                      content_type='application/json',
-                      status=200)
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response2,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response1, content_type='application/json', status=200)
+        responses.add(responses.GET, url, body=mock_response2, content_type='application/json', status=200)
 
         # Exercise the pager class for this operation
         all_results = []
@@ -903,16 +798,8 @@ class TestGetResourceUsageResourceGroup():
         url = preprocess_url('/v4/accounts/testString/resource_groups/testString/resource_instances/usage/testString')
         mock_response1 = '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
         mock_response2 = '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response1,
-                      content_type='application/json',
-                      status=200)
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response2,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response1, content_type='application/json', status=200)
+        responses.add(responses.GET, url, body=mock_response2, content_type='application/json', status=200)
 
         # Exercise the pager class for this operation
         pager = GetResourceUsageResourceGroupPager(
@@ -932,7 +819,8 @@ class TestGetResourceUsageResourceGroup():
         assert all_results is not None
         assert len(all_results) == 2
 
-class TestGetResourceUsageOrg():
+
+class TestGetResourceUsageOrg:
     """
     Test Class for get_resource_usage_org
     """
@@ -945,11 +833,7 @@ class TestGetResourceUsageOrg():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/organizations/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -977,14 +861,14 @@ class TestGetResourceUsageOrg():
             resource_id=resource_id,
             plan_id=plan_id,
             region=region,
-            headers={}
+            headers={},
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert '_names={}'.format('true' if names else 'false') in query_string
         assert '_limit={}'.format(limit) in query_string
@@ -1011,11 +895,7 @@ class TestGetResourceUsageOrg():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/organizations/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -1023,12 +903,7 @@ class TestGetResourceUsageOrg():
         billingmonth = 'testString'
 
         # Invoke method
-        response = _service.get_resource_usage_org(
-            account_id,
-            organization_id,
-            billingmonth,
-            headers={}
-        )
+        response = _service.get_resource_usage_org(account_id, organization_id, billingmonth, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1051,11 +926,7 @@ class TestGetResourceUsageOrg():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/organizations/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -1069,7 +940,7 @@ class TestGetResourceUsageOrg():
             "billingmonth": billingmonth,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_resource_usage_org(**req_copy)
 
@@ -1091,16 +962,8 @@ class TestGetResourceUsageOrg():
         url = preprocess_url('/v4/accounts/testString/organizations/testString/resource_instances/usage/testString')
         mock_response1 = '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
         mock_response2 = '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response1,
-                      content_type='application/json',
-                      status=200)
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response2,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response1, content_type='application/json', status=200)
+        responses.add(responses.GET, url, body=mock_response2, content_type='application/json', status=200)
 
         # Exercise the pager class for this operation
         all_results = []
@@ -1132,16 +995,8 @@ class TestGetResourceUsageOrg():
         url = preprocess_url('/v4/accounts/testString/organizations/testString/resource_instances/usage/testString')
         mock_response1 = '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
         mock_response2 = '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response1,
-                      content_type='application/json',
-                      status=200)
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response2,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response1, content_type='application/json', status=200)
+        responses.add(responses.GET, url, body=mock_response2, content_type='application/json', status=200)
 
         # Exercise the pager class for this operation
         pager = GetResourceUsageOrgPager(
@@ -1161,6 +1016,7 @@ class TestGetResourceUsageOrg():
         assert all_results is not None
         assert len(all_results) == 2
 
+
 # endregion
 ##############################################################################
 # End of Service: ResourceOperations
@@ -1171,7 +1027,8 @@ class TestGetResourceUsageOrg():
 ##############################################################################
 # region
 
-class TestNewInstance():
+
+class TestNewInstance:
     """
     Test Class for new_instance
     """
@@ -1198,7 +1055,8 @@ class TestNewInstance():
                 service_name='TEST_SERVICE_NOT_FOUND',
             )
 
-class TestGetOrgUsage():
+
+class TestGetOrgUsage:
     """
     Test Class for get_org_usage
     """
@@ -1211,11 +1069,7 @@ class TestGetOrgUsage():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/organizations/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "organization_id": "organization_id", "organization_name": "organization_name", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -1226,19 +1080,14 @@ class TestGetOrgUsage():
 
         # Invoke method
         response = _service.get_org_usage(
-            account_id,
-            organization_id,
-            billingmonth,
-            names=names,
-            accept_language=accept_language,
-            headers={}
+            account_id, organization_id, billingmonth, names=names, accept_language=accept_language, headers={}
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert '_names={}'.format('true' if names else 'false') in query_string
 
@@ -1259,11 +1108,7 @@ class TestGetOrgUsage():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/organizations/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "organization_id": "organization_id", "organization_name": "organization_name", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -1271,12 +1116,7 @@ class TestGetOrgUsage():
         billingmonth = 'testString'
 
         # Invoke method
-        response = _service.get_org_usage(
-            account_id,
-            organization_id,
-            billingmonth,
-            headers={}
-        )
+        response = _service.get_org_usage(account_id, organization_id, billingmonth, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1299,11 +1139,7 @@ class TestGetOrgUsage():
         # Set up mock
         url = preprocess_url('/v4/accounts/testString/organizations/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "organization_id": "organization_id", "organization_name": "organization_name", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -1317,7 +1153,7 @@ class TestGetOrgUsage():
             "billingmonth": billingmonth,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_org_usage(**req_copy)
 
@@ -1330,6 +1166,7 @@ class TestGetOrgUsage():
         _service.disable_retries()
         self.test_get_org_usage_value_error()
 
+
 # endregion
 ##############################################################################
 # End of Service: OrganizationOperations
@@ -1340,7 +1177,7 @@ class TestGetOrgUsage():
 # Start of Model Tests
 ##############################################################################
 # region
-class TestModel_AccountSummary():
+class TestModel_AccountSummary:
     """
     Test Class for AccountSummary
     """
@@ -1352,16 +1189,16 @@ class TestModel_AccountSummary():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        resources_summary_model = {} # ResourcesSummary
+        resources_summary_model = {}  # ResourcesSummary
         resources_summary_model['billable_cost'] = 72.5
         resources_summary_model['non_billable_cost'] = 72.5
 
-        offer_credits_model = {} # OfferCredits
+        offer_credits_model = {}  # OfferCredits
         offer_credits_model['starting_balance'] = 72.5
         offer_credits_model['used'] = 72.5
         offer_credits_model['balance'] = 72.5
 
-        offer_model = {} # Offer
+        offer_model = {}  # Offer
         offer_model['offer_id'] = 'testString'
         offer_model['credits_total'] = 72.5
         offer_model['offer_template'] = 'testString'
@@ -1369,23 +1206,23 @@ class TestModel_AccountSummary():
         offer_model['expires_on'] = '2019-01-01T12:00:00Z'
         offer_model['credits'] = offer_credits_model
 
-        support_summary_model = {} # SupportSummary
+        support_summary_model = {}  # SupportSummary
         support_summary_model['cost'] = 72.5
         support_summary_model['type'] = 'testString'
         support_summary_model['overage'] = 72.5
 
-        subscription_term_credits_model = {} # SubscriptionTermCredits
+        subscription_term_credits_model = {}  # SubscriptionTermCredits
         subscription_term_credits_model['total'] = 72.5
         subscription_term_credits_model['starting_balance'] = 72.5
         subscription_term_credits_model['used'] = 72.5
         subscription_term_credits_model['balance'] = 72.5
 
-        subscription_term_model = {} # SubscriptionTerm
+        subscription_term_model = {}  # SubscriptionTerm
         subscription_term_model['start'] = '2019-01-01T12:00:00Z'
         subscription_term_model['end'] = '2019-01-01T12:00:00Z'
         subscription_term_model['credits'] = subscription_term_credits_model
 
-        subscription_model = {} # Subscription
+        subscription_model = {}  # Subscription
         subscription_model['subscription_id'] = 'testString'
         subscription_model['charge_agreement_number'] = 'testString'
         subscription_model['type'] = 'testString'
@@ -1395,7 +1232,7 @@ class TestModel_AccountSummary():
         subscription_model['credits_total'] = 72.5
         subscription_model['terms'] = [subscription_term_model]
 
-        subscription_summary_model = {} # SubscriptionSummary
+        subscription_summary_model = {}  # SubscriptionSummary
         subscription_summary_model['overage'] = 72.5
         subscription_summary_model['subscriptions'] = [subscription_model]
 
@@ -1425,7 +1262,8 @@ class TestModel_AccountSummary():
         account_summary_model_json2 = account_summary_model.to_dict()
         assert account_summary_model_json2 == account_summary_model_json
 
-class TestModel_AccountUsage():
+
+class TestModel_AccountUsage:
     """
     Test Class for AccountUsage
     """
@@ -1437,13 +1275,13 @@ class TestModel_AccountUsage():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        discount_model = {} # Discount
+        discount_model = {}  # Discount
         discount_model['ref'] = 'Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9'
         discount_model['name'] = 'platform-discount'
         discount_model['display_name'] = 'Platform Service Discount'
         discount_model['discount'] = 5
 
-        metric_model = {} # Metric
+        metric_model = {}  # Metric
         metric_model['metric'] = 'UP-TIME'
         metric_model['metric_name'] = 'UP-TIME'
         metric_model['quantity'] = 711.11
@@ -1456,7 +1294,7 @@ class TestModel_AccountUsage():
         metric_model['non_chargeable'] = True
         metric_model['discounts'] = [discount_model]
 
-        plan_model = {} # Plan
+        plan_model = {}  # Plan
         plan_model['plan_id'] = 'testString'
         plan_model['plan_name'] = 'testString'
         plan_model['pricing_region'] = 'testString'
@@ -1466,7 +1304,7 @@ class TestModel_AccountUsage():
         plan_model['usage'] = [metric_model]
         plan_model['discounts'] = [discount_model]
 
-        resource_model = {} # Resource
+        resource_model = {}  # Resource
         resource_model['resource_id'] = 'testString'
         resource_model['resource_name'] = 'testString'
         resource_model['billable_cost'] = 72.5
@@ -1499,7 +1337,8 @@ class TestModel_AccountUsage():
         account_usage_model_json2 = account_usage_model.to_dict()
         assert account_usage_model_json2 == account_usage_model_json
 
-class TestModel_Discount():
+
+class TestModel_Discount:
     """
     Test Class for Discount
     """
@@ -1531,7 +1370,8 @@ class TestModel_Discount():
         discount_model_json2 = discount_model.to_dict()
         assert discount_model_json2 == discount_model_json
 
-class TestModel_InstanceUsage():
+
+class TestModel_InstanceUsage:
     """
     Test Class for InstanceUsage
     """
@@ -1543,13 +1383,13 @@ class TestModel_InstanceUsage():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        discount_model = {} # Discount
+        discount_model = {}  # Discount
         discount_model['ref'] = 'Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9'
         discount_model['name'] = 'platform-discount'
         discount_model['display_name'] = 'Platform Service Discount'
         discount_model['discount'] = 5
 
-        metric_model = {} # Metric
+        metric_model = {}  # Metric
         metric_model['metric'] = 'UP-TIME'
         metric_model['metric_name'] = 'UP-TIME'
         metric_model['quantity'] = 711.11
@@ -1601,7 +1441,8 @@ class TestModel_InstanceUsage():
         instance_usage_model_json2 = instance_usage_model.to_dict()
         assert instance_usage_model_json2 == instance_usage_model_json
 
-class TestModel_InstancesUsageFirst():
+
+class TestModel_InstancesUsageFirst:
     """
     Test Class for InstancesUsageFirst
     """
@@ -1630,7 +1471,8 @@ class TestModel_InstancesUsageFirst():
         instances_usage_first_model_json2 = instances_usage_first_model.to_dict()
         assert instances_usage_first_model_json2 == instances_usage_first_model_json
 
-class TestModel_InstancesUsageNext():
+
+class TestModel_InstancesUsageNext:
     """
     Test Class for InstancesUsageNext
     """
@@ -1660,7 +1502,8 @@ class TestModel_InstancesUsageNext():
         instances_usage_next_model_json2 = instances_usage_next_model.to_dict()
         assert instances_usage_next_model_json2 == instances_usage_next_model_json
 
-class TestModel_InstancesUsage():
+
+class TestModel_InstancesUsage:
     """
     Test Class for InstancesUsage
     """
@@ -1672,20 +1515,20 @@ class TestModel_InstancesUsage():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        instances_usage_first_model = {} # InstancesUsageFirst
+        instances_usage_first_model = {}  # InstancesUsageFirst
         instances_usage_first_model['href'] = 'testString'
 
-        instances_usage_next_model = {} # InstancesUsageNext
+        instances_usage_next_model = {}  # InstancesUsageNext
         instances_usage_next_model['href'] = 'testString'
         instances_usage_next_model['offset'] = 'testString'
 
-        discount_model = {} # Discount
+        discount_model = {}  # Discount
         discount_model['ref'] = 'Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9'
         discount_model['name'] = 'platform-discount'
         discount_model['display_name'] = 'Platform Service Discount'
         discount_model['discount'] = 5
 
-        metric_model = {} # Metric
+        metric_model = {}  # Metric
         metric_model['metric'] = 'UP-TIME'
         metric_model['metric_name'] = 'UP-TIME'
         metric_model['quantity'] = 711.11
@@ -1698,7 +1541,7 @@ class TestModel_InstancesUsage():
         metric_model['non_chargeable'] = True
         metric_model['discounts'] = [discount_model]
 
-        instance_usage_model = {} # InstanceUsage
+        instance_usage_model = {}  # InstanceUsage
         instance_usage_model['account_id'] = 'testString'
         instance_usage_model['resource_instance_id'] = 'testString'
         instance_usage_model['resource_instance_name'] = 'testString'
@@ -1744,7 +1587,8 @@ class TestModel_InstancesUsage():
         instances_usage_model_json2 = instances_usage_model.to_dict()
         assert instances_usage_model_json2 == instances_usage_model_json
 
-class TestModel_Metric():
+
+class TestModel_Metric:
     """
     Test Class for Metric
     """
@@ -1756,7 +1600,7 @@ class TestModel_Metric():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        discount_model = {} # Discount
+        discount_model = {}  # Discount
         discount_model['ref'] = 'Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9'
         discount_model['name'] = 'platform-discount'
         discount_model['display_name'] = 'Platform Service Discount'
@@ -1791,7 +1635,8 @@ class TestModel_Metric():
         metric_model_json2 = metric_model.to_dict()
         assert metric_model_json2 == metric_model_json
 
-class TestModel_Offer():
+
+class TestModel_Offer:
     """
     Test Class for Offer
     """
@@ -1803,7 +1648,7 @@ class TestModel_Offer():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        offer_credits_model = {} # OfferCredits
+        offer_credits_model = {}  # OfferCredits
         offer_credits_model['starting_balance'] = 72.5
         offer_credits_model['used'] = 72.5
         offer_credits_model['balance'] = 72.5
@@ -1832,7 +1677,8 @@ class TestModel_Offer():
         offer_model_json2 = offer_model.to_dict()
         assert offer_model_json2 == offer_model_json
 
-class TestModel_OfferCredits():
+
+class TestModel_OfferCredits:
     """
     Test Class for OfferCredits
     """
@@ -1863,7 +1709,8 @@ class TestModel_OfferCredits():
         offer_credits_model_json2 = offer_credits_model.to_dict()
         assert offer_credits_model_json2 == offer_credits_model_json
 
-class TestModel_OrgUsage():
+
+class TestModel_OrgUsage:
     """
     Test Class for OrgUsage
     """
@@ -1875,13 +1722,13 @@ class TestModel_OrgUsage():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        discount_model = {} # Discount
+        discount_model = {}  # Discount
         discount_model['ref'] = 'Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9'
         discount_model['name'] = 'platform-discount'
         discount_model['display_name'] = 'Platform Service Discount'
         discount_model['discount'] = 5
 
-        metric_model = {} # Metric
+        metric_model = {}  # Metric
         metric_model['metric'] = 'UP-TIME'
         metric_model['metric_name'] = 'UP-TIME'
         metric_model['quantity'] = 711.11
@@ -1894,7 +1741,7 @@ class TestModel_OrgUsage():
         metric_model['non_chargeable'] = True
         metric_model['discounts'] = [discount_model]
 
-        plan_model = {} # Plan
+        plan_model = {}  # Plan
         plan_model['plan_id'] = 'testString'
         plan_model['plan_name'] = 'testString'
         plan_model['pricing_region'] = 'testString'
@@ -1904,7 +1751,7 @@ class TestModel_OrgUsage():
         plan_model['usage'] = [metric_model]
         plan_model['discounts'] = [discount_model]
 
-        resource_model = {} # Resource
+        resource_model = {}  # Resource
         resource_model['resource_id'] = 'testString'
         resource_model['resource_name'] = 'testString'
         resource_model['billable_cost'] = 72.5
@@ -1939,7 +1786,8 @@ class TestModel_OrgUsage():
         org_usage_model_json2 = org_usage_model.to_dict()
         assert org_usage_model_json2 == org_usage_model_json
 
-class TestModel_Plan():
+
+class TestModel_Plan:
     """
     Test Class for Plan
     """
@@ -1951,13 +1799,13 @@ class TestModel_Plan():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        discount_model = {} # Discount
+        discount_model = {}  # Discount
         discount_model['ref'] = 'Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9'
         discount_model['name'] = 'platform-discount'
         discount_model['display_name'] = 'Platform Service Discount'
         discount_model['discount'] = 5
 
-        metric_model = {} # Metric
+        metric_model = {}  # Metric
         metric_model['metric'] = 'UP-TIME'
         metric_model['metric_name'] = 'UP-TIME'
         metric_model['quantity'] = 711.11
@@ -1996,7 +1844,8 @@ class TestModel_Plan():
         plan_model_json2 = plan_model.to_dict()
         assert plan_model_json2 == plan_model_json
 
-class TestModel_Resource():
+
+class TestModel_Resource:
     """
     Test Class for Resource
     """
@@ -2008,13 +1857,13 @@ class TestModel_Resource():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        discount_model = {} # Discount
+        discount_model = {}  # Discount
         discount_model['ref'] = 'Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9'
         discount_model['name'] = 'platform-discount'
         discount_model['display_name'] = 'Platform Service Discount'
         discount_model['discount'] = 5
 
-        metric_model = {} # Metric
+        metric_model = {}  # Metric
         metric_model['metric'] = 'UP-TIME'
         metric_model['metric_name'] = 'UP-TIME'
         metric_model['quantity'] = 711.11
@@ -2027,7 +1876,7 @@ class TestModel_Resource():
         metric_model['non_chargeable'] = True
         metric_model['discounts'] = [discount_model]
 
-        plan_model = {} # Plan
+        plan_model = {}  # Plan
         plan_model['plan_id'] = 'testString'
         plan_model['plan_name'] = 'testString'
         plan_model['pricing_region'] = 'testString'
@@ -2063,7 +1912,8 @@ class TestModel_Resource():
         resource_model_json2 = resource_model.to_dict()
         assert resource_model_json2 == resource_model_json
 
-class TestModel_ResourceGroupUsage():
+
+class TestModel_ResourceGroupUsage:
     """
     Test Class for ResourceGroupUsage
     """
@@ -2075,13 +1925,13 @@ class TestModel_ResourceGroupUsage():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        discount_model = {} # Discount
+        discount_model = {}  # Discount
         discount_model['ref'] = 'Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9'
         discount_model['name'] = 'platform-discount'
         discount_model['display_name'] = 'Platform Service Discount'
         discount_model['discount'] = 5
 
-        metric_model = {} # Metric
+        metric_model = {}  # Metric
         metric_model['metric'] = 'UP-TIME'
         metric_model['metric_name'] = 'UP-TIME'
         metric_model['quantity'] = 711.11
@@ -2094,7 +1944,7 @@ class TestModel_ResourceGroupUsage():
         metric_model['non_chargeable'] = True
         metric_model['discounts'] = [discount_model]
 
-        plan_model = {} # Plan
+        plan_model = {}  # Plan
         plan_model['plan_id'] = 'testString'
         plan_model['plan_name'] = 'testString'
         plan_model['pricing_region'] = 'testString'
@@ -2104,7 +1954,7 @@ class TestModel_ResourceGroupUsage():
         plan_model['usage'] = [metric_model]
         plan_model['discounts'] = [discount_model]
 
-        resource_model = {} # Resource
+        resource_model = {}  # Resource
         resource_model['resource_id'] = 'testString'
         resource_model['resource_name'] = 'testString'
         resource_model['billable_cost'] = 72.5
@@ -2139,7 +1989,8 @@ class TestModel_ResourceGroupUsage():
         resource_group_usage_model_json2 = resource_group_usage_model.to_dict()
         assert resource_group_usage_model_json2 == resource_group_usage_model_json
 
-class TestModel_ResourcesSummary():
+
+class TestModel_ResourcesSummary:
     """
     Test Class for ResourcesSummary
     """
@@ -2169,7 +2020,8 @@ class TestModel_ResourcesSummary():
         resources_summary_model_json2 = resources_summary_model.to_dict()
         assert resources_summary_model_json2 == resources_summary_model_json
 
-class TestModel_Subscription():
+
+class TestModel_Subscription:
     """
     Test Class for Subscription
     """
@@ -2181,13 +2033,13 @@ class TestModel_Subscription():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        subscription_term_credits_model = {} # SubscriptionTermCredits
+        subscription_term_credits_model = {}  # SubscriptionTermCredits
         subscription_term_credits_model['total'] = 72.5
         subscription_term_credits_model['starting_balance'] = 72.5
         subscription_term_credits_model['used'] = 72.5
         subscription_term_credits_model['balance'] = 72.5
 
-        subscription_term_model = {} # SubscriptionTerm
+        subscription_term_model = {}  # SubscriptionTerm
         subscription_term_model['start'] = '2019-01-01T12:00:00Z'
         subscription_term_model['end'] = '2019-01-01T12:00:00Z'
         subscription_term_model['credits'] = subscription_term_credits_model
@@ -2218,7 +2070,8 @@ class TestModel_Subscription():
         subscription_model_json2 = subscription_model.to_dict()
         assert subscription_model_json2 == subscription_model_json
 
-class TestModel_SubscriptionSummary():
+
+class TestModel_SubscriptionSummary:
     """
     Test Class for SubscriptionSummary
     """
@@ -2230,18 +2083,18 @@ class TestModel_SubscriptionSummary():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        subscription_term_credits_model = {} # SubscriptionTermCredits
+        subscription_term_credits_model = {}  # SubscriptionTermCredits
         subscription_term_credits_model['total'] = 72.5
         subscription_term_credits_model['starting_balance'] = 72.5
         subscription_term_credits_model['used'] = 72.5
         subscription_term_credits_model['balance'] = 72.5
 
-        subscription_term_model = {} # SubscriptionTerm
+        subscription_term_model = {}  # SubscriptionTerm
         subscription_term_model['start'] = '2019-01-01T12:00:00Z'
         subscription_term_model['end'] = '2019-01-01T12:00:00Z'
         subscription_term_model['credits'] = subscription_term_credits_model
 
-        subscription_model = {} # Subscription
+        subscription_model = {}  # Subscription
         subscription_model['subscription_id'] = 'testString'
         subscription_model['charge_agreement_number'] = 'testString'
         subscription_model['type'] = 'testString'
@@ -2271,7 +2124,8 @@ class TestModel_SubscriptionSummary():
         subscription_summary_model_json2 = subscription_summary_model.to_dict()
         assert subscription_summary_model_json2 == subscription_summary_model_json
 
-class TestModel_SubscriptionTerm():
+
+class TestModel_SubscriptionTerm:
     """
     Test Class for SubscriptionTerm
     """
@@ -2283,7 +2137,7 @@ class TestModel_SubscriptionTerm():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        subscription_term_credits_model = {} # SubscriptionTermCredits
+        subscription_term_credits_model = {}  # SubscriptionTermCredits
         subscription_term_credits_model['total'] = 72.5
         subscription_term_credits_model['starting_balance'] = 72.5
         subscription_term_credits_model['used'] = 72.5
@@ -2310,7 +2164,8 @@ class TestModel_SubscriptionTerm():
         subscription_term_model_json2 = subscription_term_model.to_dict()
         assert subscription_term_model_json2 == subscription_term_model_json
 
-class TestModel_SubscriptionTermCredits():
+
+class TestModel_SubscriptionTermCredits:
     """
     Test Class for SubscriptionTermCredits
     """
@@ -2332,7 +2187,9 @@ class TestModel_SubscriptionTermCredits():
         assert subscription_term_credits_model != False
 
         # Construct a model instance of SubscriptionTermCredits by calling from_dict on the json representation
-        subscription_term_credits_model_dict = SubscriptionTermCredits.from_dict(subscription_term_credits_model_json).__dict__
+        subscription_term_credits_model_dict = SubscriptionTermCredits.from_dict(
+            subscription_term_credits_model_json
+        ).__dict__
         subscription_term_credits_model2 = SubscriptionTermCredits(**subscription_term_credits_model_dict)
 
         # Verify the model instances are equivalent
@@ -2342,7 +2199,8 @@ class TestModel_SubscriptionTermCredits():
         subscription_term_credits_model_json2 = subscription_term_credits_model.to_dict()
         assert subscription_term_credits_model_json2 == subscription_term_credits_model_json
 
-class TestModel_SupportSummary():
+
+class TestModel_SupportSummary:
     """
     Test Class for SupportSummary
     """

--- a/test/unit/test_usage_reports_v4.py
+++ b/test/unit/test_usage_reports_v4.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (C) Copyright IBM Corp. 2021.
+# (C) Copyright IBM Corp. 2022.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,18 +31,46 @@ import urllib
 from ibm_platform_services.usage_reports_v4 import *
 
 
-_service = UsageReportsV4(authenticator=NoAuthAuthenticator())
+_service = UsageReportsV4(
+    authenticator=NoAuthAuthenticator()
+)
 
 _base_url = 'https://billing.cloud.ibm.com'
 _service.set_service_url(_base_url)
+
+
+def preprocess_url(operation_path: str):
+    """
+    Returns the request url associated with the specified operation path.
+    This will be base_url concatenated with a quoted version of operation_path.
+    The returned request URL is used to register the mock response so it needs
+    to match the request URL that is formed by the requests library.
+    """
+    # First, unquote the path since it might have some quoted/escaped characters in it
+    # due to how the generator inserts the operation paths into the unit test code.
+    operation_path = urllib.parse.unquote(operation_path)
+
+    # Next, quote the path using urllib so that we approximate what will
+    # happen during request processing.
+    operation_path = urllib.parse.quote(operation_path, safe='/')
+
+    # Finally, form the request URL from the base URL and operation path.
+    request_url = _base_url + operation_path
+
+    # If the request url does NOT end with a /, then just return it as-is.
+    # Otherwise, return a regular expression that matches one or more trailing /.
+    if re.fullmatch('.*/+', request_url) is None:
+        return request_url
+    else:
+        return re.compile(request_url.rstrip('/') + '/+')
+
 
 ##############################################################################
 # Start of Service: AccountOperations
 ##############################################################################
 # region
 
-
-class TestNewInstance:
+class TestNewInstance():
     """
     Test Class for new_instance
     """
@@ -65,24 +93,14 @@ class TestNewInstance:
         new_instance_without_authenticator()
         """
         with pytest.raises(ValueError, match='authenticator must be provided'):
-            service = UsageReportsV4.new_instance()
+            service = UsageReportsV4.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
 
-
-class TestGetAccountSummary:
+class TestGetAccountSummary():
     """
     Test Class for get_account_summary
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_get_account_summary_all_params(self):
@@ -90,20 +108,37 @@ class TestGetAccountSummary:
         get_account_summary()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v4/accounts/testString/summary/testString')
-        mock_response = '{"account_id": "account_id", "billing_month": "billing_month", "billing_country_code": "billing_country_code", "billing_currency_code": "billing_currency_code", "resources": {"billable_cost": 13, "non_billable_cost": 17}, "offers": [{"offer_id": "offer_id", "credits_total": 13, "offer_template": "offer_template", "valid_from": "2019-01-01T12:00:00.000Z", "expires_on": "2019-01-01T12:00:00.000Z", "credits": {"starting_balance": 16, "used": 4, "balance": 7}}], "support": [{"cost": 4, "type": "type", "overage": 7}], "subscription": {"overage": 7, "subscriptions": [{"subscription_id": "subscription_id", "charge_agreement_number": "charge_agreement_number", "type": "type", "subscription_amount": 19, "start": "2019-01-01T12:00:00.000Z", "end": "2019-01-01T12:00:00.000Z", "credits_total": 13, "terms": [{"start": "2019-01-01T12:00:00.000Z", "end": "2019-01-01T12:00:00.000Z", "credits": {"total": 5, "starting_balance": 16, "used": 4, "balance": 7}}]}]}}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        url = preprocess_url('/v4/accounts/testString/summary/testString')
+        mock_response = '{"account_id": "account_id", "month": "month", "billing_country_code": "billing_country_code", "billing_currency_code": "billing_currency_code", "resources": {"billable_cost": 13, "non_billable_cost": 17}, "offers": [{"offer_id": "offer_id", "credits_total": 13, "offer_template": "offer_template", "valid_from": "2019-01-01T12:00:00.000Z", "expires_on": "2019-01-01T12:00:00.000Z", "credits": {"starting_balance": 16, "used": 4, "balance": 7}}], "support": [{"cost": 4, "type": "type", "overage": 7}], "subscription": {"overage": 7, "subscriptions": [{"subscription_id": "subscription_id", "charge_agreement_number": "charge_agreement_number", "type": "type", "subscription_amount": 19, "start": "2019-01-01T12:00:00.000Z", "end": "2019-01-01T12:00:00.000Z", "credits_total": 13, "terms": [{"start": "2019-01-01T12:00:00.000Z", "end": "2019-01-01T12:00:00.000Z", "credits": {"total": 5, "starting_balance": 16, "used": 4, "balance": 7}}]}]}}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
         billingmonth = 'testString'
 
         # Invoke method
-        response = _service.get_account_summary(account_id, billingmonth, headers={})
+        response = _service.get_account_summary(
+            account_id,
+            billingmonth,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
+
+    def test_get_account_summary_all_params_with_retries(self):
+        # Enable retries and run test_get_account_summary_all_params.
+        _service.enable_retries()
+        self.test_get_account_summary_all_params()
+
+        # Disable retries and run test_get_account_summary_all_params.
+        _service.disable_retries()
+        self.test_get_account_summary_all_params()
 
     @responses.activate
     def test_get_account_summary_value_error(self):
@@ -111,9 +146,13 @@ class TestGetAccountSummary:
         test_get_account_summary_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v4/accounts/testString/summary/testString')
-        mock_response = '{"account_id": "account_id", "billing_month": "billing_month", "billing_country_code": "billing_country_code", "billing_currency_code": "billing_currency_code", "resources": {"billable_cost": 13, "non_billable_cost": 17}, "offers": [{"offer_id": "offer_id", "credits_total": 13, "offer_template": "offer_template", "valid_from": "2019-01-01T12:00:00.000Z", "expires_on": "2019-01-01T12:00:00.000Z", "credits": {"starting_balance": 16, "used": 4, "balance": 7}}], "support": [{"cost": 4, "type": "type", "overage": 7}], "subscription": {"overage": 7, "subscriptions": [{"subscription_id": "subscription_id", "charge_agreement_number": "charge_agreement_number", "type": "type", "subscription_amount": 19, "start": "2019-01-01T12:00:00.000Z", "end": "2019-01-01T12:00:00.000Z", "credits_total": 13, "terms": [{"start": "2019-01-01T12:00:00.000Z", "end": "2019-01-01T12:00:00.000Z", "credits": {"total": 5, "starting_balance": 16, "used": 4, "balance": 7}}]}]}}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        url = preprocess_url('/v4/accounts/testString/summary/testString')
+        mock_response = '{"account_id": "account_id", "month": "month", "billing_country_code": "billing_country_code", "billing_currency_code": "billing_currency_code", "resources": {"billable_cost": 13, "non_billable_cost": 17}, "offers": [{"offer_id": "offer_id", "credits_total": 13, "offer_template": "offer_template", "valid_from": "2019-01-01T12:00:00.000Z", "expires_on": "2019-01-01T12:00:00.000Z", "credits": {"starting_balance": 16, "used": 4, "balance": 7}}], "support": [{"cost": 4, "type": "type", "overage": 7}], "subscription": {"overage": 7, "subscriptions": [{"subscription_id": "subscription_id", "charge_agreement_number": "charge_agreement_number", "type": "type", "subscription_amount": 19, "start": "2019-01-01T12:00:00.000Z", "end": "2019-01-01T12:00:00.000Z", "credits_total": 13, "terms": [{"start": "2019-01-01T12:00:00.000Z", "end": "2019-01-01T12:00:00.000Z", "credits": {"total": 5, "starting_balance": 16, "used": 4, "balance": 7}}]}]}}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -125,26 +164,23 @@ class TestGetAccountSummary:
             "billingmonth": billingmonth,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_account_summary(**req_copy)
 
+    def test_get_account_summary_value_error_with_retries(self):
+        # Enable retries and run test_get_account_summary_value_error.
+        _service.enable_retries()
+        self.test_get_account_summary_value_error()
 
-class TestGetAccountUsage:
+        # Disable retries and run test_get_account_summary_value_error.
+        _service.disable_retries()
+        self.test_get_account_summary_value_error()
+
+class TestGetAccountUsage():
     """
     Test Class for get_account_usage
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_get_account_usage_all_params(self):
@@ -152,9 +188,13 @@ class TestGetAccountUsage:
         get_account_usage()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v4/accounts/testString/usage/testString')
+        url = preprocess_url('/v4/accounts/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -164,16 +204,29 @@ class TestGetAccountUsage:
 
         # Invoke method
         response = _service.get_account_usage(
-            account_id, billingmonth, names=names, accept_language=accept_language, headers={}
+            account_id,
+            billingmonth,
+            names=names,
+            accept_language=accept_language,
+            headers={}
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = responses.calls[0].request.url.split('?',1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert '_names={}'.format('true' if names else 'false') in query_string
+
+    def test_get_account_usage_all_params_with_retries(self):
+        # Enable retries and run test_get_account_usage_all_params.
+        _service.enable_retries()
+        self.test_get_account_usage_all_params()
+
+        # Disable retries and run test_get_account_usage_all_params.
+        _service.disable_retries()
+        self.test_get_account_usage_all_params()
 
     @responses.activate
     def test_get_account_usage_required_params(self):
@@ -181,20 +234,37 @@ class TestGetAccountUsage:
         test_get_account_usage_required_params()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v4/accounts/testString/usage/testString')
+        url = preprocess_url('/v4/accounts/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
         billingmonth = 'testString'
 
         # Invoke method
-        response = _service.get_account_usage(account_id, billingmonth, headers={})
+        response = _service.get_account_usage(
+            account_id,
+            billingmonth,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
+
+    def test_get_account_usage_required_params_with_retries(self):
+        # Enable retries and run test_get_account_usage_required_params.
+        _service.enable_retries()
+        self.test_get_account_usage_required_params()
+
+        # Disable retries and run test_get_account_usage_required_params.
+        _service.disable_retries()
+        self.test_get_account_usage_required_params()
 
     @responses.activate
     def test_get_account_usage_value_error(self):
@@ -202,9 +272,13 @@ class TestGetAccountUsage:
         test_get_account_usage_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v4/accounts/testString/usage/testString')
+        url = preprocess_url('/v4/accounts/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -216,10 +290,18 @@ class TestGetAccountUsage:
             "billingmonth": billingmonth,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_account_usage(**req_copy)
 
+    def test_get_account_usage_value_error_with_retries(self):
+        # Enable retries and run test_get_account_usage_value_error.
+        _service.enable_retries()
+        self.test_get_account_usage_value_error()
+
+        # Disable retries and run test_get_account_usage_value_error.
+        _service.disable_retries()
+        self.test_get_account_usage_value_error()
 
 # endregion
 ##############################################################################
@@ -231,8 +313,7 @@ class TestGetAccountUsage:
 ##############################################################################
 # region
 
-
-class TestNewInstance:
+class TestNewInstance():
     """
     Test Class for new_instance
     """
@@ -255,24 +336,14 @@ class TestNewInstance:
         new_instance_without_authenticator()
         """
         with pytest.raises(ValueError, match='authenticator must be provided'):
-            service = UsageReportsV4.new_instance()
+            service = UsageReportsV4.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
 
-
-class TestGetResourceGroupUsage:
+class TestGetResourceGroupUsage():
     """
     Test Class for get_resource_group_usage
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_get_resource_group_usage_all_params(self):
@@ -280,9 +351,13 @@ class TestGetResourceGroupUsage:
         get_resource_group_usage()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v4/accounts/testString/resource_groups/testString/usage/testString')
+        url = preprocess_url('/v4/accounts/testString/resource_groups/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -293,16 +368,30 @@ class TestGetResourceGroupUsage:
 
         # Invoke method
         response = _service.get_resource_group_usage(
-            account_id, resource_group_id, billingmonth, names=names, accept_language=accept_language, headers={}
+            account_id,
+            resource_group_id,
+            billingmonth,
+            names=names,
+            accept_language=accept_language,
+            headers={}
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = responses.calls[0].request.url.split('?',1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert '_names={}'.format('true' if names else 'false') in query_string
+
+    def test_get_resource_group_usage_all_params_with_retries(self):
+        # Enable retries and run test_get_resource_group_usage_all_params.
+        _service.enable_retries()
+        self.test_get_resource_group_usage_all_params()
+
+        # Disable retries and run test_get_resource_group_usage_all_params.
+        _service.disable_retries()
+        self.test_get_resource_group_usage_all_params()
 
     @responses.activate
     def test_get_resource_group_usage_required_params(self):
@@ -310,9 +399,13 @@ class TestGetResourceGroupUsage:
         test_get_resource_group_usage_required_params()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v4/accounts/testString/resource_groups/testString/usage/testString')
+        url = preprocess_url('/v4/accounts/testString/resource_groups/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -320,11 +413,25 @@ class TestGetResourceGroupUsage:
         billingmonth = 'testString'
 
         # Invoke method
-        response = _service.get_resource_group_usage(account_id, resource_group_id, billingmonth, headers={})
+        response = _service.get_resource_group_usage(
+            account_id,
+            resource_group_id,
+            billingmonth,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
+
+    def test_get_resource_group_usage_required_params_with_retries(self):
+        # Enable retries and run test_get_resource_group_usage_required_params.
+        _service.enable_retries()
+        self.test_get_resource_group_usage_required_params()
+
+        # Disable retries and run test_get_resource_group_usage_required_params.
+        _service.disable_retries()
+        self.test_get_resource_group_usage_required_params()
 
     @responses.activate
     def test_get_resource_group_usage_value_error(self):
@@ -332,9 +439,13 @@ class TestGetResourceGroupUsage:
         test_get_resource_group_usage_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v4/accounts/testString/resource_groups/testString/usage/testString')
+        url = preprocess_url('/v4/accounts/testString/resource_groups/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -348,26 +459,23 @@ class TestGetResourceGroupUsage:
             "billingmonth": billingmonth,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_resource_group_usage(**req_copy)
 
+    def test_get_resource_group_usage_value_error_with_retries(self):
+        # Enable retries and run test_get_resource_group_usage_value_error.
+        _service.enable_retries()
+        self.test_get_resource_group_usage_value_error()
 
-class TestGetResourceUsageAccount:
+        # Disable retries and run test_get_resource_group_usage_value_error.
+        _service.disable_retries()
+        self.test_get_resource_group_usage_value_error()
+
+class TestGetResourceUsageAccount():
     """
     Test Class for get_resource_usage_account
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_get_resource_usage_account_all_params(self):
@@ -375,9 +483,13 @@ class TestGetResourceUsageAccount:
         get_resource_usage_account()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v4/accounts/testString/resource_instances/usage/testString')
+        url = preprocess_url('/v4/accounts/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -407,14 +519,14 @@ class TestGetResourceUsageAccount:
             resource_id=resource_id,
             plan_id=plan_id,
             region=region,
-            headers={},
+            headers={}
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = responses.calls[0].request.url.split('?',1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert '_names={}'.format('true' if names else 'false') in query_string
         assert '_limit={}'.format(limit) in query_string
@@ -426,26 +538,52 @@ class TestGetResourceUsageAccount:
         assert 'plan_id={}'.format(plan_id) in query_string
         assert 'region={}'.format(region) in query_string
 
+    def test_get_resource_usage_account_all_params_with_retries(self):
+        # Enable retries and run test_get_resource_usage_account_all_params.
+        _service.enable_retries()
+        self.test_get_resource_usage_account_all_params()
+
+        # Disable retries and run test_get_resource_usage_account_all_params.
+        _service.disable_retries()
+        self.test_get_resource_usage_account_all_params()
+
     @responses.activate
     def test_get_resource_usage_account_required_params(self):
         """
         test_get_resource_usage_account_required_params()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v4/accounts/testString/resource_instances/usage/testString')
+        url = preprocess_url('/v4/accounts/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
         billingmonth = 'testString'
 
         # Invoke method
-        response = _service.get_resource_usage_account(account_id, billingmonth, headers={})
+        response = _service.get_resource_usage_account(
+            account_id,
+            billingmonth,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
+
+    def test_get_resource_usage_account_required_params_with_retries(self):
+        # Enable retries and run test_get_resource_usage_account_required_params.
+        _service.enable_retries()
+        self.test_get_resource_usage_account_required_params()
+
+        # Disable retries and run test_get_resource_usage_account_required_params.
+        _service.disable_retries()
+        self.test_get_resource_usage_account_required_params()
 
     @responses.activate
     def test_get_resource_usage_account_value_error(self):
@@ -453,9 +591,13 @@ class TestGetResourceUsageAccount:
         test_get_resource_usage_account_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v4/accounts/testString/resource_instances/usage/testString')
+        url = preprocess_url('/v4/accounts/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -467,26 +609,104 @@ class TestGetResourceUsageAccount:
             "billingmonth": billingmonth,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_resource_usage_account(**req_copy)
 
+    def test_get_resource_usage_account_value_error_with_retries(self):
+        # Enable retries and run test_get_resource_usage_account_value_error.
+        _service.enable_retries()
+        self.test_get_resource_usage_account_value_error()
 
-class TestGetResourceUsageResourceGroup:
+        # Disable retries and run test_get_resource_usage_account_value_error.
+        _service.disable_retries()
+        self.test_get_resource_usage_account_value_error()
+
+    @responses.activate
+    def test_get_resource_usage_account_with_pager_get_next(self):
+        """
+        test_get_resource_usage_account_with_pager_get_next()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v4/accounts/testString/resource_instances/usage/testString')
+        mock_response1 = '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
+        mock_response2 = '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response1,
+                      content_type='application/json',
+                      status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response2,
+                      content_type='application/json',
+                      status=200)
+
+        # Exercise the pager class for this operation
+        all_results = []
+        pager = GetResourceUsageAccountPager(
+            client=_service,
+            account_id='testString',
+            billingmonth='testString',
+            names=True,
+            accept_language='testString',
+            limit=1,
+            resource_group_id='testString',
+            organization_id='testString',
+            resource_instance_id='testString',
+            resource_id='testString',
+            plan_id='testString',
+            region='testString',
+        )
+        while pager.has_next():
+            next_page = pager.get_next()
+            assert next_page is not None
+            all_results.extend(next_page)
+        assert len(all_results) == 2
+
+    @responses.activate
+    def test_get_resource_usage_account_with_pager_get_all(self):
+        """
+        test_get_resource_usage_account_with_pager_get_all()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v4/accounts/testString/resource_instances/usage/testString')
+        mock_response1 = '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
+        mock_response2 = '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response1,
+                      content_type='application/json',
+                      status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response2,
+                      content_type='application/json',
+                      status=200)
+
+        # Exercise the pager class for this operation
+        pager = GetResourceUsageAccountPager(
+            client=_service,
+            account_id='testString',
+            billingmonth='testString',
+            names=True,
+            accept_language='testString',
+            limit=1,
+            resource_group_id='testString',
+            organization_id='testString',
+            resource_instance_id='testString',
+            resource_id='testString',
+            plan_id='testString',
+            region='testString',
+        )
+        all_results = pager.get_all()
+        assert all_results is not None
+        assert len(all_results) == 2
+
+class TestGetResourceUsageResourceGroup():
     """
     Test Class for get_resource_usage_resource_group
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_get_resource_usage_resource_group_all_params(self):
@@ -494,11 +714,13 @@ class TestGetResourceUsageResourceGroup:
         get_resource_usage_resource_group()
         """
         # Set up mock
-        url = self.preprocess_url(
-            _base_url + '/v4/accounts/testString/resource_groups/testString/resource_instances/usage/testString'
-        )
+        url = preprocess_url('/v4/accounts/testString/resource_groups/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -526,14 +748,14 @@ class TestGetResourceUsageResourceGroup:
             resource_id=resource_id,
             plan_id=plan_id,
             region=region,
-            headers={},
+            headers={}
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = responses.calls[0].request.url.split('?',1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert '_names={}'.format('true' if names else 'false') in query_string
         assert '_limit={}'.format(limit) in query_string
@@ -543,17 +765,28 @@ class TestGetResourceUsageResourceGroup:
         assert 'plan_id={}'.format(plan_id) in query_string
         assert 'region={}'.format(region) in query_string
 
+    def test_get_resource_usage_resource_group_all_params_with_retries(self):
+        # Enable retries and run test_get_resource_usage_resource_group_all_params.
+        _service.enable_retries()
+        self.test_get_resource_usage_resource_group_all_params()
+
+        # Disable retries and run test_get_resource_usage_resource_group_all_params.
+        _service.disable_retries()
+        self.test_get_resource_usage_resource_group_all_params()
+
     @responses.activate
     def test_get_resource_usage_resource_group_required_params(self):
         """
         test_get_resource_usage_resource_group_required_params()
         """
         # Set up mock
-        url = self.preprocess_url(
-            _base_url + '/v4/accounts/testString/resource_groups/testString/resource_instances/usage/testString'
-        )
+        url = preprocess_url('/v4/accounts/testString/resource_groups/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -561,11 +794,25 @@ class TestGetResourceUsageResourceGroup:
         billingmonth = 'testString'
 
         # Invoke method
-        response = _service.get_resource_usage_resource_group(account_id, resource_group_id, billingmonth, headers={})
+        response = _service.get_resource_usage_resource_group(
+            account_id,
+            resource_group_id,
+            billingmonth,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
+
+    def test_get_resource_usage_resource_group_required_params_with_retries(self):
+        # Enable retries and run test_get_resource_usage_resource_group_required_params.
+        _service.enable_retries()
+        self.test_get_resource_usage_resource_group_required_params()
+
+        # Disable retries and run test_get_resource_usage_resource_group_required_params.
+        _service.disable_retries()
+        self.test_get_resource_usage_resource_group_required_params()
 
     @responses.activate
     def test_get_resource_usage_resource_group_value_error(self):
@@ -573,11 +820,13 @@ class TestGetResourceUsageResourceGroup:
         test_get_resource_usage_resource_group_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(
-            _base_url + '/v4/accounts/testString/resource_groups/testString/resource_instances/usage/testString'
-        )
+        url = preprocess_url('/v4/accounts/testString/resource_groups/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -591,26 +840,102 @@ class TestGetResourceUsageResourceGroup:
             "billingmonth": billingmonth,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_resource_usage_resource_group(**req_copy)
 
+    def test_get_resource_usage_resource_group_value_error_with_retries(self):
+        # Enable retries and run test_get_resource_usage_resource_group_value_error.
+        _service.enable_retries()
+        self.test_get_resource_usage_resource_group_value_error()
 
-class TestGetResourceUsageOrg:
+        # Disable retries and run test_get_resource_usage_resource_group_value_error.
+        _service.disable_retries()
+        self.test_get_resource_usage_resource_group_value_error()
+
+    @responses.activate
+    def test_get_resource_usage_resource_group_with_pager_get_next(self):
+        """
+        test_get_resource_usage_resource_group_with_pager_get_next()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v4/accounts/testString/resource_groups/testString/resource_instances/usage/testString')
+        mock_response1 = '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
+        mock_response2 = '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response1,
+                      content_type='application/json',
+                      status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response2,
+                      content_type='application/json',
+                      status=200)
+
+        # Exercise the pager class for this operation
+        all_results = []
+        pager = GetResourceUsageResourceGroupPager(
+            client=_service,
+            account_id='testString',
+            resource_group_id='testString',
+            billingmonth='testString',
+            names=True,
+            accept_language='testString',
+            limit=1,
+            resource_instance_id='testString',
+            resource_id='testString',
+            plan_id='testString',
+            region='testString',
+        )
+        while pager.has_next():
+            next_page = pager.get_next()
+            assert next_page is not None
+            all_results.extend(next_page)
+        assert len(all_results) == 2
+
+    @responses.activate
+    def test_get_resource_usage_resource_group_with_pager_get_all(self):
+        """
+        test_get_resource_usage_resource_group_with_pager_get_all()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v4/accounts/testString/resource_groups/testString/resource_instances/usage/testString')
+        mock_response1 = '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
+        mock_response2 = '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response1,
+                      content_type='application/json',
+                      status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response2,
+                      content_type='application/json',
+                      status=200)
+
+        # Exercise the pager class for this operation
+        pager = GetResourceUsageResourceGroupPager(
+            client=_service,
+            account_id='testString',
+            resource_group_id='testString',
+            billingmonth='testString',
+            names=True,
+            accept_language='testString',
+            limit=1,
+            resource_instance_id='testString',
+            resource_id='testString',
+            plan_id='testString',
+            region='testString',
+        )
+        all_results = pager.get_all()
+        assert all_results is not None
+        assert len(all_results) == 2
+
+class TestGetResourceUsageOrg():
     """
     Test Class for get_resource_usage_org
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_get_resource_usage_org_all_params(self):
@@ -618,11 +943,13 @@ class TestGetResourceUsageOrg:
         get_resource_usage_org()
         """
         # Set up mock
-        url = self.preprocess_url(
-            _base_url + '/v4/accounts/testString/organizations/testString/resource_instances/usage/testString'
-        )
+        url = preprocess_url('/v4/accounts/testString/organizations/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -650,14 +977,14 @@ class TestGetResourceUsageOrg:
             resource_id=resource_id,
             plan_id=plan_id,
             region=region,
-            headers={},
+            headers={}
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = responses.calls[0].request.url.split('?',1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert '_names={}'.format('true' if names else 'false') in query_string
         assert '_limit={}'.format(limit) in query_string
@@ -667,17 +994,28 @@ class TestGetResourceUsageOrg:
         assert 'plan_id={}'.format(plan_id) in query_string
         assert 'region={}'.format(region) in query_string
 
+    def test_get_resource_usage_org_all_params_with_retries(self):
+        # Enable retries and run test_get_resource_usage_org_all_params.
+        _service.enable_retries()
+        self.test_get_resource_usage_org_all_params()
+
+        # Disable retries and run test_get_resource_usage_org_all_params.
+        _service.disable_retries()
+        self.test_get_resource_usage_org_all_params()
+
     @responses.activate
     def test_get_resource_usage_org_required_params(self):
         """
         test_get_resource_usage_org_required_params()
         """
         # Set up mock
-        url = self.preprocess_url(
-            _base_url + '/v4/accounts/testString/organizations/testString/resource_instances/usage/testString'
-        )
+        url = preprocess_url('/v4/accounts/testString/organizations/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -685,11 +1023,25 @@ class TestGetResourceUsageOrg:
         billingmonth = 'testString'
 
         # Invoke method
-        response = _service.get_resource_usage_org(account_id, organization_id, billingmonth, headers={})
+        response = _service.get_resource_usage_org(
+            account_id,
+            organization_id,
+            billingmonth,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
+
+    def test_get_resource_usage_org_required_params_with_retries(self):
+        # Enable retries and run test_get_resource_usage_org_required_params.
+        _service.enable_retries()
+        self.test_get_resource_usage_org_required_params()
+
+        # Disable retries and run test_get_resource_usage_org_required_params.
+        _service.disable_retries()
+        self.test_get_resource_usage_org_required_params()
 
     @responses.activate
     def test_get_resource_usage_org_value_error(self):
@@ -697,11 +1049,13 @@ class TestGetResourceUsageOrg:
         test_get_resource_usage_org_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(
-            _base_url + '/v4/accounts/testString/organizations/testString/resource_instances/usage/testString'
-        )
+        url = preprocess_url('/v4/accounts/testString/organizations/testString/resource_instances/usage/testString')
         mock_response = '{"limit": 5, "count": 5, "first": {"href": "href"}, "next": {"href": "href", "offset": "offset"}, "resources": [{"account_id": "account_id", "resource_instance_id": "resource_instance_id", "resource_instance_name": "resource_instance_name", "resource_id": "resource_id", "resource_name": "resource_name", "resource_group_id": "resource_group_id", "resource_group_name": "resource_group_name", "organization_id": "organization_id", "organization_name": "organization_name", "space_id": "space_id", "space_name": "space_name", "consumer_id": "consumer_id", "region": "region", "pricing_region": "pricing_region", "pricing_country": "USA", "currency_code": "USD", "billable": true, "plan_id": "plan_id", "plan_name": "plan_name", "month": "2017-08", "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -715,10 +1069,97 @@ class TestGetResourceUsageOrg:
             "billingmonth": billingmonth,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_resource_usage_org(**req_copy)
 
+    def test_get_resource_usage_org_value_error_with_retries(self):
+        # Enable retries and run test_get_resource_usage_org_value_error.
+        _service.enable_retries()
+        self.test_get_resource_usage_org_value_error()
+
+        # Disable retries and run test_get_resource_usage_org_value_error.
+        _service.disable_retries()
+        self.test_get_resource_usage_org_value_error()
+
+    @responses.activate
+    def test_get_resource_usage_org_with_pager_get_next(self):
+        """
+        test_get_resource_usage_org_with_pager_get_next()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v4/accounts/testString/organizations/testString/resource_instances/usage/testString')
+        mock_response1 = '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
+        mock_response2 = '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response1,
+                      content_type='application/json',
+                      status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response2,
+                      content_type='application/json',
+                      status=200)
+
+        # Exercise the pager class for this operation
+        all_results = []
+        pager = GetResourceUsageOrgPager(
+            client=_service,
+            account_id='testString',
+            organization_id='testString',
+            billingmonth='testString',
+            names=True,
+            accept_language='testString',
+            limit=1,
+            resource_instance_id='testString',
+            resource_id='testString',
+            plan_id='testString',
+            region='testString',
+        )
+        while pager.has_next():
+            next_page = pager.get_next()
+            assert next_page is not None
+            all_results.extend(next_page)
+        assert len(all_results) == 2
+
+    @responses.activate
+    def test_get_resource_usage_org_with_pager_get_all(self):
+        """
+        test_get_resource_usage_org_with_pager_get_all()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v4/accounts/testString/organizations/testString/resource_instances/usage/testString')
+        mock_response1 = '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
+        mock_response2 = '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}]}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response1,
+                      content_type='application/json',
+                      status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response2,
+                      content_type='application/json',
+                      status=200)
+
+        # Exercise the pager class for this operation
+        pager = GetResourceUsageOrgPager(
+            client=_service,
+            account_id='testString',
+            organization_id='testString',
+            billingmonth='testString',
+            names=True,
+            accept_language='testString',
+            limit=1,
+            resource_instance_id='testString',
+            resource_id='testString',
+            plan_id='testString',
+            region='testString',
+        )
+        all_results = pager.get_all()
+        assert all_results is not None
+        assert len(all_results) == 2
 
 # endregion
 ##############################################################################
@@ -730,8 +1171,7 @@ class TestGetResourceUsageOrg:
 ##############################################################################
 # region
 
-
-class TestNewInstance:
+class TestNewInstance():
     """
     Test Class for new_instance
     """
@@ -754,24 +1194,14 @@ class TestNewInstance:
         new_instance_without_authenticator()
         """
         with pytest.raises(ValueError, match='authenticator must be provided'):
-            service = UsageReportsV4.new_instance()
+            service = UsageReportsV4.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
 
-
-class TestGetOrgUsage:
+class TestGetOrgUsage():
     """
     Test Class for get_org_usage
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url)  # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_get_org_usage_all_params(self):
@@ -779,9 +1209,13 @@ class TestGetOrgUsage:
         get_org_usage()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v4/accounts/testString/organizations/testString/usage/testString')
+        url = preprocess_url('/v4/accounts/testString/organizations/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "organization_id": "organization_id", "organization_name": "organization_name", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -792,16 +1226,30 @@ class TestGetOrgUsage:
 
         # Invoke method
         response = _service.get_org_usage(
-            account_id, organization_id, billingmonth, names=names, accept_language=accept_language, headers={}
+            account_id,
+            organization_id,
+            billingmonth,
+            names=names,
+            accept_language=accept_language,
+            headers={}
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = responses.calls[0].request.url.split('?',1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert '_names={}'.format('true' if names else 'false') in query_string
+
+    def test_get_org_usage_all_params_with_retries(self):
+        # Enable retries and run test_get_org_usage_all_params.
+        _service.enable_retries()
+        self.test_get_org_usage_all_params()
+
+        # Disable retries and run test_get_org_usage_all_params.
+        _service.disable_retries()
+        self.test_get_org_usage_all_params()
 
     @responses.activate
     def test_get_org_usage_required_params(self):
@@ -809,9 +1257,13 @@ class TestGetOrgUsage:
         test_get_org_usage_required_params()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v4/accounts/testString/organizations/testString/usage/testString')
+        url = preprocess_url('/v4/accounts/testString/organizations/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "organization_id": "organization_id", "organization_name": "organization_name", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -819,11 +1271,25 @@ class TestGetOrgUsage:
         billingmonth = 'testString'
 
         # Invoke method
-        response = _service.get_org_usage(account_id, organization_id, billingmonth, headers={})
+        response = _service.get_org_usage(
+            account_id,
+            organization_id,
+            billingmonth,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
+
+    def test_get_org_usage_required_params_with_retries(self):
+        # Enable retries and run test_get_org_usage_required_params.
+        _service.enable_retries()
+        self.test_get_org_usage_required_params()
+
+        # Disable retries and run test_get_org_usage_required_params.
+        _service.disable_retries()
+        self.test_get_org_usage_required_params()
 
     @responses.activate
     def test_get_org_usage_value_error(self):
@@ -831,9 +1297,13 @@ class TestGetOrgUsage:
         test_get_org_usage_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v4/accounts/testString/organizations/testString/usage/testString')
+        url = preprocess_url('/v4/accounts/testString/organizations/testString/usage/testString')
         mock_response = '{"account_id": "account_id", "organization_id": "organization_id", "organization_name": "organization_name", "pricing_country": "USA", "currency_code": "USD", "month": "2017-08", "resources": [{"resource_id": "resource_id", "resource_name": "resource_name", "billable_cost": 13, "billable_rated_cost": 19, "non_billable_cost": 17, "non_billable_rated_cost": 23, "plans": [{"plan_id": "plan_id", "plan_name": "plan_name", "pricing_region": "pricing_region", "billable": true, "cost": 4, "rated_cost": 10, "usage": [{"metric": "UP-TIME", "metric_name": "UP-TIME", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130.0, "price": ["anyValue"], "unit": "HOURS", "unit_name": "HOURS", "non_chargeable": true, "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}], "discounts": [{"ref": "Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9", "name": "platform-discount", "display_name": "Platform Service Discount", "discount": 5}]}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
@@ -847,10 +1317,18 @@ class TestGetOrgUsage:
             "billingmonth": billingmonth,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
                 _service.get_org_usage(**req_copy)
 
+    def test_get_org_usage_value_error_with_retries(self):
+        # Enable retries and run test_get_org_usage_value_error.
+        _service.enable_retries()
+        self.test_get_org_usage_value_error()
+
+        # Disable retries and run test_get_org_usage_value_error.
+        _service.disable_retries()
+        self.test_get_org_usage_value_error()
 
 # endregion
 ##############################################################################
@@ -862,7 +1340,7 @@ class TestGetOrgUsage:
 # Start of Model Tests
 ##############################################################################
 # region
-class TestModel_AccountSummary:
+class TestModel_AccountSummary():
     """
     Test Class for AccountSummary
     """
@@ -874,57 +1352,57 @@ class TestModel_AccountSummary:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        resources_summary_model = {}  # ResourcesSummary
+        resources_summary_model = {} # ResourcesSummary
         resources_summary_model['billable_cost'] = 72.5
         resources_summary_model['non_billable_cost'] = 72.5
 
-        offer_credits_model = {}  # OfferCredits
+        offer_credits_model = {} # OfferCredits
         offer_credits_model['starting_balance'] = 72.5
         offer_credits_model['used'] = 72.5
         offer_credits_model['balance'] = 72.5
 
-        offer_model = {}  # Offer
+        offer_model = {} # Offer
         offer_model['offer_id'] = 'testString'
         offer_model['credits_total'] = 72.5
         offer_model['offer_template'] = 'testString'
-        offer_model['valid_from'] = "2019-01-01T12:00:00Z"
-        offer_model['expires_on'] = "2019-01-01T12:00:00Z"
+        offer_model['valid_from'] = '2019-01-01T12:00:00Z'
+        offer_model['expires_on'] = '2019-01-01T12:00:00Z'
         offer_model['credits'] = offer_credits_model
 
-        support_summary_model = {}  # SupportSummary
+        support_summary_model = {} # SupportSummary
         support_summary_model['cost'] = 72.5
         support_summary_model['type'] = 'testString'
         support_summary_model['overage'] = 72.5
 
-        subscription_term_credits_model = {}  # SubscriptionTermCredits
+        subscription_term_credits_model = {} # SubscriptionTermCredits
         subscription_term_credits_model['total'] = 72.5
         subscription_term_credits_model['starting_balance'] = 72.5
         subscription_term_credits_model['used'] = 72.5
         subscription_term_credits_model['balance'] = 72.5
 
-        subscription_term_model = {}  # SubscriptionTerm
-        subscription_term_model['start'] = "2019-01-01T12:00:00Z"
-        subscription_term_model['end'] = "2019-01-01T12:00:00Z"
+        subscription_term_model = {} # SubscriptionTerm
+        subscription_term_model['start'] = '2019-01-01T12:00:00Z'
+        subscription_term_model['end'] = '2019-01-01T12:00:00Z'
         subscription_term_model['credits'] = subscription_term_credits_model
 
-        subscription_model = {}  # Subscription
+        subscription_model = {} # Subscription
         subscription_model['subscription_id'] = 'testString'
         subscription_model['charge_agreement_number'] = 'testString'
         subscription_model['type'] = 'testString'
         subscription_model['subscription_amount'] = 72.5
-        subscription_model['start'] = "2019-01-01T12:00:00Z"
-        subscription_model['end'] = "2019-01-01T12:00:00Z"
+        subscription_model['start'] = '2019-01-01T12:00:00Z'
+        subscription_model['end'] = '2019-01-01T12:00:00Z'
         subscription_model['credits_total'] = 72.5
         subscription_model['terms'] = [subscription_term_model]
 
-        subscription_summary_model = {}  # SubscriptionSummary
+        subscription_summary_model = {} # SubscriptionSummary
         subscription_summary_model['overage'] = 72.5
         subscription_summary_model['subscriptions'] = [subscription_model]
 
         # Construct a json representation of a AccountSummary model
         account_summary_model_json = {}
         account_summary_model_json['account_id'] = 'testString'
-        account_summary_model_json['billing_month'] = 'testString'
+        account_summary_model_json['month'] = 'testString'
         account_summary_model_json['billing_country_code'] = 'testString'
         account_summary_model_json['billing_currency_code'] = 'testString'
         account_summary_model_json['resources'] = resources_summary_model
@@ -947,8 +1425,7 @@ class TestModel_AccountSummary:
         account_summary_model_json2 = account_summary_model.to_dict()
         assert account_summary_model_json2 == account_summary_model_json
 
-
-class TestModel_AccountUsage:
+class TestModel_AccountUsage():
     """
     Test Class for AccountUsage
     """
@@ -960,13 +1437,13 @@ class TestModel_AccountUsage:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        discount_model = {}  # Discount
+        discount_model = {} # Discount
         discount_model['ref'] = 'Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9'
         discount_model['name'] = 'platform-discount'
         discount_model['display_name'] = 'Platform Service Discount'
         discount_model['discount'] = 5
 
-        metric_model = {}  # Metric
+        metric_model = {} # Metric
         metric_model['metric'] = 'UP-TIME'
         metric_model['metric_name'] = 'UP-TIME'
         metric_model['quantity'] = 711.11
@@ -979,7 +1456,7 @@ class TestModel_AccountUsage:
         metric_model['non_chargeable'] = True
         metric_model['discounts'] = [discount_model]
 
-        plan_model = {}  # Plan
+        plan_model = {} # Plan
         plan_model['plan_id'] = 'testString'
         plan_model['plan_name'] = 'testString'
         plan_model['pricing_region'] = 'testString'
@@ -989,7 +1466,7 @@ class TestModel_AccountUsage:
         plan_model['usage'] = [metric_model]
         plan_model['discounts'] = [discount_model]
 
-        resource_model = {}  # Resource
+        resource_model = {} # Resource
         resource_model['resource_id'] = 'testString'
         resource_model['resource_name'] = 'testString'
         resource_model['billable_cost'] = 72.5
@@ -1022,8 +1499,7 @@ class TestModel_AccountUsage:
         account_usage_model_json2 = account_usage_model.to_dict()
         assert account_usage_model_json2 == account_usage_model_json
 
-
-class TestModel_Discount:
+class TestModel_Discount():
     """
     Test Class for Discount
     """
@@ -1055,8 +1531,7 @@ class TestModel_Discount:
         discount_model_json2 = discount_model.to_dict()
         assert discount_model_json2 == discount_model_json
 
-
-class TestModel_InstanceUsage:
+class TestModel_InstanceUsage():
     """
     Test Class for InstanceUsage
     """
@@ -1068,13 +1543,13 @@ class TestModel_InstanceUsage:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        discount_model = {}  # Discount
+        discount_model = {} # Discount
         discount_model['ref'] = 'Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9'
         discount_model['name'] = 'platform-discount'
         discount_model['display_name'] = 'Platform Service Discount'
         discount_model['discount'] = 5
 
-        metric_model = {}  # Metric
+        metric_model = {} # Metric
         metric_model['metric'] = 'UP-TIME'
         metric_model['metric_name'] = 'UP-TIME'
         metric_model['quantity'] = 711.11
@@ -1126,8 +1601,7 @@ class TestModel_InstanceUsage:
         instance_usage_model_json2 = instance_usage_model.to_dict()
         assert instance_usage_model_json2 == instance_usage_model_json
 
-
-class TestModel_InstancesUsageFirst:
+class TestModel_InstancesUsageFirst():
     """
     Test Class for InstancesUsageFirst
     """
@@ -1156,8 +1630,7 @@ class TestModel_InstancesUsageFirst:
         instances_usage_first_model_json2 = instances_usage_first_model.to_dict()
         assert instances_usage_first_model_json2 == instances_usage_first_model_json
 
-
-class TestModel_InstancesUsageNext:
+class TestModel_InstancesUsageNext():
     """
     Test Class for InstancesUsageNext
     """
@@ -1187,8 +1660,7 @@ class TestModel_InstancesUsageNext:
         instances_usage_next_model_json2 = instances_usage_next_model.to_dict()
         assert instances_usage_next_model_json2 == instances_usage_next_model_json
 
-
-class TestModel_InstancesUsage:
+class TestModel_InstancesUsage():
     """
     Test Class for InstancesUsage
     """
@@ -1200,20 +1672,20 @@ class TestModel_InstancesUsage:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        instances_usage_first_model = {}  # InstancesUsageFirst
+        instances_usage_first_model = {} # InstancesUsageFirst
         instances_usage_first_model['href'] = 'testString'
 
-        instances_usage_next_model = {}  # InstancesUsageNext
+        instances_usage_next_model = {} # InstancesUsageNext
         instances_usage_next_model['href'] = 'testString'
         instances_usage_next_model['offset'] = 'testString'
 
-        discount_model = {}  # Discount
+        discount_model = {} # Discount
         discount_model['ref'] = 'Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9'
         discount_model['name'] = 'platform-discount'
         discount_model['display_name'] = 'Platform Service Discount'
         discount_model['discount'] = 5
 
-        metric_model = {}  # Metric
+        metric_model = {} # Metric
         metric_model['metric'] = 'UP-TIME'
         metric_model['metric_name'] = 'UP-TIME'
         metric_model['quantity'] = 711.11
@@ -1226,7 +1698,7 @@ class TestModel_InstancesUsage:
         metric_model['non_chargeable'] = True
         metric_model['discounts'] = [discount_model]
 
-        instance_usage_model = {}  # InstanceUsage
+        instance_usage_model = {} # InstanceUsage
         instance_usage_model['account_id'] = 'testString'
         instance_usage_model['resource_instance_id'] = 'testString'
         instance_usage_model['resource_instance_name'] = 'testString'
@@ -1272,8 +1744,7 @@ class TestModel_InstancesUsage:
         instances_usage_model_json2 = instances_usage_model.to_dict()
         assert instances_usage_model_json2 == instances_usage_model_json
 
-
-class TestModel_Metric:
+class TestModel_Metric():
     """
     Test Class for Metric
     """
@@ -1285,7 +1756,7 @@ class TestModel_Metric:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        discount_model = {}  # Discount
+        discount_model = {} # Discount
         discount_model['ref'] = 'Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9'
         discount_model['name'] = 'platform-discount'
         discount_model['display_name'] = 'Platform Service Discount'
@@ -1320,8 +1791,7 @@ class TestModel_Metric:
         metric_model_json2 = metric_model.to_dict()
         assert metric_model_json2 == metric_model_json
 
-
-class TestModel_Offer:
+class TestModel_Offer():
     """
     Test Class for Offer
     """
@@ -1333,7 +1803,7 @@ class TestModel_Offer:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        offer_credits_model = {}  # OfferCredits
+        offer_credits_model = {} # OfferCredits
         offer_credits_model['starting_balance'] = 72.5
         offer_credits_model['used'] = 72.5
         offer_credits_model['balance'] = 72.5
@@ -1343,8 +1813,8 @@ class TestModel_Offer:
         offer_model_json['offer_id'] = 'testString'
         offer_model_json['credits_total'] = 72.5
         offer_model_json['offer_template'] = 'testString'
-        offer_model_json['valid_from'] = "2019-01-01T12:00:00Z"
-        offer_model_json['expires_on'] = "2019-01-01T12:00:00Z"
+        offer_model_json['valid_from'] = '2019-01-01T12:00:00Z'
+        offer_model_json['expires_on'] = '2019-01-01T12:00:00Z'
         offer_model_json['credits'] = offer_credits_model
 
         # Construct a model instance of Offer by calling from_dict on the json representation
@@ -1362,8 +1832,7 @@ class TestModel_Offer:
         offer_model_json2 = offer_model.to_dict()
         assert offer_model_json2 == offer_model_json
 
-
-class TestModel_OfferCredits:
+class TestModel_OfferCredits():
     """
     Test Class for OfferCredits
     """
@@ -1394,8 +1863,7 @@ class TestModel_OfferCredits:
         offer_credits_model_json2 = offer_credits_model.to_dict()
         assert offer_credits_model_json2 == offer_credits_model_json
 
-
-class TestModel_OrgUsage:
+class TestModel_OrgUsage():
     """
     Test Class for OrgUsage
     """
@@ -1407,13 +1875,13 @@ class TestModel_OrgUsage:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        discount_model = {}  # Discount
+        discount_model = {} # Discount
         discount_model['ref'] = 'Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9'
         discount_model['name'] = 'platform-discount'
         discount_model['display_name'] = 'Platform Service Discount'
         discount_model['discount'] = 5
 
-        metric_model = {}  # Metric
+        metric_model = {} # Metric
         metric_model['metric'] = 'UP-TIME'
         metric_model['metric_name'] = 'UP-TIME'
         metric_model['quantity'] = 711.11
@@ -1426,7 +1894,7 @@ class TestModel_OrgUsage:
         metric_model['non_chargeable'] = True
         metric_model['discounts'] = [discount_model]
 
-        plan_model = {}  # Plan
+        plan_model = {} # Plan
         plan_model['plan_id'] = 'testString'
         plan_model['plan_name'] = 'testString'
         plan_model['pricing_region'] = 'testString'
@@ -1436,7 +1904,7 @@ class TestModel_OrgUsage:
         plan_model['usage'] = [metric_model]
         plan_model['discounts'] = [discount_model]
 
-        resource_model = {}  # Resource
+        resource_model = {} # Resource
         resource_model['resource_id'] = 'testString'
         resource_model['resource_name'] = 'testString'
         resource_model['billable_cost'] = 72.5
@@ -1471,8 +1939,7 @@ class TestModel_OrgUsage:
         org_usage_model_json2 = org_usage_model.to_dict()
         assert org_usage_model_json2 == org_usage_model_json
 
-
-class TestModel_Plan:
+class TestModel_Plan():
     """
     Test Class for Plan
     """
@@ -1484,13 +1951,13 @@ class TestModel_Plan:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        discount_model = {}  # Discount
+        discount_model = {} # Discount
         discount_model['ref'] = 'Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9'
         discount_model['name'] = 'platform-discount'
         discount_model['display_name'] = 'Platform Service Discount'
         discount_model['discount'] = 5
 
-        metric_model = {}  # Metric
+        metric_model = {} # Metric
         metric_model['metric'] = 'UP-TIME'
         metric_model['metric_name'] = 'UP-TIME'
         metric_model['quantity'] = 711.11
@@ -1529,8 +1996,7 @@ class TestModel_Plan:
         plan_model_json2 = plan_model.to_dict()
         assert plan_model_json2 == plan_model_json
 
-
-class TestModel_Resource:
+class TestModel_Resource():
     """
     Test Class for Resource
     """
@@ -1542,13 +2008,13 @@ class TestModel_Resource:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        discount_model = {}  # Discount
+        discount_model = {} # Discount
         discount_model['ref'] = 'Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9'
         discount_model['name'] = 'platform-discount'
         discount_model['display_name'] = 'Platform Service Discount'
         discount_model['discount'] = 5
 
-        metric_model = {}  # Metric
+        metric_model = {} # Metric
         metric_model['metric'] = 'UP-TIME'
         metric_model['metric_name'] = 'UP-TIME'
         metric_model['quantity'] = 711.11
@@ -1561,7 +2027,7 @@ class TestModel_Resource:
         metric_model['non_chargeable'] = True
         metric_model['discounts'] = [discount_model]
 
-        plan_model = {}  # Plan
+        plan_model = {} # Plan
         plan_model['plan_id'] = 'testString'
         plan_model['plan_name'] = 'testString'
         plan_model['pricing_region'] = 'testString'
@@ -1597,8 +2063,7 @@ class TestModel_Resource:
         resource_model_json2 = resource_model.to_dict()
         assert resource_model_json2 == resource_model_json
 
-
-class TestModel_ResourceGroupUsage:
+class TestModel_ResourceGroupUsage():
     """
     Test Class for ResourceGroupUsage
     """
@@ -1610,13 +2075,13 @@ class TestModel_ResourceGroupUsage:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        discount_model = {}  # Discount
+        discount_model = {} # Discount
         discount_model['ref'] = 'Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9'
         discount_model['name'] = 'platform-discount'
         discount_model['display_name'] = 'Platform Service Discount'
         discount_model['discount'] = 5
 
-        metric_model = {}  # Metric
+        metric_model = {} # Metric
         metric_model['metric'] = 'UP-TIME'
         metric_model['metric_name'] = 'UP-TIME'
         metric_model['quantity'] = 711.11
@@ -1629,7 +2094,7 @@ class TestModel_ResourceGroupUsage:
         metric_model['non_chargeable'] = True
         metric_model['discounts'] = [discount_model]
 
-        plan_model = {}  # Plan
+        plan_model = {} # Plan
         plan_model['plan_id'] = 'testString'
         plan_model['plan_name'] = 'testString'
         plan_model['pricing_region'] = 'testString'
@@ -1639,7 +2104,7 @@ class TestModel_ResourceGroupUsage:
         plan_model['usage'] = [metric_model]
         plan_model['discounts'] = [discount_model]
 
-        resource_model = {}  # Resource
+        resource_model = {} # Resource
         resource_model['resource_id'] = 'testString'
         resource_model['resource_name'] = 'testString'
         resource_model['billable_cost'] = 72.5
@@ -1674,8 +2139,7 @@ class TestModel_ResourceGroupUsage:
         resource_group_usage_model_json2 = resource_group_usage_model.to_dict()
         assert resource_group_usage_model_json2 == resource_group_usage_model_json
 
-
-class TestModel_ResourcesSummary:
+class TestModel_ResourcesSummary():
     """
     Test Class for ResourcesSummary
     """
@@ -1705,8 +2169,7 @@ class TestModel_ResourcesSummary:
         resources_summary_model_json2 = resources_summary_model.to_dict()
         assert resources_summary_model_json2 == resources_summary_model_json
 
-
-class TestModel_Subscription:
+class TestModel_Subscription():
     """
     Test Class for Subscription
     """
@@ -1718,15 +2181,15 @@ class TestModel_Subscription:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        subscription_term_credits_model = {}  # SubscriptionTermCredits
+        subscription_term_credits_model = {} # SubscriptionTermCredits
         subscription_term_credits_model['total'] = 72.5
         subscription_term_credits_model['starting_balance'] = 72.5
         subscription_term_credits_model['used'] = 72.5
         subscription_term_credits_model['balance'] = 72.5
 
-        subscription_term_model = {}  # SubscriptionTerm
-        subscription_term_model['start'] = "2019-01-01T12:00:00Z"
-        subscription_term_model['end'] = "2019-01-01T12:00:00Z"
+        subscription_term_model = {} # SubscriptionTerm
+        subscription_term_model['start'] = '2019-01-01T12:00:00Z'
+        subscription_term_model['end'] = '2019-01-01T12:00:00Z'
         subscription_term_model['credits'] = subscription_term_credits_model
 
         # Construct a json representation of a Subscription model
@@ -1735,8 +2198,8 @@ class TestModel_Subscription:
         subscription_model_json['charge_agreement_number'] = 'testString'
         subscription_model_json['type'] = 'testString'
         subscription_model_json['subscription_amount'] = 72.5
-        subscription_model_json['start'] = "2019-01-01T12:00:00Z"
-        subscription_model_json['end'] = "2019-01-01T12:00:00Z"
+        subscription_model_json['start'] = '2019-01-01T12:00:00Z'
+        subscription_model_json['end'] = '2019-01-01T12:00:00Z'
         subscription_model_json['credits_total'] = 72.5
         subscription_model_json['terms'] = [subscription_term_model]
 
@@ -1755,8 +2218,7 @@ class TestModel_Subscription:
         subscription_model_json2 = subscription_model.to_dict()
         assert subscription_model_json2 == subscription_model_json
 
-
-class TestModel_SubscriptionSummary:
+class TestModel_SubscriptionSummary():
     """
     Test Class for SubscriptionSummary
     """
@@ -1768,24 +2230,24 @@ class TestModel_SubscriptionSummary:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        subscription_term_credits_model = {}  # SubscriptionTermCredits
+        subscription_term_credits_model = {} # SubscriptionTermCredits
         subscription_term_credits_model['total'] = 72.5
         subscription_term_credits_model['starting_balance'] = 72.5
         subscription_term_credits_model['used'] = 72.5
         subscription_term_credits_model['balance'] = 72.5
 
-        subscription_term_model = {}  # SubscriptionTerm
-        subscription_term_model['start'] = "2019-01-01T12:00:00Z"
-        subscription_term_model['end'] = "2019-01-01T12:00:00Z"
+        subscription_term_model = {} # SubscriptionTerm
+        subscription_term_model['start'] = '2019-01-01T12:00:00Z'
+        subscription_term_model['end'] = '2019-01-01T12:00:00Z'
         subscription_term_model['credits'] = subscription_term_credits_model
 
-        subscription_model = {}  # Subscription
+        subscription_model = {} # Subscription
         subscription_model['subscription_id'] = 'testString'
         subscription_model['charge_agreement_number'] = 'testString'
         subscription_model['type'] = 'testString'
         subscription_model['subscription_amount'] = 72.5
-        subscription_model['start'] = "2019-01-01T12:00:00Z"
-        subscription_model['end'] = "2019-01-01T12:00:00Z"
+        subscription_model['start'] = '2019-01-01T12:00:00Z'
+        subscription_model['end'] = '2019-01-01T12:00:00Z'
         subscription_model['credits_total'] = 72.5
         subscription_model['terms'] = [subscription_term_model]
 
@@ -1809,8 +2271,7 @@ class TestModel_SubscriptionSummary:
         subscription_summary_model_json2 = subscription_summary_model.to_dict()
         assert subscription_summary_model_json2 == subscription_summary_model_json
 
-
-class TestModel_SubscriptionTerm:
+class TestModel_SubscriptionTerm():
     """
     Test Class for SubscriptionTerm
     """
@@ -1822,7 +2283,7 @@ class TestModel_SubscriptionTerm:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        subscription_term_credits_model = {}  # SubscriptionTermCredits
+        subscription_term_credits_model = {} # SubscriptionTermCredits
         subscription_term_credits_model['total'] = 72.5
         subscription_term_credits_model['starting_balance'] = 72.5
         subscription_term_credits_model['used'] = 72.5
@@ -1830,8 +2291,8 @@ class TestModel_SubscriptionTerm:
 
         # Construct a json representation of a SubscriptionTerm model
         subscription_term_model_json = {}
-        subscription_term_model_json['start'] = "2019-01-01T12:00:00Z"
-        subscription_term_model_json['end'] = "2019-01-01T12:00:00Z"
+        subscription_term_model_json['start'] = '2019-01-01T12:00:00Z'
+        subscription_term_model_json['end'] = '2019-01-01T12:00:00Z'
         subscription_term_model_json['credits'] = subscription_term_credits_model
 
         # Construct a model instance of SubscriptionTerm by calling from_dict on the json representation
@@ -1849,8 +2310,7 @@ class TestModel_SubscriptionTerm:
         subscription_term_model_json2 = subscription_term_model.to_dict()
         assert subscription_term_model_json2 == subscription_term_model_json
 
-
-class TestModel_SubscriptionTermCredits:
+class TestModel_SubscriptionTermCredits():
     """
     Test Class for SubscriptionTermCredits
     """
@@ -1872,9 +2332,7 @@ class TestModel_SubscriptionTermCredits:
         assert subscription_term_credits_model != False
 
         # Construct a model instance of SubscriptionTermCredits by calling from_dict on the json representation
-        subscription_term_credits_model_dict = SubscriptionTermCredits.from_dict(
-            subscription_term_credits_model_json
-        ).__dict__
+        subscription_term_credits_model_dict = SubscriptionTermCredits.from_dict(subscription_term_credits_model_json).__dict__
         subscription_term_credits_model2 = SubscriptionTermCredits(**subscription_term_credits_model_dict)
 
         # Verify the model instances are equivalent
@@ -1884,8 +2342,7 @@ class TestModel_SubscriptionTermCredits:
         subscription_term_credits_model_json2 = subscription_term_credits_model.to_dict()
         assert subscription_term_credits_model_json2 == subscription_term_credits_model_json
 
-
-class TestModel_SupportSummary:
+class TestModel_SupportSummary():
     """
     Test Class for SupportSummary
     """


### PR DESCRIPTION
## PR summary
Rename the `billing_month` property in the `Account_Summary` schema to `month`


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
The `Account_Summary` schema should now correctly have the `month` property instead of the `billing_month` property.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No