### PR TITLE
feat(IAM Policy Management): add support for v2/policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.30.2](https://github.com/IBM/platform-services-python-sdk/compare/v0.30.1...v0.30.2) (2022-12-07)
+
+
+### Bug Fixes
+
+* **IAM Policy Management:** remove support for v2/polices until GA ([#183](https://github.com/IBM/platform-services-python-sdk/issues/183)) ([f1ccda4](https://github.com/IBM/platform-services-python-sdk/commit/f1ccda41d09a01c839b34c78bb1c79cc31c7f7d5))
+
 ## [0.30.1](https://github.com/IBM/platform-services-python-sdk/compare/v0.30.0...v0.30.1) (2022-12-05)
 
 

--- a/examples/test_iam_policy_management_v1_examples.py
+++ b/examples/test_iam_policy_management_v1_examples.py
@@ -144,15 +144,15 @@ class TestIamPolicyManagementV1Examples:
             pytest.fail(str(e))
 
     @needscredentials
-    def test_update_policy_example(self):
+    def test_replace_policy_example(self):
         """
-        update_policy request example
+        replace_policy request example
         """
         try:
             global example_updated_policy_etag
 
-            print('\nupdate_policy() result:')
-            # begin-update_policy
+            print('\nreplace_policy() result:')
+            # begin-replace_policy
 
             policy_subjects = PolicySubject(attributes=[SubjectAttribute(name='iam_id', value=example_user_id)])
             account_id_resource_attribute = ResourceAttribute(name='accountId', value=example_account_id)
@@ -163,7 +163,7 @@ class TestIamPolicyManagementV1Examples:
             )
             updated_policy_roles = PolicyRole(role_id='crn:v1:bluemix:public:iam::::role:Editor')
 
-            response = iam_policy_management_service.update_policy(
+            response = iam_policy_management_service.replace_policy(
                 type='access',
                 policy_id=example_policy_id,
                 if_match=example_policy_etag,
@@ -175,7 +175,7 @@ class TestIamPolicyManagementV1Examples:
 
             print(json.dumps(policy, indent=2))
 
-            # end-update_policy
+            # end-replace_policy
 
             example_updated_policy_etag = response.get_headers().get("Etag")
 
@@ -183,22 +183,22 @@ class TestIamPolicyManagementV1Examples:
             pytest.fail(str(e))
 
     @needscredentials
-    def test_patch_policy_example(self):
+    def test_update_policy_state_example(self):
         """
-        patch_policy request example
+        update_policy_state request example
         """
         try:
 
-            print('\npatch_policy() result:')
-            # begin-patch_policy
+            print('\nupdate_policy_state() result:')
+            # begin-update_policy_state
 
-            policy = iam_policy_management_service.patch_policy(
+            policy = iam_policy_management_service.update_policy_state(
                 policy_id=example_policy_id, if_match=example_updated_policy_etag, state='active'
             ).get_result()
 
             print(json.dumps(policy, indent=2))
 
-            # end-patch_policy
+            # end-update_policy_state
 
         except ApiException as e:
             pytest.fail(str(e))
@@ -244,51 +244,54 @@ class TestIamPolicyManagementV1Examples:
             pytest.fail(str(e))
 
     @needscredentials
-    def test_v2_create_policy_example(self):
+    def test_create_v2_policy_example(self):
         """
-        v2_create_policy request example
+        create_v2_policy request example
         """
         try:
             global example_policy_id
 
-            print('\nv2_create_policy() result:')
-            # begin-v2_create_policy
+            print('\ncreate_v2_policy() result:')
+            # begin-create_v2_policy
 
-            policy_subject = V2PolicyBaseSubject(
-                attributes=[V2PolicyAttribute(key='iam_id', value=example_user_id, operator='stringEquals')]
+            policy_subject = V2PolicySubject(
+                attributes=[V2PolicySubjectAttribute(key='iam_id', value=example_user_id, operator='stringEquals')]
             )
             policy_role = PolicyRole(role_id='crn:v1:bluemix:public:iam::::role:Viewer')
-            account_id_resource_attribute = V2PolicyAttribute(
+            account_id_resource_attribute = V2PolicyResourceAttribute(
                 key='accountId', value=example_account_id, operator='stringEquals'
             )
-            service_name_resource_attribute = V2PolicyAttribute(
+            service_name_resource_attribute = V2PolicyResourceAttribute(
                 key='serviceType', value='service', operator='stringEquals'
             )
-            policy_resource = PolicyResource(
-                attributes=[account_id_resource_attribute, service_name_resource_attribute],
+            policy_resource_tag = V2PolicyResourceTag(key='project', value='prototype', operator='stringEquals')
+            policy_resource = V2PolicyResource(
+                attributes=[account_id_resource_attribute, service_name_resource_attribute], tags=[policy_resource_tag]
             )
-            policy_control = V2PolicyBaseControl(grant=V2PolicyBaseControlGrant(roles=[policy_role]))
-            policy_rule = V2PolicyBaseRuleV2RuleWithConditions(
+            policy_control = Control(grant=V2PolicyGrant(roles=[policy_role]))
+            policy_rule = V2PolicyRuleRuleWithConditions(
                 operator='and',
                 conditions=[
-                    V2PolicyAttribute(
-                        key='{{environment.attributes.day_of_week}}', operator='dayOfWeekAnyOf', value=[1, 2, 3, 4, 5]
+                    RuleAttribute(
+                        key='{{environment.attributes.day_of_week}}',
+                        operator='dayOfWeekAnyOf',
+                        value=['1+00:00', '2+00:00', '3+00:00', '4+00:00', '5+00:00'],
                     ),
-                    V2PolicyAttribute(
+                    RuleAttribute(
                         key='{{environment.attributes.current_time}}',
                         operator='timeGreaterThanOrEquals',
                         value='09:00:00+00:00',
                     ),
-                    V2PolicyAttribute(
+                    RuleAttribute(
                         key='{{environment.attributes.current_time}}',
                         operator='timeLessThanOrEquals',
                         value='17:00:00+00:00',
                     ),
                 ],
             )
-            policy_pattern = 'time-based-restrictions:weekly'
+            policy_pattern = 'time-based-conditions:weekly:custom-hours'
 
-            policy = iam_policy_management_service.v2_create_policy(
+            policy = iam_policy_management_service.create_v2_policy(
                 type='access',
                 subject=policy_subject,
                 control=policy_control,
@@ -299,7 +302,7 @@ class TestIamPolicyManagementV1Examples:
 
             print(json.dumps(policy, indent=2))
 
-            # end-v2_create_policy
+            # end-create_v2_policy
 
             example_policy_id = policy['id']
 
@@ -307,22 +310,22 @@ class TestIamPolicyManagementV1Examples:
             pytest.fail(str(e))
 
     @needscredentials
-    def test_v2_get_policy_example(self):
+    def test_get_v2_policy_example(self):
         """
-        v2_get_policy request example
+        get_v2_policy request example
         """
         try:
             global example_policy_etag
 
-            print('\nv2_get_policy() result:')
-            # begin-v2_get_policy
+            print('\nget_v2_policy() result:')
+            # begin-get_v2_policy
 
-            response = iam_policy_management_service.v2_get_policy(policy_id=example_policy_id)
+            response = iam_policy_management_service.get_v2_policy(id=example_policy_id)
             policy = response.get_result()
 
             print(json.dumps(policy, indent=2))
 
-            # end-v2_get_policy
+            # end-get_v2_policy
 
             example_policy_etag = response.get_headers().get("Etag")
 
@@ -330,52 +333,55 @@ class TestIamPolicyManagementV1Examples:
             pytest.fail(str(e))
 
     @needscredentials
-    def test_v2_update_policy_example(self):
+    def test_replace_v2_policy_example(self):
         """
-        v2_update_policy request example
+        replace_v2_policy request example
         """
         try:
 
-            print('\nupdate_policy() result:')
-            # begin-v2_update_policy
+            print('\nreplace_v2_policy() result:')
+            # begin-replace_v2_policy
 
-            policy_subject = V2PolicyBaseSubject(
-                attributes=[V2PolicyAttribute(key='iam_id', value=example_user_id, operator='stringEquals')]
+            policy_subject = V2PolicySubject(
+                attributes=[V2PolicySubjectAttribute(key='iam_id', value=example_user_id, operator='stringEquals')]
             )
             updated_policy_role = PolicyRole(role_id='crn:v1:bluemix:public:iam::::role:Editor')
-            account_id_resource_attribute = V2PolicyAttribute(
+            account_id_resource_attribute = V2PolicyResourceAttribute(
                 key='accountId', value=example_account_id, operator='stringEquals'
             )
-            service_name_resource_attribute = V2PolicyAttribute(
+            service_name_resource_attribute = V2PolicyResourceAttribute(
                 key='serviceType', value='service', operator='stringEquals'
             )
+            policy_resource_tag = V2PolicyResourceTag(key='project', value='prototype', operator='stringEquals')
             policy_resource = PolicyResource(
-                attributes=[account_id_resource_attribute, service_name_resource_attribute],
+                attributes=[account_id_resource_attribute, service_name_resource_attribute], tags=[policy_resource_tag]
             )
-            policy_control = V2PolicyBaseControl(grant=V2PolicyBaseControlGrant(roles=[updated_policy_role]))
-            policy_rule = V2PolicyBaseRuleV2RuleWithConditions(
+            policy_control = Control(grant=V2PolicyGrant(roles=[updated_policy_role]))
+            policy_rule = V2PolicyRuleRuleWithConditions(
                 operator='and',
                 conditions=[
-                    V2PolicyAttribute(
-                        key='{{environment.attributes.day_of_week}}', operator='dayOfWeekAnyOf', value=[1, 2, 3, 4, 5]
+                    RuleAttribute(
+                        key='{{environment.attributes.day_of_week}}',
+                        operator='dayOfWeekAnyOf',
+                        value=['1+00:00', '2+00:00', '3+00:00', '4+00:00', '5+00:00'],
                     ),
-                    V2PolicyAttribute(
+                    RuleAttribute(
                         key='{{environment.attributes.current_time}}',
                         operator='timeGreaterThanOrEquals',
                         value='09:00:00+00:00',
                     ),
-                    V2PolicyAttribute(
+                    RuleAttribute(
                         key='{{environment.attributes.current_time}}',
                         operator='timeLessThanOrEquals',
                         value='17:00:00+00:00',
                     ),
                 ],
             )
-            policy_pattern = 'time-based-restrictions:weekly'
+            policy_pattern = 'time-based-conditions:weekly:custom-hours'
 
-            response = iam_policy_management_service.v2_update_policy(
+            response = iam_policy_management_service.replace_v2_policy(
                 type='access',
-                policy_id=example_policy_id,
+                id=example_policy_id,
                 if_match=example_policy_etag,
                 subject=policy_subject,
                 control=policy_control,
@@ -387,47 +393,47 @@ class TestIamPolicyManagementV1Examples:
 
             print(json.dumps(policy, indent=2))
 
-            # end-v2_update_policy
+            # end-replace_v2_policy
 
         except ApiException as e:
             pytest.fail(str(e))
 
     @needscredentials
-    def test_v2_list_policies_example(self):
+    def test_list_v2_policies_example(self):
         """
-        v2_list_policies request example
+        list_v2_policies request example
         """
         try:
 
-            print('\nlist_policies() result:')
-            # begin-v2_list_policies
+            print('\nlist_v2_policies() result:')
+            # begin-list_v2_policies
 
-            policy_list = iam_policy_management_service.v2_list_policies(
+            policy_list = iam_policy_management_service.list_v2_policies(
                 account_id=example_account_id, iam_id=example_user_id, format='include_last_permit'
             ).get_result()
 
             print(json.dumps(policy_list, indent=2))
 
-            # end-v2_list_policies
+            # end-list_v2_policies
 
         except ApiException as e:
             pytest.fail(str(e))
 
     @needscredentials
-    def test_v2_delete_policy_example(self):
+    def test_delete_v2_policy_example(self):
         """
-        v2_delete_policy request example
+        delete_v2_policy request example
         """
         try:
 
-            print('\nv2_delete_policy() result:')
-            # begin-v2_delete_policy
+            print('\ndelete_v2_policy() result:')
+            # begin-delete_v2_policy
 
-            response = iam_policy_management_service.v2_delete_policy(policy_id=example_policy_id).get_result()
+            response = iam_policy_management_service.delete_v2_policy(id=example_policy_id).get_result()
 
             print(json.dumps(response, indent=2))
 
-            # end-v2_delete_policy
+            # end-delete_v2_policy
 
         except ApiException as e:
             pytest.fail(str(e))
@@ -484,23 +490,26 @@ class TestIamPolicyManagementV1Examples:
             pytest.fail(str(e))
 
     @needscredentials
-    def test_update_role_example(self):
+    def test_replace_role_example(self):
         """
-        update_role request example
+        replace_role request example
         """
         try:
 
-            print('\nupdate_role() result:')
-            # begin-update_role
+            print('\nreplace_role() result:')
+            # begin-replace_role
 
             updated_role_actions = ['iam-groups.groups.read', 'iam-groups.groups.list']
-            custom_role = iam_policy_management_service.update_role(
-                role_id=example_custom_role_id, if_match=example_custom_role_etag, actions=updated_role_actions
+            custom_role = iam_policy_management_service.replace_role(
+                role_id=example_custom_role_id,
+                if_match=example_custom_role_etag,
+                actions=updated_role_actions,
+                display_name='IAM Groups read access',
             ).get_result()
 
             print(json.dumps(custom_role, indent=2))
 
-            # end-update_role
+            # end-replace_role
 
         except ApiException as e:
             pytest.fail(str(e))

--- a/examples/test_iam_policy_management_v1_examples.py
+++ b/examples/test_iam_policy_management_v1_examples.py
@@ -244,6 +244,195 @@ class TestIamPolicyManagementV1Examples:
             pytest.fail(str(e))
 
     @needscredentials
+    def test_v2_create_policy_example(self):
+        """
+        v2_create_policy request example
+        """
+        try:
+            global example_policy_id
+
+            print('\nv2_create_policy() result:')
+            # begin-v2_create_policy
+
+            policy_subject = V2PolicyBaseSubject(
+                attributes=[V2PolicyAttribute(key='iam_id', value=example_user_id, operator='stringEquals')]
+            )
+            policy_role = PolicyRole(role_id='crn:v1:bluemix:public:iam::::role:Viewer')
+            account_id_resource_attribute = V2PolicyAttribute(
+                key='accountId', value=example_account_id, operator='stringEquals'
+            )
+            service_name_resource_attribute = V2PolicyAttribute(
+                key='serviceType', value='service', operator='stringEquals'
+            )
+            policy_resource = PolicyResource(
+                attributes=[account_id_resource_attribute, service_name_resource_attribute],
+            )
+            policy_control = V2PolicyBaseControl(grant=V2PolicyBaseControlGrant(roles=[policy_role]))
+            policy_rule = V2PolicyBaseRuleV2RuleWithConditions(
+                operator='and',
+                conditions=[
+                    V2PolicyAttribute(
+                        key='{{environment.attributes.day_of_week}}', operator='dayOfWeekAnyOf', value=[1, 2, 3, 4, 5]
+                    ),
+                    V2PolicyAttribute(
+                        key='{{environment.attributes.current_time}}',
+                        operator='timeGreaterThanOrEquals',
+                        value='09:00:00+00:00',
+                    ),
+                    V2PolicyAttribute(
+                        key='{{environment.attributes.current_time}}',
+                        operator='timeLessThanOrEquals',
+                        value='17:00:00+00:00',
+                    ),
+                ],
+            )
+            policy_pattern = 'time-based-restrictions:weekly'
+
+            policy = iam_policy_management_service.v2_create_policy(
+                type='access',
+                subject=policy_subject,
+                control=policy_control,
+                resource=policy_resource,
+                rule=policy_rule,
+                pattern=policy_pattern,
+            ).get_result()
+
+            print(json.dumps(policy, indent=2))
+
+            # end-v2_create_policy
+
+            example_policy_id = policy['id']
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_v2_get_policy_example(self):
+        """
+        v2_get_policy request example
+        """
+        try:
+            global example_policy_etag
+
+            print('\nv2_get_policy() result:')
+            # begin-v2_get_policy
+
+            response = iam_policy_management_service.v2_get_policy(policy_id=example_policy_id)
+            policy = response.get_result()
+
+            print(json.dumps(policy, indent=2))
+
+            # end-v2_get_policy
+
+            example_policy_etag = response.get_headers().get("Etag")
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_v2_update_policy_example(self):
+        """
+        v2_update_policy request example
+        """
+        try:
+
+            print('\nupdate_policy() result:')
+            # begin-v2_update_policy
+
+            policy_subject = V2PolicyBaseSubject(
+                attributes=[V2PolicyAttribute(key='iam_id', value=example_user_id, operator='stringEquals')]
+            )
+            updated_policy_role = PolicyRole(role_id='crn:v1:bluemix:public:iam::::role:Editor')
+            account_id_resource_attribute = V2PolicyAttribute(
+                key='accountId', value=example_account_id, operator='stringEquals'
+            )
+            service_name_resource_attribute = V2PolicyAttribute(
+                key='serviceType', value='service', operator='stringEquals'
+            )
+            policy_resource = PolicyResource(
+                attributes=[account_id_resource_attribute, service_name_resource_attribute],
+            )
+            policy_control = V2PolicyBaseControl(grant=V2PolicyBaseControlGrant(roles=[updated_policy_role]))
+            policy_rule = V2PolicyBaseRuleV2RuleWithConditions(
+                operator='and',
+                conditions=[
+                    V2PolicyAttribute(
+                        key='{{environment.attributes.day_of_week}}', operator='dayOfWeekAnyOf', value=[1, 2, 3, 4, 5]
+                    ),
+                    V2PolicyAttribute(
+                        key='{{environment.attributes.current_time}}',
+                        operator='timeGreaterThanOrEquals',
+                        value='09:00:00+00:00',
+                    ),
+                    V2PolicyAttribute(
+                        key='{{environment.attributes.current_time}}',
+                        operator='timeLessThanOrEquals',
+                        value='17:00:00+00:00',
+                    ),
+                ],
+            )
+            policy_pattern = 'time-based-restrictions:weekly'
+
+            response = iam_policy_management_service.v2_update_policy(
+                type='access',
+                policy_id=example_policy_id,
+                if_match=example_policy_etag,
+                subject=policy_subject,
+                control=policy_control,
+                resource=policy_resource,
+                rule=policy_rule,
+                pattern=policy_pattern,
+            )
+            policy = response.get_result()
+
+            print(json.dumps(policy, indent=2))
+
+            # end-v2_update_policy
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_v2_list_policies_example(self):
+        """
+        v2_list_policies request example
+        """
+        try:
+
+            print('\nlist_policies() result:')
+            # begin-v2_list_policies
+
+            policy_list = iam_policy_management_service.v2_list_policies(
+                account_id=example_account_id, iam_id=example_user_id, format='include_last_permit'
+            ).get_result()
+
+            print(json.dumps(policy_list, indent=2))
+
+            # end-v2_list_policies
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_v2_delete_policy_example(self):
+        """
+        v2_delete_policy request example
+        """
+        try:
+
+            print('\nv2_delete_policy() result:')
+            # begin-v2_delete_policy
+
+            response = iam_policy_management_service.v2_delete_policy(policy_id=example_policy_id).get_result()
+
+            print(json.dumps(response, indent=2))
+
+            # end-v2_delete_policy
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
     def test_create_role_example(self):
         """
         create_role request example

--- a/ibm_platform_services/iam_policy_management_v1.py
+++ b/ibm_platform_services/iam_policy_management_v1.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# (C) Copyright IBM Corp. 2022.
+# (C) Copyright IBM Corp. 2023.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# IBM OpenAPI SDK Code Generator Version: 3.62.0-a2a22f95-20221115-162524
+# IBM OpenAPI SDK Code Generator Version: 3.64.0-959a5845-20230112-195144
 
 """
 IAM Policy Management API
@@ -101,7 +101,10 @@ class IamPolicyManagementV1(BaseService):
         account_id, iam_id, access_group_id, type, service_type, sort, format and state.
         account_id is a required query parameter. Only policies that have the specified
         attributes and that the caller has read access to are returned. If the caller does
-        not have read access to any policies an empty array is returned.
+        not have read access to any policies an empty array is returned. If a policy was
+        created using the new beta v2/policies API, then the caller will see placeholder
+        information, e.g., "unsupported version" for iam_id, and a valid v2/policies href.
+        The caller should use this href to view the policy.
 
         :param str account_id: The account GUID in which the policies belong to.
         :param str accept_language: (optional) Language code for translations
@@ -142,7 +145,9 @@ class IamPolicyManagementV1(BaseService):
 
         if not account_id:
             raise ValueError('account_id must be provided')
-        headers = {'Accept-Language': accept_language}
+        headers = {
+            'Accept-Language': accept_language,
+        }
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='list_policies'
         )
@@ -265,13 +270,21 @@ class IamPolicyManagementV1(BaseService):
         subjects = [convert_model(x) for x in subjects]
         roles = [convert_model(x) for x in roles]
         resources = [convert_model(x) for x in resources]
-        headers = {'Accept-Language': accept_language}
+        headers = {
+            'Accept-Language': accept_language,
+        }
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='create_policy'
         )
         headers.update(sdk_headers)
 
-        data = {'type': type, 'subjects': subjects, 'roles': roles, 'resources': resources, 'description': description}
+        data = {
+            'type': type,
+            'subjects': subjects,
+            'roles': roles,
+            'resources': resources,
+            'description': description,
+        }
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
         headers['content-type'] = 'application/json'
@@ -287,7 +300,7 @@ class IamPolicyManagementV1(BaseService):
         response = self.send(request, **kwargs)
         return response
 
-    def update_policy(
+    def replace_policy(
         self,
         policy_id: str,
         if_match: str,
@@ -371,13 +384,21 @@ class IamPolicyManagementV1(BaseService):
         subjects = [convert_model(x) for x in subjects]
         roles = [convert_model(x) for x in roles]
         resources = [convert_model(x) for x in resources]
-        headers = {'If-Match': if_match}
+        headers = {
+            'If-Match': if_match,
+        }
         sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='update_policy'
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='replace_policy'
         )
         headers.update(sdk_headers)
 
-        data = {'type': type, 'subjects': subjects, 'roles': roles, 'resources': resources, 'description': description}
+        data = {
+            'type': type,
+            'subjects': subjects,
+            'roles': roles,
+            'resources': resources,
+            'description': description,
+        }
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
         headers['content-type'] = 'application/json'
@@ -465,7 +486,7 @@ class IamPolicyManagementV1(BaseService):
         response = self.send(request, **kwargs)
         return response
 
-    def patch_policy(self, policy_id: str, if_match: str, *, state: str = None, **kwargs) -> DetailedResponse:
+    def update_policy_state(self, policy_id: str, if_match: str, *, state: str = None, **kwargs) -> DetailedResponse:
         """
         Restore a deleted policy by ID.
 
@@ -488,13 +509,17 @@ class IamPolicyManagementV1(BaseService):
             raise ValueError('policy_id must be provided')
         if not if_match:
             raise ValueError('if_match must be provided')
-        headers = {'If-Match': if_match}
+        headers = {
+            'If-Match': if_match,
+        }
         sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='patch_policy'
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='update_policy_state'
         )
         headers.update(sdk_headers)
 
-        data = {'state': state}
+        data = {
+            'state': state,
+        }
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
         headers['content-type'] = 'application/json'
@@ -560,7 +585,9 @@ class IamPolicyManagementV1(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `RoleList` object
         """
 
-        headers = {'Accept-Language': accept_language}
+        headers = {
+            'Accept-Language': accept_language,
+        }
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='list_roles'
         )
@@ -642,7 +669,9 @@ class IamPolicyManagementV1(BaseService):
             raise ValueError('account_id must be provided')
         if service_name is None:
             raise ValueError('service_name must be provided')
-        headers = {'Accept-Language': accept_language}
+        headers = {
+            'Accept-Language': accept_language,
+        }
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='create_role'
         )
@@ -671,15 +700,8 @@ class IamPolicyManagementV1(BaseService):
         response = self.send(request, **kwargs)
         return response
 
-    def update_role(
-        self,
-        role_id: str,
-        if_match: str,
-        *,
-        display_name: str = None,
-        description: str = None,
-        actions: List[str] = None,
-        **kwargs
+    def replace_role(
+        self, role_id: str, if_match: str, display_name: str, actions: List[str], *, description: str = None, **kwargs
     ) -> DetailedResponse:
         """
         Update a role.
@@ -692,12 +714,12 @@ class IamPolicyManagementV1(BaseService):
         :param str if_match: The revision number for updating a role and must match
                the ETag value of the existing role. The Etag can be retrieved using the
                GET /v2/roles/{role_id} API and looking at the ETag response header.
-        :param str display_name: (optional) The display name of the role that is
-               shown in the console.
-        :param str description: (optional) The description of the role.
-        :param List[str] actions: (optional) The actions of the role. Please refer
-               to [IAM roles and
+        :param str display_name: The display name of the role that is shown in the
+               console.
+        :param List[str] actions: The actions of the role. Please refer to [IAM
+               roles and
                actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions).
+        :param str description: (optional) The description of the role.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `CustomRole` object
@@ -707,13 +729,23 @@ class IamPolicyManagementV1(BaseService):
             raise ValueError('role_id must be provided')
         if not if_match:
             raise ValueError('if_match must be provided')
-        headers = {'If-Match': if_match}
+        if display_name is None:
+            raise ValueError('display_name must be provided')
+        if actions is None:
+            raise ValueError('actions must be provided')
+        headers = {
+            'If-Match': if_match,
+        }
         sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='update_role'
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='replace_role'
         )
         headers.update(sdk_headers)
 
-        data = {'display_name': display_name, 'description': description, 'actions': actions}
+        data = {
+            'display_name': display_name,
+            'actions': actions,
+            'description': description,
+        }
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
         headers['content-type'] = 'application/json'
@@ -800,10 +832,10 @@ class IamPolicyManagementV1(BaseService):
         return response
 
     #########################
-    # v2Policies
+    # v2/Policies
     #########################
 
-    def v2_list_policies(
+    def list_v2_policies(
         self,
         account_id: str,
         *,
@@ -858,14 +890,16 @@ class IamPolicyManagementV1(BaseService):
                * `deleted` - returns non-active policies.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
-        :rtype: DetailedResponse with `dict` result representing a `V2PolicyList` object
+        :rtype: DetailedResponse with `dict` result representing a `V2PolicyCollection` object
         """
 
         if not account_id:
             raise ValueError('account_id must be provided')
-        headers = {'Accept-Language': accept_language}
+        headers = {
+            'Accept-Language': accept_language,
+        }
         sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='v2_list_policies'
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='list_v2_policies'
         )
         headers.update(sdk_headers)
 
@@ -892,16 +926,16 @@ class IamPolicyManagementV1(BaseService):
         response = self.send(request, **kwargs)
         return response
 
-    def v2_create_policy(
+    def create_v2_policy(
         self,
+        control: 'Control',
         type: str,
-        control: 'V2PolicyBaseControl',
         *,
         description: str = None,
-        subject: 'V2PolicyBaseSubject' = None,
-        resource: 'V2PolicyBaseResource' = None,
+        subject: 'V2PolicySubject' = None,
+        resource: 'V2PolicyResource' = None,
         pattern: str = None,
-        rule: 'V2PolicyBaseRule' = None,
+        rule: 'V2PolicyRule' = None,
         accept_language: str = None,
         **kwargs
     ) -> DetailedResponse:
@@ -918,24 +952,27 @@ class IamPolicyManagementV1(BaseService):
         **`iam_id`** subject attribute for assigning access for a user or service-id. Use
         the **`access_group_id`** subject attribute for assigning access for an access
         group. The roles must be a subset of a service's or the platform's supported
-        roles. The resource attributes must be a subset of a service's or the platform's
+        roles. For more information, see [IAM roles and
+        actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions).
+        The resource attributes must be a subset of a service's or the platform's
+        supported attributes. Caller should check with service, e.g.,
+        [VPC](https://cloud.ibm.com/docs/vpc?topic=vpc-resource-attributes), to view
         supported attributes. The policy resource must include either the
         **`serviceType`**, **`serviceName`**, **`resourceGroupId`** or
         **`service_group_id`** attribute and the **`accountId`** attribute.` The rule
         field can either specify single **`key`**, **`value`**, and **`operator`** or be
         set of **`conditions`** with a combination **`operator`**.  The possible
-        combination operator are **`and`** and **`or`**. The rule field has a maximum of 2
-        levels of nested **`conditions`**. The operator for a rule can be used to specify
-        a time based restriction (e.g., access only during business hours, during the
-        Monday-Friday work week). For example, a policy can grant access Monday-Friday,
-        9:00am-5:00pm using the following rule:
+        combination operator are **`and`** and **`or`**. The operator for a rule can be
+        used to specify a time-based condition (e.g., access only during business hours,
+        during the Monday-Friday work week). For example, a policy can grant access
+        Monday-Friday, 9:00am-5:00pm using the following rule:
         ```json
           "rule": {
             "operator": "and",
             "conditions": [{
               "key": "{{environment.attributes.day_of_week}}",
               "operator": "dayOfWeekAnyOf",
-              "value": [1, 2, 3, 4, 5]
+              "value": ["1+00:00", "2+00:00", "3+00:00", "4+00:00", "5+00:00"]
             },
               "key": "{{environment.attributes.current_time}}",
               "operator": "timeGreaterThanOrEquals",
@@ -951,19 +988,22 @@ class IamPolicyManagementV1(BaseService):
         ```
           'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan',
         'timeGreaterThanOrEquals',
-          'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan',
-        'dateGreaterThanOrEquals',
           'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan',
         'dateTimeGreaterThanOrEquals',
           'dayOfWeekEquals', 'dayOfWeekAnyOf',
-          'monthEquals', 'monthAnyOf',
-          'dayOfMonthEquals', 'dayOfMonthAnyOf'
-        ``` The pattern field can be coupled with a rule that matches the pattern. For the
+        ```
+        The pattern field that matches the rule is required when rule is provided. For the
         business hour rule example above, the **`pattern`** is
-        **`"time-based-restrictions:weekly"`**. The IAM Services group (`IAM`) is a subset
-        of account management services that includes the IAM platform services IAM
-        Identity, IAM Access Management, IAM Users Management, IAM Groups, and future IAM
-        services. If the subject is a locked service-id, the request will fail.
+        **`"time-based-conditions:weekly"`**. For more information, see [Time-based
+        conditions
+        operators](https://cloud.ibm.com/docs/account?topic=account-iam-condition-properties&interface=ui#policy-condition-properties)
+        and
+        [Limiting access with time-based
+        conditions](https://cloud.ibm.com/docs/account?topic=account-iam-time-based&interface=ui).
+        The IAM Services group (`IAM`) is a subset of account management services that
+        includes the IAM platform services IAM Identity, IAM Access Management, IAM Users
+        Management, IAM Groups, and future IAM services. If the subject is a locked
+        service-id, the request will fail.
         ### Attribute Operators
         Currently, only the `stringEquals`, `stringMatch`, and `stringEquals` operators
         are available. For more information, see [how to assign access by using wildcards
@@ -974,17 +1014,19 @@ class IamPolicyManagementV1(BaseService):
         locationvalues are supported by the service, they are validated against Global
         Catalog locations.
 
+        :param Control control: Specifies the type of access granted by the policy.
         :param str type: The policy type; either 'access' or 'authorization'.
-        :param V2PolicyBaseControl control: Specifies the type of access granted by
-               the policy.
-        :param str description: (optional) Customer-defined description.
-        :param V2PolicyBaseSubject subject: (optional) The subject attributes
-               associated with a policy.
-        :param V2PolicyBaseResource resource: (optional) The resource attributes
-               associated with a policy.
-        :param str pattern: (optional) Indicates pattern of rule.
-        :param V2PolicyBaseRule rule: (optional) Additional access conditions
-               associated with a policy.
+        :param str description: (optional) Allows the customer to use their own
+               words to record the purpose/context related to a policy.
+        :param V2PolicySubject subject: (optional) The subject attributes for whom
+               the policy grants access.
+        :param V2PolicyResource resource: (optional) The resource attributes to
+               which the policy grants access.
+        :param str pattern: (optional) Indicates pattern of rule, either
+               'time-based-conditions:once', 'time-based-conditions:weekly:all-day', or
+               'time-based-conditions:weekly:custom-hours'.
+        :param V2PolicyRule rule: (optional) Additional access conditions
+               associated with the policy.
         :param str accept_language: (optional) Language code for translations
                * `default` - English
                * `de` -  German (Standard)
@@ -1002,10 +1044,10 @@ class IamPolicyManagementV1(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `V2Policy` object
         """
 
-        if type is None:
-            raise ValueError('type must be provided')
         if control is None:
             raise ValueError('control must be provided')
+        if type is None:
+            raise ValueError('type must be provided')
         control = convert_model(control)
         if subject is not None:
             subject = convert_model(subject)
@@ -1013,15 +1055,17 @@ class IamPolicyManagementV1(BaseService):
             resource = convert_model(resource)
         if rule is not None:
             rule = convert_model(rule)
-        headers = {'Accept-Language': accept_language}
+        headers = {
+            'Accept-Language': accept_language,
+        }
         sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='v2_create_policy'
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='create_v2_policy'
         )
         headers.update(sdk_headers)
 
         data = {
-            'type': type,
             'control': control,
+            'type': type,
             'description': description,
             'subject': subject,
             'resource': resource,
@@ -1043,18 +1087,18 @@ class IamPolicyManagementV1(BaseService):
         response = self.send(request, **kwargs)
         return response
 
-    def v2_update_policy(
+    def replace_v2_policy(
         self,
-        policy_id: str,
+        id: str,
         if_match: str,
+        control: 'Control',
         type: str,
-        control: 'V2PolicyBaseControl',
         *,
         description: str = None,
-        subject: 'V2PolicyBaseSubject' = None,
-        resource: 'V2PolicyBaseResource' = None,
+        subject: 'V2PolicySubject' = None,
+        resource: 'V2PolicyResource' = None,
         pattern: str = None,
-        rule: 'V2PolicyBaseRule' = None,
+        rule: 'V2PolicyRule' = None,
         **kwargs
     ) -> DetailedResponse:
         """
@@ -1068,23 +1112,26 @@ class IamPolicyManagementV1(BaseService):
         **`iam_id`** subject attribute for assigning access for a user or service-id. Use
         the **`access_group_id`** subject attribute for assigning access for an access
         group. The roles must be a subset of a service's or the platform's supported
-        roles. The resource attributes must be a subset of a service's or the platform's
+        roles. For more information, see [IAM roles and
+        actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions).
+        The resource attributes must be a subset of a service's or the platform's
+        supported attributes. Caller should check with service, e.g.,
+        [VPC](https://cloud.ibm.com/docs/vpc?topic=vpc-resource-attributes), to view
         supported attributes. The policy resource must include either the
         **`serviceType`**, **`serviceName`**,  or **`resourceGroupId`** attribute and the
         **`accountId`** attribute.` The rule field can either specify single **`key`**,
         **`value`**, and **`operator`** or be set of **`conditions`** with a combination
         **`operator`**.  The possible combination operator are **`and`** and **`or`**. The
-        rule field has a maximum of 2 levels of nested **`conditions`**. The operator for
-        a rule can be used to specify a time based restriction (e.g., access only during
-        business hours, during the Monday-Friday work week). For example, a policy can
-        grant access Monday-Friday, 9:00am-5:00pm using the following rule:
+        operator for a rule can be used to specify a time-based condition (e.g., access
+        only during business hours, during the Monday-Friday work week). For example, a
+        policy can grant access Monday-Friday, 9:00am-5:00pm using the following rule:
         ```json
           "rule": {
             "operator": "and",
             "conditions": [{
               "key": "{{environment.attributes.day_of_week}}",
               "operator": "dayOfWeekAnyOf",
-              "value": [1, 2, 3, 4, 5]
+              "value": ["1+00:00", "2+00:00", "3+00:00", "4+00:00", "5+00:00"]
             },
               "key": "{{environment.attributes.current_time}}",
               "operator": "timeGreaterThanOrEquals",
@@ -1100,17 +1147,17 @@ class IamPolicyManagementV1(BaseService):
         ```
           'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan',
         'timeGreaterThanOrEquals',
-          'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan',
-        'dateGreaterThanOrEquals',
           'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan',
         'dateTimeGreaterThanOrEquals',
           'dayOfWeekEquals', 'dayOfWeekAnyOf',
-          'monthEquals', 'monthAnyOf',
-          'dayOfMonthEquals', 'dayOfMonthAnyOf'
-        ``` The pattern field can be coupled with a rule that matches the pattern. For the
-        business hour rule example above, the **`pattern`** is
-        **`"time-based-restrictions:weekly"`**. If the subject is a locked service-id, the
-        request will fail.
+        ``` The pattern field that matches the rule is required when rule is provided. For
+        the business hour rule example above, the **`pattern`** is
+        **`"time-based-conditions:weekly"`**. For more information, see [Time-based
+        conditions
+        operators](https://cloud.ibm.com/docs/account?topic=account-iam-condition-properties&interface=ui#policy-condition-properties)
+        and
+        [Limiting access with time-based
+        conditions](https://cloud.ibm.com/docs/account?topic=account-iam-time-based&interface=ui).
         ### Attribute Operators
         Currently, only the `stringEquals`, `stringMatch`, and `stringEquals` operators
         are available. For more information, see [how to assign access by using wildcards
@@ -1121,35 +1168,37 @@ class IamPolicyManagementV1(BaseService):
         locationvalues are supported by the service, they are validated against Global
         Catalog locations.
 
-        :param str policy_id: The policy ID.
+        :param str id: The policy ID.
         :param str if_match: The revision number for updating a policy and must
                match the ETag value of the existing policy. The Etag can be retrieved
-               using the GET /v1/policies/{policy_id} API and looking at the ETag response
+               using the GET /v2/policies/{id} API and looking at the ETag response
                header.
+        :param Control control: Specifies the type of access granted by the policy.
         :param str type: The policy type; either 'access' or 'authorization'.
-        :param V2PolicyBaseControl control: Specifies the type of access granted by
-               the policy.
-        :param str description: (optional) Customer-defined description.
-        :param V2PolicyBaseSubject subject: (optional) The subject attributes
-               associated with a policy.
-        :param V2PolicyBaseResource resource: (optional) The resource attributes
-               associated with a policy.
-        :param str pattern: (optional) Indicates pattern of rule.
-        :param V2PolicyBaseRule rule: (optional) Additional access conditions
-               associated with a policy.
+        :param str description: (optional) Allows the customer to use their own
+               words to record the purpose/context related to a policy.
+        :param V2PolicySubject subject: (optional) The subject attributes for whom
+               the policy grants access.
+        :param V2PolicyResource resource: (optional) The resource attributes to
+               which the policy grants access.
+        :param str pattern: (optional) Indicates pattern of rule, either
+               'time-based-conditions:once', 'time-based-conditions:weekly:all-day', or
+               'time-based-conditions:weekly:custom-hours'.
+        :param V2PolicyRule rule: (optional) Additional access conditions
+               associated with the policy.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `V2Policy` object
         """
 
-        if not policy_id:
-            raise ValueError('policy_id must be provided')
+        if not id:
+            raise ValueError('id must be provided')
         if not if_match:
             raise ValueError('if_match must be provided')
-        if type is None:
-            raise ValueError('type must be provided')
         if control is None:
             raise ValueError('control must be provided')
+        if type is None:
+            raise ValueError('type must be provided')
         control = convert_model(control)
         if subject is not None:
             subject = convert_model(subject)
@@ -1157,15 +1206,17 @@ class IamPolicyManagementV1(BaseService):
             resource = convert_model(resource)
         if rule is not None:
             rule = convert_model(rule)
-        headers = {'If-Match': if_match}
+        headers = {
+            'If-Match': if_match,
+        }
         sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='v2_update_policy'
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='replace_v2_policy'
         )
         headers.update(sdk_headers)
 
         data = {
-            'type': type,
             'control': control,
+            'type': type,
             'description': description,
             'subject': subject,
             'resource': resource,
@@ -1181,32 +1232,32 @@ class IamPolicyManagementV1(BaseService):
             del kwargs['headers']
         headers['Accept'] = 'application/json'
 
-        path_param_keys = ['policy_id']
-        path_param_values = self.encode_path_vars(policy_id)
+        path_param_keys = ['id']
+        path_param_values = self.encode_path_vars(id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v2/policies/{policy_id}'.format(**path_param_dict)
+        url = '/v2/policies/{id}'.format(**path_param_dict)
         request = self.prepare_request(method='PUT', url=url, headers=headers, data=data)
 
         response = self.send(request, **kwargs)
         return response
 
-    def v2_get_policy(self, policy_id: str, **kwargs) -> DetailedResponse:
+    def get_v2_policy(self, id: str, **kwargs) -> DetailedResponse:
         """
         Retrieve a policy by ID.
 
         Retrieve a policy by providing a policy ID.
 
-        :param str policy_id: The policy ID.
+        :param str id: The policy ID.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `V2Policy` object
         """
 
-        if not policy_id:
-            raise ValueError('policy_id must be provided')
+        if not id:
+            raise ValueError('id must be provided')
         headers = {}
         sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='v2_get_policy'
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='get_v2_policy'
         )
         headers.update(sdk_headers)
 
@@ -1215,16 +1266,16 @@ class IamPolicyManagementV1(BaseService):
             del kwargs['headers']
         headers['Accept'] = 'application/json'
 
-        path_param_keys = ['policy_id']
-        path_param_values = self.encode_path_vars(policy_id)
+        path_param_keys = ['id']
+        path_param_values = self.encode_path_vars(id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v2/policies/{policy_id}'.format(**path_param_dict)
+        url = '/v2/policies/{id}'.format(**path_param_dict)
         request = self.prepare_request(method='GET', url=url, headers=headers)
 
         response = self.send(request, **kwargs)
         return response
 
-    def v2_delete_policy(self, policy_id: str, **kwargs) -> DetailedResponse:
+    def delete_v2_policy(self, id: str, **kwargs) -> DetailedResponse:
         """
         Delete a policy by ID.
 
@@ -1232,17 +1283,17 @@ class IamPolicyManagementV1(BaseService):
         subject ID contains a locked service ID. If the subject of the policy is a locked
         service-id, the request will fail.
 
-        :param str policy_id: The policy ID.
+        :param str id: The policy ID.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse
         """
 
-        if not policy_id:
-            raise ValueError('policy_id must be provided')
+        if not id:
+            raise ValueError('id must be provided')
         headers = {}
         sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='v2_delete_policy'
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='delete_v2_policy'
         )
         headers.update(sdk_headers)
 
@@ -1250,10 +1301,10 @@ class IamPolicyManagementV1(BaseService):
             headers.update(kwargs.get('headers'))
             del kwargs['headers']
 
-        path_param_keys = ['policy_id']
-        path_param_values = self.encode_path_vars(policy_id)
+        path_param_keys = ['id']
+        path_param_values = self.encode_path_vars(id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v2/policies/{policy_id}'.format(**path_param_dict)
+        url = '/v2/policies/{id}'.format(**path_param_dict)
         request = self.prepare_request(method='DELETE', url=url, headers=headers)
 
         response = self.send(request, **kwargs)
@@ -1319,9 +1370,9 @@ class ListPoliciesEnums:
         DELETED = 'deleted'
 
 
-class V2ListPoliciesEnums:
+class ListV2PoliciesEnums:
     """
-    Enums for v2_list_policies parameters.
+    Enums for list_v2_policies parameters.
     """
 
     class Type(str, Enum):
@@ -1368,34 +1419,34 @@ class V2ListPoliciesEnums:
 ##############################################################################
 
 
-class V2PolicyBaseControl:
+class Control:
     """
     Specifies the type of access granted by the policy.
 
-    :attr V2PolicyBaseControlGrant grant: Permission granted by the policy.
+    :attr V2PolicyGrant grant: Permission granted by the policy.
     """
 
-    def __init__(self, grant: 'V2PolicyBaseControlGrant') -> None:
+    def __init__(self, grant: 'V2PolicyGrant') -> None:
         """
-        Initialize a V2PolicyBaseControl object.
+        Initialize a Control object.
 
-        :param V2PolicyBaseControlGrant grant: Permission granted by the policy.
+        :param V2PolicyGrant grant: Permission granted by the policy.
         """
         self.grant = grant
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseControl':
-        """Initialize a V2PolicyBaseControl object from a json dictionary."""
+    def from_dict(cls, _dict: Dict) -> 'Control':
+        """Initialize a Control object from a json dictionary."""
         args = {}
         if 'grant' in _dict:
-            args['grant'] = V2PolicyBaseControlGrant.from_dict(_dict.get('grant'))
+            args['grant'] = V2PolicyGrant.from_dict(_dict.get('grant'))
         else:
-            raise ValueError('Required property \'grant\' not present in V2PolicyBaseControl JSON')
+            raise ValueError('Required property \'grant\' not present in Control JSON')
         return cls(**args)
 
     @classmethod
     def _from_dict(cls, _dict):
-        """Initialize a V2PolicyBaseControl object from a json dictionary."""
+        """Initialize a Control object from a json dictionary."""
         return cls.from_dict(_dict)
 
     def to_dict(self) -> Dict:
@@ -1413,50 +1464,67 @@ class V2PolicyBaseControl:
         return self.to_dict()
 
     def __str__(self) -> str:
-        """Return a `str` version of this V2PolicyBaseControl object."""
+        """Return a `str` version of this Control object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: 'V2PolicyBaseControl') -> bool:
+    def __eq__(self, other: 'Control') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: 'V2PolicyBaseControl') -> bool:
+    def __ne__(self, other: 'Control') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
 
-class V2PolicyBaseControlGrant:
+class ControlResponse:
     """
-    Permission granted by the policy.
+    ControlResponse.
 
-    :attr List[PolicyRole] roles: A set of role cloud resource names (CRNs) granted
-          by the policy.
     """
 
-    def __init__(self, roles: List['PolicyRole']) -> None:
+    def __init__(self) -> None:
         """
-        Initialize a V2PolicyBaseControlGrant object.
+        Initialize a ControlResponse object.
 
-        :param List[PolicyRole] roles: A set of role cloud resource names (CRNs)
-               granted by the policy.
+        """
+        msg = "Cannot instantiate base class. Instead, instantiate one of the defined subclasses: {0}".format(
+            ", ".join(['ControlResponseControl', 'ControlResponseControlWithTranslatedRoles'])
+        )
+        raise Exception(msg)
+
+
+class GrantWithTranslatedRoles:
+    """
+    Permission granted by the policy with translated roles and additional role
+    information.
+
+    :attr List[RoleInDisplayFormat] roles: A set of roles granted by the policy.
+    """
+
+    def __init__(self, roles: List['RoleInDisplayFormat']) -> None:
+        """
+        Initialize a GrantWithTranslatedRoles object.
+
+        :param List[RoleInDisplayFormat] roles: A set of roles granted by the
+               policy.
         """
         self.roles = roles
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseControlGrant':
-        """Initialize a V2PolicyBaseControlGrant object from a json dictionary."""
+    def from_dict(cls, _dict: Dict) -> 'GrantWithTranslatedRoles':
+        """Initialize a GrantWithTranslatedRoles object from a json dictionary."""
         args = {}
         if 'roles' in _dict:
-            args['roles'] = [PolicyRole.from_dict(v) for v in _dict.get('roles')]
+            args['roles'] = [RoleInDisplayFormat.from_dict(v) for v in _dict.get('roles')]
         else:
-            raise ValueError('Required property \'roles\' not present in V2PolicyBaseControlGrant JSON')
+            raise ValueError('Required property \'roles\' not present in GrantWithTranslatedRoles JSON')
         return cls(**args)
 
     @classmethod
     def _from_dict(cls, _dict):
-        """Initialize a V2PolicyBaseControlGrant object from a json dictionary."""
+        """Initialize a GrantWithTranslatedRoles object from a json dictionary."""
         return cls.from_dict(_dict)
 
     def to_dict(self) -> Dict:
@@ -1477,48 +1545,746 @@ class V2PolicyBaseControlGrant:
         return self.to_dict()
 
     def __str__(self) -> str:
-        """Return a `str` version of this V2PolicyBaseControlGrant object."""
+        """Return a `str` version of this GrantWithTranslatedRoles object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: 'V2PolicyBaseControlGrant') -> bool:
+    def __eq__(self, other: 'GrantWithTranslatedRoles') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: 'V2PolicyBaseControlGrant') -> bool:
+    def __ne__(self, other: 'GrantWithTranslatedRoles') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
 
-class V2PolicyBaseResource:
+class PolicyRole:
     """
-    The resource attributes associated with a policy.
+    A role associated with a policy.
 
-    :attr List[V2PolicyAttribute] attributes: (optional) List of resource attributes
-          associated with policy/.
+    :attr str role_id: The role Cloud Resource Name (CRN) granted by the policy.
+          Example CRN: 'crn:v1:bluemix:public:iam::::role:Editor'.
+    :attr str display_name: (optional) The display name of the role.
+    :attr str description: (optional) The description of the role.
     """
 
-    def __init__(self, *, attributes: List['V2PolicyAttribute'] = None) -> None:
+    def __init__(self, role_id: str, *, display_name: str = None, description: str = None) -> None:
         """
-        Initialize a V2PolicyBaseResource object.
+        Initialize a PolicyRole object.
 
-        :param List[V2PolicyAttribute] attributes: (optional) List of resource
-               attributes associated with policy/.
+        :param str role_id: The role Cloud Resource Name (CRN) granted by the
+               policy. Example CRN: 'crn:v1:bluemix:public:iam::::role:Editor'.
         """
-        self.attributes = attributes
+        self.role_id = role_id
+        self.display_name = display_name
+        self.description = description
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseResource':
-        """Initialize a V2PolicyBaseResource object from a json dictionary."""
+    def from_dict(cls, _dict: Dict) -> 'PolicyRole':
+        """Initialize a PolicyRole object from a json dictionary."""
         args = {}
-        if 'attributes' in _dict:
-            args['attributes'] = [V2PolicyAttribute.from_dict(v) for v in _dict.get('attributes')]
+        if 'role_id' in _dict:
+            args['role_id'] = _dict.get('role_id')
+        else:
+            raise ValueError('Required property \'role_id\' not present in PolicyRole JSON')
+        if 'display_name' in _dict:
+            args['display_name'] = _dict.get('display_name')
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
         return cls(**args)
 
     @classmethod
     def _from_dict(cls, _dict):
-        """Initialize a V2PolicyBaseResource object from a json dictionary."""
+        """Initialize a PolicyRole object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'role_id') and self.role_id is not None:
+            _dict['role_id'] = self.role_id
+        if hasattr(self, 'display_name') and getattr(self, 'display_name') is not None:
+            _dict['display_name'] = getattr(self, 'display_name')
+        if hasattr(self, 'description') and getattr(self, 'description') is not None:
+            _dict['description'] = getattr(self, 'description')
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyRole object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyRole') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyRole') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class RoleAction:
+    """
+    An action that can be performed by the policy subject when assigned role.
+
+    :attr str id: Unique identifier for action with structure
+          service.resource.action e.g., cbr.rule.read.
+    :attr str display_name: Service defined display name for action.
+    :attr str description: Service defined description for action.
+    """
+
+    def __init__(self, id: str, display_name: str, description: str) -> None:
+        """
+        Initialize a RoleAction object.
+
+        :param str id: Unique identifier for action with structure
+               service.resource.action e.g., cbr.rule.read.
+        :param str display_name: Service defined display name for action.
+        :param str description: Service defined description for action.
+        """
+        self.id = id
+        self.display_name = display_name
+        self.description = description
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'RoleAction':
+        """Initialize a RoleAction object from a json dictionary."""
+        args = {}
+        if 'id' in _dict:
+            args['id'] = _dict.get('id')
+        else:
+            raise ValueError('Required property \'id\' not present in RoleAction JSON')
+        if 'display_name' in _dict:
+            args['display_name'] = _dict.get('display_name')
+        else:
+            raise ValueError('Required property \'display_name\' not present in RoleAction JSON')
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
+        else:
+            raise ValueError('Required property \'description\' not present in RoleAction JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a RoleAction object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'display_name') and self.display_name is not None:
+            _dict['display_name'] = self.display_name
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this RoleAction object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'RoleAction') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'RoleAction') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class RoleInDisplayFormat:
+    """
+    A role associated with a policy with additional information (display_name,
+    description, actions) when `format=display`.
+
+    :attr str role_id: The role Cloud Resource Name (CRN) granted by the policy.
+          Example CRN: 'crn:v1:bluemix:public:iam::::role:Editor'.
+    :attr str display_name: (optional) The service defined (or user defined if a
+          custom role) display name of the role.
+    :attr str description: (optional) The service defined (or user defined if a
+          custom role) description of the role.
+    :attr List[RoleAction] actions: The actions of the role. Please refer to [IAM
+          roles and
+          actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions).
+    """
+
+    def __init__(
+        self, role_id: str, actions: List['RoleAction'], *, display_name: str = None, description: str = None
+    ) -> None:
+        """
+        Initialize a RoleInDisplayFormat object.
+
+        :param str role_id: The role Cloud Resource Name (CRN) granted by the
+               policy. Example CRN: 'crn:v1:bluemix:public:iam::::role:Editor'.
+        :param List[RoleAction] actions: The actions of the role. Please refer to
+               [IAM roles and
+               actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions).
+        """
+        self.role_id = role_id
+        self.display_name = display_name
+        self.description = description
+        self.actions = actions
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'RoleInDisplayFormat':
+        """Initialize a RoleInDisplayFormat object from a json dictionary."""
+        args = {}
+        if 'role_id' in _dict:
+            args['role_id'] = _dict.get('role_id')
+        else:
+            raise ValueError('Required property \'role_id\' not present in RoleInDisplayFormat JSON')
+        if 'display_name' in _dict:
+            args['display_name'] = _dict.get('display_name')
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
+        if 'actions' in _dict:
+            args['actions'] = [RoleAction.from_dict(v) for v in _dict.get('actions')]
+        else:
+            raise ValueError('Required property \'actions\' not present in RoleInDisplayFormat JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a RoleInDisplayFormat object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'role_id') and self.role_id is not None:
+            _dict['role_id'] = self.role_id
+        if hasattr(self, 'display_name') and getattr(self, 'display_name') is not None:
+            _dict['display_name'] = getattr(self, 'display_name')
+        if hasattr(self, 'description') and getattr(self, 'description') is not None:
+            _dict['description'] = getattr(self, 'description')
+        if hasattr(self, 'actions') and self.actions is not None:
+            actions_list = []
+            for v in self.actions:
+                if isinstance(v, dict):
+                    actions_list.append(v)
+                else:
+                    actions_list.append(v.to_dict())
+            _dict['actions'] = actions_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this RoleInDisplayFormat object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'RoleInDisplayFormat') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'RoleInDisplayFormat') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class RuleAttribute:
+    """
+    Rule that specifies additional access granted (e.g., time-based condition).
+
+    :attr str key: The name of an attribute.
+    :attr str operator: The operator of an attribute.
+    :attr object value: The value of an rule or resource attribute; can be boolean
+          or string for resource attribute. Can be a string or an array of strings (e.g.,
+          array of days to permit access) for rule attribute.
+    """
+
+    def __init__(self, key: str, operator: str, value: object) -> None:
+        """
+        Initialize a RuleAttribute object.
+
+        :param str key: The name of an attribute.
+        :param str operator: The operator of an attribute.
+        :param object value: The value of an rule or resource attribute; can be
+               boolean or string for resource attribute. Can be a string or an array of
+               strings (e.g., array of days to permit access) for rule attribute.
+        """
+        self.key = key
+        self.operator = operator
+        self.value = value
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'RuleAttribute':
+        """Initialize a RuleAttribute object from a json dictionary."""
+        args = {}
+        if 'key' in _dict:
+            args['key'] = _dict.get('key')
+        else:
+            raise ValueError('Required property \'key\' not present in RuleAttribute JSON')
+        if 'operator' in _dict:
+            args['operator'] = _dict.get('operator')
+        else:
+            raise ValueError('Required property \'operator\' not present in RuleAttribute JSON')
+        if 'value' in _dict:
+            args['value'] = _dict.get('value')
+        else:
+            raise ValueError('Required property \'value\' not present in RuleAttribute JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a RuleAttribute object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'key') and self.key is not None:
+            _dict['key'] = self.key
+        if hasattr(self, 'operator') and self.operator is not None:
+            _dict['operator'] = self.operator
+        if hasattr(self, 'value') and self.value is not None:
+            _dict['value'] = self.value
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this RuleAttribute object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'RuleAttribute') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'RuleAttribute') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class OperatorEnum(str, Enum):
+        """
+        The operator of an attribute.
+        """
+
+        TIMELESSTHAN = 'timeLessThan'
+        TIMELESSTHANOREQUALS = 'timeLessThanOrEquals'
+        TIMEGREATERTHAN = 'timeGreaterThan'
+        TIMEGREATERTHANOREQUALS = 'timeGreaterThanOrEquals'
+        DATETIMELESSTHAN = 'dateTimeLessThan'
+        DATETIMELESSTHANOREQUALS = 'dateTimeLessThanOrEquals'
+        DATETIMEGREATERTHAN = 'dateTimeGreaterThan'
+        DATETIMEGREATERTHANOREQUALS = 'dateTimeGreaterThanOrEquals'
+        DAYOFWEEKEQUALS = 'dayOfWeekEquals'
+        DAYOFWEEKANYOF = 'dayOfWeekAnyOf'
+
+
+class V2Policy:
+    """
+    The core set of properties associated with the policy.
+
+    :attr str type: The policy type; either 'access' or 'authorization'.
+    :attr str description: (optional) Allows the customer to use their own words to
+          record the purpose/context related to a policy.
+    :attr V2PolicySubject subject: (optional) The subject attributes for whom the
+          policy grants access.
+    :attr V2PolicyResource resource: (optional) The resource attributes to which the
+          policy grants access.
+    :attr str pattern: (optional) Indicates pattern of rule, either
+          'time-based-conditions:once', 'time-based-conditions:weekly:all-day', or
+          'time-based-conditions:weekly:custom-hours'.
+    :attr V2PolicyRule rule: (optional) Additional access conditions associated with
+          the policy.
+    :attr str id: (optional) The policy ID.
+    :attr str href: (optional) The href URL that links to the policies API by policy
+          ID.
+    :attr ControlResponse control:
+    :attr datetime created_at: (optional) The UTC timestamp when the policy was
+          created.
+    :attr str created_by_id: (optional) The iam ID of the entity that created the
+          policy.
+    :attr datetime last_modified_at: (optional) The UTC timestamp when the policy
+          was last modified.
+    :attr str last_modified_by_id: (optional) The iam ID of the entity that last
+          modified the policy.
+    :attr str state: The policy state, either 'deleted' or 'active'.
+    :attr str last_permit_at: (optional) The optional last permit time of policy,
+          when passing query parameter format=include_last_permit.
+    :attr int last_permit_frequency: (optional) The optional count of times that
+          policy has provided a permit, when passing query parameter
+          format=include_last_permit.
+    """
+
+    def __init__(
+        self,
+        type: str,
+        control: 'ControlResponse',
+        state: str,
+        *,
+        description: str = None,
+        subject: 'V2PolicySubject' = None,
+        resource: 'V2PolicyResource' = None,
+        pattern: str = None,
+        rule: 'V2PolicyRule' = None,
+        id: str = None,
+        href: str = None,
+        created_at: datetime = None,
+        created_by_id: str = None,
+        last_modified_at: datetime = None,
+        last_modified_by_id: str = None,
+        last_permit_at: str = None,
+        last_permit_frequency: int = None
+    ) -> None:
+        """
+        Initialize a V2Policy object.
+
+        :param str type: The policy type; either 'access' or 'authorization'.
+        :param ControlResponse control:
+        :param str state: The policy state, either 'deleted' or 'active'.
+        :param str description: (optional) Allows the customer to use their own
+               words to record the purpose/context related to a policy.
+        :param V2PolicySubject subject: (optional) The subject attributes for whom
+               the policy grants access.
+        :param V2PolicyResource resource: (optional) The resource attributes to
+               which the policy grants access.
+        :param str pattern: (optional) Indicates pattern of rule, either
+               'time-based-conditions:once', 'time-based-conditions:weekly:all-day', or
+               'time-based-conditions:weekly:custom-hours'.
+        :param V2PolicyRule rule: (optional) Additional access conditions
+               associated with the policy.
+        :param str last_permit_at: (optional) The optional last permit time of
+               policy, when passing query parameter format=include_last_permit.
+        :param int last_permit_frequency: (optional) The optional count of times
+               that policy has provided a permit, when passing query parameter
+               format=include_last_permit.
+        """
+        self.type = type
+        self.description = description
+        self.subject = subject
+        self.resource = resource
+        self.pattern = pattern
+        self.rule = rule
+        self.id = id
+        self.href = href
+        self.control = control
+        self.created_at = created_at
+        self.created_by_id = created_by_id
+        self.last_modified_at = last_modified_at
+        self.last_modified_by_id = last_modified_by_id
+        self.state = state
+        self.last_permit_at = last_permit_at
+        self.last_permit_frequency = last_permit_frequency
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2Policy':
+        """Initialize a V2Policy object from a json dictionary."""
+        args = {}
+        if 'type' in _dict:
+            args['type'] = _dict.get('type')
+        else:
+            raise ValueError('Required property \'type\' not present in V2Policy JSON')
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
+        if 'subject' in _dict:
+            args['subject'] = V2PolicySubject.from_dict(_dict.get('subject'))
+        if 'resource' in _dict:
+            args['resource'] = V2PolicyResource.from_dict(_dict.get('resource'))
+        if 'pattern' in _dict:
+            args['pattern'] = _dict.get('pattern')
+        if 'rule' in _dict:
+            args['rule'] = _dict.get('rule')
+        if 'id' in _dict:
+            args['id'] = _dict.get('id')
+        if 'href' in _dict:
+            args['href'] = _dict.get('href')
+        if 'control' in _dict:
+            args['control'] = _dict.get('control')
+        else:
+            raise ValueError('Required property \'control\' not present in V2Policy JSON')
+        if 'created_at' in _dict:
+            args['created_at'] = string_to_datetime(_dict.get('created_at'))
+        if 'created_by_id' in _dict:
+            args['created_by_id'] = _dict.get('created_by_id')
+        if 'last_modified_at' in _dict:
+            args['last_modified_at'] = string_to_datetime(_dict.get('last_modified_at'))
+        if 'last_modified_by_id' in _dict:
+            args['last_modified_by_id'] = _dict.get('last_modified_by_id')
+        if 'state' in _dict:
+            args['state'] = _dict.get('state')
+        else:
+            raise ValueError('Required property \'state\' not present in V2Policy JSON')
+        if 'last_permit_at' in _dict:
+            args['last_permit_at'] = _dict.get('last_permit_at')
+        if 'last_permit_frequency' in _dict:
+            args['last_permit_frequency'] = _dict.get('last_permit_frequency')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2Policy object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'type') and self.type is not None:
+            _dict['type'] = self.type
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'subject') and self.subject is not None:
+            if isinstance(self.subject, dict):
+                _dict['subject'] = self.subject
+            else:
+                _dict['subject'] = self.subject.to_dict()
+        if hasattr(self, 'resource') and self.resource is not None:
+            if isinstance(self.resource, dict):
+                _dict['resource'] = self.resource
+            else:
+                _dict['resource'] = self.resource.to_dict()
+        if hasattr(self, 'pattern') and self.pattern is not None:
+            _dict['pattern'] = self.pattern
+        if hasattr(self, 'rule') and self.rule is not None:
+            if isinstance(self.rule, dict):
+                _dict['rule'] = self.rule
+            else:
+                _dict['rule'] = self.rule.to_dict()
+        if hasattr(self, 'id') and getattr(self, 'id') is not None:
+            _dict['id'] = getattr(self, 'id')
+        if hasattr(self, 'href') and getattr(self, 'href') is not None:
+            _dict['href'] = getattr(self, 'href')
+        if hasattr(self, 'control') and self.control is not None:
+            if isinstance(self.control, dict):
+                _dict['control'] = self.control
+            else:
+                _dict['control'] = self.control.to_dict()
+        if hasattr(self, 'created_at') and getattr(self, 'created_at') is not None:
+            _dict['created_at'] = datetime_to_string(getattr(self, 'created_at'))
+        if hasattr(self, 'created_by_id') and getattr(self, 'created_by_id') is not None:
+            _dict['created_by_id'] = getattr(self, 'created_by_id')
+        if hasattr(self, 'last_modified_at') and getattr(self, 'last_modified_at') is not None:
+            _dict['last_modified_at'] = datetime_to_string(getattr(self, 'last_modified_at'))
+        if hasattr(self, 'last_modified_by_id') and getattr(self, 'last_modified_by_id') is not None:
+            _dict['last_modified_by_id'] = getattr(self, 'last_modified_by_id')
+        if hasattr(self, 'state') and self.state is not None:
+            _dict['state'] = self.state
+        if hasattr(self, 'last_permit_at') and self.last_permit_at is not None:
+            _dict['last_permit_at'] = self.last_permit_at
+        if hasattr(self, 'last_permit_frequency') and self.last_permit_frequency is not None:
+            _dict['last_permit_frequency'] = self.last_permit_frequency
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2Policy object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2Policy') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2Policy') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class TypeEnum(str, Enum):
+        """
+        The policy type; either 'access' or 'authorization'.
+        """
+
+        ACCESS = 'access'
+        AUTHORIZATION = 'authorization'
+
+    class StateEnum(str, Enum):
+        """
+        The policy state, either 'deleted' or 'active'.
+        """
+
+        ACTIVE = 'active'
+        DELETED = 'deleted'
+
+
+class V2PolicyCollection:
+    """
+    A collection of policies.
+
+    :attr List[V2Policy] policies: (optional) List of policies.
+    """
+
+    def __init__(self, *, policies: List['V2Policy'] = None) -> None:
+        """
+        Initialize a V2PolicyCollection object.
+
+        :param List[V2Policy] policies: (optional) List of policies.
+        """
+        self.policies = policies
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyCollection':
+        """Initialize a V2PolicyCollection object from a json dictionary."""
+        args = {}
+        if 'policies' in _dict:
+            args['policies'] = [V2Policy.from_dict(v) for v in _dict.get('policies')]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyCollection object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'policies') and self.policies is not None:
+            policies_list = []
+            for v in self.policies:
+                if isinstance(v, dict):
+                    policies_list.append(v)
+                else:
+                    policies_list.append(v.to_dict())
+            _dict['policies'] = policies_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyCollection object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyCollection') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyCollection') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class V2PolicyGrant:
+    """
+    Permission granted by the policy.
+
+    :attr List[PolicyRole] roles: A set of role cloud resource names (CRNs) granted
+          by the policy.
+    """
+
+    def __init__(self, roles: List['PolicyRole']) -> None:
+        """
+        Initialize a V2PolicyGrant object.
+
+        :param List[PolicyRole] roles: A set of role cloud resource names (CRNs)
+               granted by the policy.
+        """
+        self.roles = roles
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyGrant':
+        """Initialize a V2PolicyGrant object from a json dictionary."""
+        args = {}
+        if 'roles' in _dict:
+            args['roles'] = [PolicyRole.from_dict(v) for v in _dict.get('roles')]
+        else:
+            raise ValueError('Required property \'roles\' not present in V2PolicyGrant JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyGrant object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'roles') and self.roles is not None:
+            roles_list = []
+            for v in self.roles:
+                if isinstance(v, dict):
+                    roles_list.append(v)
+                else:
+                    roles_list.append(v.to_dict())
+            _dict['roles'] = roles_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyGrant object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyGrant') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyGrant') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class V2PolicyResource:
+    """
+    The resource attributes to which the policy grants access.
+
+    :attr List[V2PolicyResourceAttribute] attributes: List of resource attributes to
+          which the policy grants access.
+    :attr List[V2PolicyResourceTag] tags: (optional) Optional list of resource tags
+          to which the policy grants access.
+    """
+
+    def __init__(
+        self, attributes: List['V2PolicyResourceAttribute'], *, tags: List['V2PolicyResourceTag'] = None
+    ) -> None:
+        """
+        Initialize a V2PolicyResource object.
+
+        :param List[V2PolicyResourceAttribute] attributes: List of resource
+               attributes to which the policy grants access.
+        :param List[V2PolicyResourceTag] tags: (optional) Optional list of resource
+               tags to which the policy grants access.
+        """
+        self.attributes = attributes
+        self.tags = tags
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyResource':
+        """Initialize a V2PolicyResource object from a json dictionary."""
+        args = {}
+        if 'attributes' in _dict:
+            args['attributes'] = [V2PolicyResourceAttribute.from_dict(v) for v in _dict.get('attributes')]
+        else:
+            raise ValueError('Required property \'attributes\' not present in V2PolicyResource JSON')
+        if 'tags' in _dict:
+            args['tags'] = [V2PolicyResourceTag.from_dict(v) for v in _dict.get('tags')]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyResource object from a json dictionary."""
         return cls.from_dict(_dict)
 
     def to_dict(self) -> Dict:
@@ -1532,6 +2298,14 @@ class V2PolicyBaseResource:
                 else:
                     attributes_list.append(v.to_dict())
             _dict['attributes'] = attributes_list
+        if hasattr(self, 'tags') and self.tags is not None:
+            tags_list = []
+            for v in self.tags:
+                if isinstance(v, dict):
+                    tags_list.append(v)
+                else:
+                    tags_list.append(v.to_dict())
+            _dict['tags'] = tags_list
         return _dict
 
     def _to_dict(self):
@@ -1539,65 +2313,236 @@ class V2PolicyBaseResource:
         return self.to_dict()
 
     def __str__(self) -> str:
-        """Return a `str` version of this V2PolicyBaseResource object."""
+        """Return a `str` version of this V2PolicyResource object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: 'V2PolicyBaseResource') -> bool:
+    def __eq__(self, other: 'V2PolicyResource') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: 'V2PolicyBaseResource') -> bool:
+    def __ne__(self, other: 'V2PolicyResource') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
 
-class V2PolicyBaseRule:
+class V2PolicyResourceAttribute:
     """
-    Additional access conditions associated with a policy.
+    Resource attribute to which the policy grants access.
+
+    :attr str key: The name of a resource attribute.
+    :attr str operator: The operator of an attribute.
+    :attr object value: The value of an rule or resource attribute; can be boolean
+          or string for resource attribute. Can be a string or an array of strings (e.g.,
+          array of days to permit access) for rule attribute.
+    """
+
+    def __init__(self, key: str, operator: str, value: object) -> None:
+        """
+        Initialize a V2PolicyResourceAttribute object.
+
+        :param str key: The name of a resource attribute.
+        :param str operator: The operator of an attribute.
+        :param object value: The value of an rule or resource attribute; can be
+               boolean or string for resource attribute. Can be a string or an array of
+               strings (e.g., array of days to permit access) for rule attribute.
+        """
+        self.key = key
+        self.operator = operator
+        self.value = value
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyResourceAttribute':
+        """Initialize a V2PolicyResourceAttribute object from a json dictionary."""
+        args = {}
+        if 'key' in _dict:
+            args['key'] = _dict.get('key')
+        else:
+            raise ValueError('Required property \'key\' not present in V2PolicyResourceAttribute JSON')
+        if 'operator' in _dict:
+            args['operator'] = _dict.get('operator')
+        else:
+            raise ValueError('Required property \'operator\' not present in V2PolicyResourceAttribute JSON')
+        if 'value' in _dict:
+            args['value'] = _dict.get('value')
+        else:
+            raise ValueError('Required property \'value\' not present in V2PolicyResourceAttribute JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyResourceAttribute object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'key') and self.key is not None:
+            _dict['key'] = self.key
+        if hasattr(self, 'operator') and self.operator is not None:
+            _dict['operator'] = self.operator
+        if hasattr(self, 'value') and self.value is not None:
+            _dict['value'] = self.value
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyResourceAttribute object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyResourceAttribute') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyResourceAttribute') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class OperatorEnum(str, Enum):
+        """
+        The operator of an attribute.
+        """
+
+        STRINGEQUALS = 'stringEquals'
+        STRINGEXISTS = 'stringExists'
+        STRINGMATCH = 'stringMatch'
+
+
+class V2PolicyResourceTag:
+    """
+    A tag associated with a resource.
+
+    :attr str key: The name of an access management tag.
+    :attr str value: The value of an access management tag.
+    :attr str operator: The operator of an access management tag.
+    """
+
+    def __init__(self, key: str, value: str, operator: str) -> None:
+        """
+        Initialize a V2PolicyResourceTag object.
+
+        :param str key: The name of an access management tag.
+        :param str value: The value of an access management tag.
+        :param str operator: The operator of an access management tag.
+        """
+        self.key = key
+        self.value = value
+        self.operator = operator
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyResourceTag':
+        """Initialize a V2PolicyResourceTag object from a json dictionary."""
+        args = {}
+        if 'key' in _dict:
+            args['key'] = _dict.get('key')
+        else:
+            raise ValueError('Required property \'key\' not present in V2PolicyResourceTag JSON')
+        if 'value' in _dict:
+            args['value'] = _dict.get('value')
+        else:
+            raise ValueError('Required property \'value\' not present in V2PolicyResourceTag JSON')
+        if 'operator' in _dict:
+            args['operator'] = _dict.get('operator')
+        else:
+            raise ValueError('Required property \'operator\' not present in V2PolicyResourceTag JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyResourceTag object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'key') and self.key is not None:
+            _dict['key'] = self.key
+        if hasattr(self, 'value') and self.value is not None:
+            _dict['value'] = self.value
+        if hasattr(self, 'operator') and self.operator is not None:
+            _dict['operator'] = self.operator
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyResourceTag object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyResourceTag') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyResourceTag') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class OperatorEnum(str, Enum):
+        """
+        The operator of an access management tag.
+        """
+
+        STRINGEQUALS = 'stringEquals'
+        STRINGMATCH = 'stringMatch'
+
+
+class V2PolicyRule:
+    """
+    Additional access conditions associated with the policy.
 
     """
 
     def __init__(self) -> None:
         """
-        Initialize a V2PolicyBaseRule object.
+        Initialize a V2PolicyRule object.
 
         """
         msg = "Cannot instantiate base class. Instead, instantiate one of the defined subclasses: {0}".format(
-            ", ".join(['V2PolicyBaseRuleV2PolicyAttribute', 'V2PolicyBaseRuleV2RuleWithConditions'])
+            ", ".join(['V2PolicyRuleRuleAttribute', 'V2PolicyRuleRuleWithConditions'])
         )
         raise Exception(msg)
 
 
-class V2PolicyBaseSubject:
+class V2PolicySubject:
     """
-    The subject attributes associated with a policy.
+    The subject attributes for whom the policy grants access.
 
-    :attr List[V2PolicyAttribute] attributes: (optional) List of subject attributes
+    :attr List[V2PolicySubjectAttribute] attributes: List of subject attributes
           associated with policy/.
     """
 
-    def __init__(self, *, attributes: List['V2PolicyAttribute'] = None) -> None:
+    def __init__(self, attributes: List['V2PolicySubjectAttribute']) -> None:
         """
-        Initialize a V2PolicyBaseSubject object.
+        Initialize a V2PolicySubject object.
 
-        :param List[V2PolicyAttribute] attributes: (optional) List of subject
+        :param List[V2PolicySubjectAttribute] attributes: List of subject
                attributes associated with policy/.
         """
         self.attributes = attributes
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseSubject':
-        """Initialize a V2PolicyBaseSubject object from a json dictionary."""
+    def from_dict(cls, _dict: Dict) -> 'V2PolicySubject':
+        """Initialize a V2PolicySubject object from a json dictionary."""
         args = {}
         if 'attributes' in _dict:
-            args['attributes'] = [V2PolicyAttribute.from_dict(v) for v in _dict.get('attributes')]
+            args['attributes'] = [V2PolicySubjectAttribute.from_dict(v) for v in _dict.get('attributes')]
+        else:
+            raise ValueError('Required property \'attributes\' not present in V2PolicySubject JSON')
         return cls(**args)
 
     @classmethod
     def _from_dict(cls, _dict):
-        """Initialize a V2PolicyBaseSubject object from a json dictionary."""
+        """Initialize a V2PolicySubject object from a json dictionary."""
         return cls.from_dict(_dict)
 
     def to_dict(self) -> Dict:
@@ -1618,18 +2563,102 @@ class V2PolicyBaseSubject:
         return self.to_dict()
 
     def __str__(self) -> str:
-        """Return a `str` version of this V2PolicyBaseSubject object."""
+        """Return a `str` version of this V2PolicySubject object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: 'V2PolicyBaseSubject') -> bool:
+    def __eq__(self, other: 'V2PolicySubject') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: 'V2PolicyBaseSubject') -> bool:
+    def __ne__(self, other: 'V2PolicySubject') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
+
+
+class V2PolicySubjectAttribute:
+    """
+    Subject attribute for whom the policy grants access.
+
+    :attr str key: The name of a subject attribute, e.g., iam_id, access_group_id.
+    :attr str operator: The operator of an attribute.
+    :attr str value: The value of the ID of the subject, e.g., service ID, access
+          group ID, IAM ID.
+    """
+
+    def __init__(self, key: str, operator: str, value: str) -> None:
+        """
+        Initialize a V2PolicySubjectAttribute object.
+
+        :param str key: The name of a subject attribute, e.g., iam_id,
+               access_group_id.
+        :param str operator: The operator of an attribute.
+        :param str value: The value of the ID of the subject, e.g., service ID,
+               access group ID, IAM ID.
+        """
+        self.key = key
+        self.operator = operator
+        self.value = value
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicySubjectAttribute':
+        """Initialize a V2PolicySubjectAttribute object from a json dictionary."""
+        args = {}
+        if 'key' in _dict:
+            args['key'] = _dict.get('key')
+        else:
+            raise ValueError('Required property \'key\' not present in V2PolicySubjectAttribute JSON')
+        if 'operator' in _dict:
+            args['operator'] = _dict.get('operator')
+        else:
+            raise ValueError('Required property \'operator\' not present in V2PolicySubjectAttribute JSON')
+        if 'value' in _dict:
+            args['value'] = _dict.get('value')
+        else:
+            raise ValueError('Required property \'value\' not present in V2PolicySubjectAttribute JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicySubjectAttribute object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'key') and self.key is not None:
+            _dict['key'] = self.key
+        if hasattr(self, 'operator') and self.operator is not None:
+            _dict['operator'] = self.operator
+        if hasattr(self, 'value') and self.value is not None:
+            _dict['value'] = self.value
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicySubjectAttribute object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicySubjectAttribute') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicySubjectAttribute') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class OperatorEnum(str, Enum):
+        """
+        The operator of an attribute.
+        """
+
+        STRINGEQUALS = 'stringEquals'
 
 
 class CustomRole:
@@ -1637,18 +2666,17 @@ class CustomRole:
     An additional set of properties associated with a role.
 
     :attr str id: (optional) The role ID. Composed of hexadecimal characters.
-    :attr str display_name: (optional) The display name of the role that is shown in
-          the console.
+    :attr str display_name: The display name of the role that is shown in the
+          console.
     :attr str description: (optional) The description of the role.
-    :attr List[str] actions: (optional) The actions of the role. Please refer to
-          [IAM roles and
+    :attr List[str] actions: The actions of the role. Please refer to [IAM roles and
           actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions).
     :attr str crn: (optional) The role Cloud Resource Name (CRN). Example CRN:
           'crn:v1:ibmcloud:public:iam-access-management::a/exampleAccountId::customRole:ExampleRoleName'.
-    :attr str name: (optional) The name of the role that is used in the CRN. Can
-          only be alphanumeric and has to be capitalized.
-    :attr str account_id: (optional) The account GUID.
-    :attr str service_name: (optional) The service name.
+    :attr str name: The name of the role that is used in the CRN. Can only be
+          alphanumeric and has to be capitalized.
+    :attr str account_id: The account GUID.
+    :attr str service_name: The service name.
     :attr datetime created_at: (optional) The UTC timestamp when the role was
           created.
     :attr str created_by_id: (optional) The iam ID of the entity that created the
@@ -1662,15 +2690,15 @@ class CustomRole:
 
     def __init__(
         self,
+        display_name: str,
+        actions: List[str],
+        name: str,
+        account_id: str,
+        service_name: str,
         *,
         id: str = None,
-        display_name: str = None,
         description: str = None,
-        actions: List[str] = None,
         crn: str = None,
-        name: str = None,
-        account_id: str = None,
-        service_name: str = None,
         created_at: datetime = None,
         created_by_id: str = None,
         last_modified_at: datetime = None,
@@ -1680,16 +2708,16 @@ class CustomRole:
         """
         Initialize a CustomRole object.
 
-        :param str display_name: (optional) The display name of the role that is
-               shown in the console.
-        :param str description: (optional) The description of the role.
-        :param List[str] actions: (optional) The actions of the role. Please refer
-               to [IAM roles and
+        :param str display_name: The display name of the role that is shown in the
+               console.
+        :param List[str] actions: The actions of the role. Please refer to [IAM
+               roles and
                actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions).
-        :param str name: (optional) The name of the role that is used in the CRN.
-               Can only be alphanumeric and has to be capitalized.
-        :param str account_id: (optional) The account GUID.
-        :param str service_name: (optional) The service name.
+        :param str name: The name of the role that is used in the CRN. Can only be
+               alphanumeric and has to be capitalized.
+        :param str account_id: The account GUID.
+        :param str service_name: The service name.
+        :param str description: (optional) The description of the role.
         """
         self.id = id
         self.display_name = display_name
@@ -1713,18 +2741,28 @@ class CustomRole:
             args['id'] = _dict.get('id')
         if 'display_name' in _dict:
             args['display_name'] = _dict.get('display_name')
+        else:
+            raise ValueError('Required property \'display_name\' not present in CustomRole JSON')
         if 'description' in _dict:
             args['description'] = _dict.get('description')
         if 'actions' in _dict:
             args['actions'] = _dict.get('actions')
+        else:
+            raise ValueError('Required property \'actions\' not present in CustomRole JSON')
         if 'crn' in _dict:
             args['crn'] = _dict.get('crn')
         if 'name' in _dict:
             args['name'] = _dict.get('name')
+        else:
+            raise ValueError('Required property \'name\' not present in CustomRole JSON')
         if 'account_id' in _dict:
             args['account_id'] = _dict.get('account_id')
+        else:
+            raise ValueError('Required property \'account_id\' not present in CustomRole JSON')
         if 'service_name' in _dict:
             args['service_name'] = _dict.get('service_name')
+        else:
+            raise ValueError('Required property \'service_name\' not present in CustomRole JSON')
         if 'created_at' in _dict:
             args['created_at'] = string_to_datetime(_dict.get('created_at'))
         if 'created_by_id' in _dict:
@@ -1797,14 +2835,12 @@ class Policy:
     The core set of properties associated with a policy.
 
     :attr str id: (optional) The policy ID.
-    :attr str type: (optional) The policy type; either 'access' or 'authorization'.
+    :attr str type: The policy type; either 'access' or 'authorization'.
     :attr str description: (optional) Customer-defined description.
-    :attr List[PolicySubject] subjects: (optional) The subjects associated with a
-          policy.
-    :attr List[PolicyRole] roles: (optional) A set of role cloud resource names
-          (CRNs) granted by the policy.
-    :attr List[PolicyResource] resources: (optional) The resources associated with a
-          policy.
+    :attr List[PolicySubject] subjects: The subjects associated with a policy.
+    :attr List[PolicyRole] roles: A set of role cloud resource names (CRNs) granted
+          by the policy.
+    :attr List[PolicyResource] resources: The resources associated with a policy.
     :attr str href: (optional) The href link back to the policy.
     :attr datetime created_at: (optional) The UTC timestamp when the policy was
           created.
@@ -1819,13 +2855,13 @@ class Policy:
 
     def __init__(
         self,
+        type: str,
+        subjects: List['PolicySubject'],
+        roles: List['PolicyRole'],
+        resources: List['PolicyResource'],
         *,
         id: str = None,
-        type: str = None,
         description: str = None,
-        subjects: List['PolicySubject'] = None,
-        roles: List['PolicyRole'] = None,
-        resources: List['PolicyResource'] = None,
         href: str = None,
         created_at: datetime = None,
         created_by_id: str = None,
@@ -1836,15 +2872,13 @@ class Policy:
         """
         Initialize a Policy object.
 
-        :param str type: (optional) The policy type; either 'access' or
-               'authorization'.
+        :param str type: The policy type; either 'access' or 'authorization'.
+        :param List[PolicySubject] subjects: The subjects associated with a policy.
+        :param List[PolicyRole] roles: A set of role cloud resource names (CRNs)
+               granted by the policy.
+        :param List[PolicyResource] resources: The resources associated with a
+               policy.
         :param str description: (optional) Customer-defined description.
-        :param List[PolicySubject] subjects: (optional) The subjects associated
-               with a policy.
-        :param List[PolicyRole] roles: (optional) A set of role cloud resource
-               names (CRNs) granted by the policy.
-        :param List[PolicyResource] resources: (optional) The resources associated
-               with a policy.
         :param str state: (optional) The policy state.
         """
         self.id = id
@@ -1868,14 +2902,22 @@ class Policy:
             args['id'] = _dict.get('id')
         if 'type' in _dict:
             args['type'] = _dict.get('type')
+        else:
+            raise ValueError('Required property \'type\' not present in Policy JSON')
         if 'description' in _dict:
             args['description'] = _dict.get('description')
         if 'subjects' in _dict:
             args['subjects'] = [PolicySubject.from_dict(v) for v in _dict.get('subjects')]
+        else:
+            raise ValueError('Required property \'subjects\' not present in Policy JSON')
         if 'roles' in _dict:
             args['roles'] = [PolicyRole.from_dict(v) for v in _dict.get('roles')]
+        else:
+            raise ValueError('Required property \'roles\' not present in Policy JSON')
         if 'resources' in _dict:
             args['resources'] = [PolicyResource.from_dict(v) for v in _dict.get('resources')]
+        else:
+            raise ValueError('Required property \'resources\' not present in Policy JSON')
         if 'href' in _dict:
             args['href'] = _dict.get('href')
         if 'created_at' in _dict:
@@ -2104,76 +3146,6 @@ class PolicyResource:
         return not self == other
 
 
-class PolicyRole:
-    """
-    A role associated with a policy.
-
-    :attr str role_id: The role Cloud Resource Name (CRN) granted by the policy.
-          Example CRN: 'crn:v1:bluemix:public:iam::::role:Editor'.
-    :attr str display_name: (optional) The display name of the role.
-    :attr str description: (optional) The description of the role.
-    """
-
-    def __init__(self, role_id: str, *, display_name: str = None, description: str = None) -> None:
-        """
-        Initialize a PolicyRole object.
-
-        :param str role_id: The role Cloud Resource Name (CRN) granted by the
-               policy. Example CRN: 'crn:v1:bluemix:public:iam::::role:Editor'.
-        """
-        self.role_id = role_id
-        self.display_name = display_name
-        self.description = description
-
-    @classmethod
-    def from_dict(cls, _dict: Dict) -> 'PolicyRole':
-        """Initialize a PolicyRole object from a json dictionary."""
-        args = {}
-        if 'role_id' in _dict:
-            args['role_id'] = _dict.get('role_id')
-        else:
-            raise ValueError('Required property \'role_id\' not present in PolicyRole JSON')
-        if 'display_name' in _dict:
-            args['display_name'] = _dict.get('display_name')
-        if 'description' in _dict:
-            args['description'] = _dict.get('description')
-        return cls(**args)
-
-    @classmethod
-    def _from_dict(cls, _dict):
-        """Initialize a PolicyRole object from a json dictionary."""
-        return cls.from_dict(_dict)
-
-    def to_dict(self) -> Dict:
-        """Return a json dictionary representing this model."""
-        _dict = {}
-        if hasattr(self, 'role_id') and self.role_id is not None:
-            _dict['role_id'] = self.role_id
-        if hasattr(self, 'display_name') and getattr(self, 'display_name') is not None:
-            _dict['display_name'] = getattr(self, 'display_name')
-        if hasattr(self, 'description') and getattr(self, 'description') is not None:
-            _dict['description'] = getattr(self, 'description')
-        return _dict
-
-    def _to_dict(self):
-        """Return a json dictionary representing this model."""
-        return self.to_dict()
-
-    def __str__(self) -> str:
-        """Return a `str` version of this PolicyRole object."""
-        return json.dumps(self.to_dict(), indent=2)
-
-    def __eq__(self, other: 'PolicyRole') -> bool:
-        """Return `true` when self and other are equal, false otherwise."""
-        if not isinstance(other, self.__class__):
-            return False
-        return self.__dict__ == other.__dict__
-
-    def __ne__(self, other: 'PolicyRole') -> bool:
-        """Return `true` when self and other are not equal, false otherwise."""
-        return not self == other
-
-
 class PolicySubject:
     """
     The subject attribute values that must match in order for this policy to apply in a
@@ -2384,28 +3356,25 @@ class Role:
     """
     A role resource.
 
-    :attr str display_name: (optional) The display name of the role that is shown in
-          the console.
+    :attr str display_name: The display name of the role that is shown in the
+          console.
     :attr str description: (optional) The description of the role.
-    :attr List[str] actions: (optional) The actions of the role. Please refer to
-          [IAM roles and
+    :attr List[str] actions: The actions of the role. Please refer to [IAM roles and
           actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions).
     :attr str crn: (optional) The role Cloud Resource Name (CRN). Example CRN:
           'crn:v1:ibmcloud:public:iam-access-management::a/exampleAccountId::customRole:ExampleRoleName'.
     """
 
-    def __init__(
-        self, *, display_name: str = None, description: str = None, actions: List[str] = None, crn: str = None
-    ) -> None:
+    def __init__(self, display_name: str, actions: List[str], *, description: str = None, crn: str = None) -> None:
         """
         Initialize a Role object.
 
-        :param str display_name: (optional) The display name of the role that is
-               shown in the console.
-        :param str description: (optional) The description of the role.
-        :param List[str] actions: (optional) The actions of the role. Please refer
-               to [IAM roles and
+        :param str display_name: The display name of the role that is shown in the
+               console.
+        :param List[str] actions: The actions of the role. Please refer to [IAM
+               roles and
                actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions).
+        :param str description: (optional) The description of the role.
         """
         self.display_name = display_name
         self.description = description
@@ -2418,10 +3387,14 @@ class Role:
         args = {}
         if 'display_name' in _dict:
             args['display_name'] = _dict.get('display_name')
+        else:
+            raise ValueError('Required property \'display_name\' not present in Role JSON')
         if 'description' in _dict:
             args['description'] = _dict.get('description')
         if 'actions' in _dict:
             args['actions'] = _dict.get('actions')
+        else:
+            raise ValueError('Required property \'actions\' not present in Role JSON')
         if 'crn' in _dict:
             args['crn'] = _dict.get('crn')
         return cls(**args)
@@ -2620,169 +3593,45 @@ class SubjectAttribute:
         return not self == other
 
 
-class V2Policy:
+class ControlResponseControl(ControlResponse):
     """
-    The core set of properties associated with a policy.
+    Specifies the type of access granted by the policy.
 
-    :attr str id: (optional) The policy ID.
-    :attr str type: The policy type; either 'access' or 'authorization'.
-    :attr str description: (optional) Customer-defined description.
-    :attr V2PolicyBaseSubject subject: (optional) The subject attributes associated
-          with a policy.
-    :attr V2PolicyBaseControl control: Specifies the type of access granted by the
-          policy.
-    :attr V2PolicyBaseResource resource: (optional) The resource attributes
-          associated with a policy.
-    :attr str pattern: (optional) Indicates pattern of rule.
-    :attr V2PolicyBaseRule rule: (optional) Additional access conditions associated
-          with a policy.
-    :attr str href: (optional) The href link back to the policy.
-    :attr datetime created_at: (optional) The UTC timestamp when the policy was
-          created.
-    :attr str created_by_id: (optional) The iam ID of the entity that created the
-          policy.
-    :attr datetime last_modified_at: (optional) The UTC timestamp when the policy
-          was last modified.
-    :attr str last_modified_by_id: (optional) The iam ID of the entity that last
-          modified the policy.
-    :attr str state: (optional) The policy state.
+    :attr V2PolicyGrant grant: Permission granted by the policy.
     """
 
-    def __init__(
-        self,
-        type: str,
-        control: 'V2PolicyBaseControl',
-        *,
-        id: str = None,
-        description: str = None,
-        subject: 'V2PolicyBaseSubject' = None,
-        resource: 'V2PolicyBaseResource' = None,
-        pattern: str = None,
-        rule: 'V2PolicyBaseRule' = None,
-        href: str = None,
-        created_at: datetime = None,
-        created_by_id: str = None,
-        last_modified_at: datetime = None,
-        last_modified_by_id: str = None,
-        state: str = None
-    ) -> None:
+    def __init__(self, grant: 'V2PolicyGrant') -> None:
         """
-        Initialize a V2Policy object.
+        Initialize a ControlResponseControl object.
 
-        :param str type: The policy type; either 'access' or 'authorization'.
-        :param V2PolicyBaseControl control: Specifies the type of access granted by
-               the policy.
-        :param str description: (optional) Customer-defined description.
-        :param V2PolicyBaseSubject subject: (optional) The subject attributes
-               associated with a policy.
-        :param V2PolicyBaseResource resource: (optional) The resource attributes
-               associated with a policy.
-        :param str pattern: (optional) Indicates pattern of rule.
-        :param V2PolicyBaseRule rule: (optional) Additional access conditions
-               associated with a policy.
-        :param str state: (optional) The policy state.
+        :param V2PolicyGrant grant: Permission granted by the policy.
         """
-        self.id = id
-        self.type = type
-        self.description = description
-        self.subject = subject
-        self.control = control
-        self.resource = resource
-        self.pattern = pattern
-        self.rule = rule
-        self.href = href
-        self.created_at = created_at
-        self.created_by_id = created_by_id
-        self.last_modified_at = last_modified_at
-        self.last_modified_by_id = last_modified_by_id
-        self.state = state
+        # pylint: disable=super-init-not-called
+        self.grant = grant
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> 'V2Policy':
-        """Initialize a V2Policy object from a json dictionary."""
+    def from_dict(cls, _dict: Dict) -> 'ControlResponseControl':
+        """Initialize a ControlResponseControl object from a json dictionary."""
         args = {}
-        if 'id' in _dict:
-            args['id'] = _dict.get('id')
-        if 'type' in _dict:
-            args['type'] = _dict.get('type')
+        if 'grant' in _dict:
+            args['grant'] = V2PolicyGrant.from_dict(_dict.get('grant'))
         else:
-            raise ValueError('Required property \'type\' not present in V2Policy JSON')
-        if 'description' in _dict:
-            args['description'] = _dict.get('description')
-        if 'subject' in _dict:
-            args['subject'] = V2PolicyBaseSubject.from_dict(_dict.get('subject'))
-        if 'control' in _dict:
-            args['control'] = V2PolicyBaseControl.from_dict(_dict.get('control'))
-        else:
-            raise ValueError('Required property \'control\' not present in V2Policy JSON')
-        if 'resource' in _dict:
-            args['resource'] = V2PolicyBaseResource.from_dict(_dict.get('resource'))
-        if 'pattern' in _dict:
-            args['pattern'] = _dict.get('pattern')
-        if 'rule' in _dict:
-            args['rule'] = _dict.get('rule')
-        if 'href' in _dict:
-            args['href'] = _dict.get('href')
-        if 'created_at' in _dict:
-            args['created_at'] = string_to_datetime(_dict.get('created_at'))
-        if 'created_by_id' in _dict:
-            args['created_by_id'] = _dict.get('created_by_id')
-        if 'last_modified_at' in _dict:
-            args['last_modified_at'] = string_to_datetime(_dict.get('last_modified_at'))
-        if 'last_modified_by_id' in _dict:
-            args['last_modified_by_id'] = _dict.get('last_modified_by_id')
-        if 'state' in _dict:
-            args['state'] = _dict.get('state')
+            raise ValueError('Required property \'grant\' not present in ControlResponseControl JSON')
         return cls(**args)
 
     @classmethod
     def _from_dict(cls, _dict):
-        """Initialize a V2Policy object from a json dictionary."""
+        """Initialize a ControlResponseControl object from a json dictionary."""
         return cls.from_dict(_dict)
 
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, 'id') and getattr(self, 'id') is not None:
-            _dict['id'] = getattr(self, 'id')
-        if hasattr(self, 'type') and self.type is not None:
-            _dict['type'] = self.type
-        if hasattr(self, 'description') and self.description is not None:
-            _dict['description'] = self.description
-        if hasattr(self, 'subject') and self.subject is not None:
-            if isinstance(self.subject, dict):
-                _dict['subject'] = self.subject
+        if hasattr(self, 'grant') and self.grant is not None:
+            if isinstance(self.grant, dict):
+                _dict['grant'] = self.grant
             else:
-                _dict['subject'] = self.subject.to_dict()
-        if hasattr(self, 'control') and self.control is not None:
-            if isinstance(self.control, dict):
-                _dict['control'] = self.control
-            else:
-                _dict['control'] = self.control.to_dict()
-        if hasattr(self, 'resource') and self.resource is not None:
-            if isinstance(self.resource, dict):
-                _dict['resource'] = self.resource
-            else:
-                _dict['resource'] = self.resource.to_dict()
-        if hasattr(self, 'pattern') and self.pattern is not None:
-            _dict['pattern'] = self.pattern
-        if hasattr(self, 'rule') and self.rule is not None:
-            if isinstance(self.rule, dict):
-                _dict['rule'] = self.rule
-            else:
-                _dict['rule'] = self.rule.to_dict()
-        if hasattr(self, 'href') and getattr(self, 'href') is not None:
-            _dict['href'] = getattr(self, 'href')
-        if hasattr(self, 'created_at') and getattr(self, 'created_at') is not None:
-            _dict['created_at'] = datetime_to_string(getattr(self, 'created_at'))
-        if hasattr(self, 'created_by_id') and getattr(self, 'created_by_id') is not None:
-            _dict['created_by_id'] = getattr(self, 'created_by_id')
-        if hasattr(self, 'last_modified_at') and getattr(self, 'last_modified_at') is not None:
-            _dict['last_modified_at'] = datetime_to_string(getattr(self, 'last_modified_at'))
-        if hasattr(self, 'last_modified_by_id') and getattr(self, 'last_modified_by_id') is not None:
-            _dict['last_modified_by_id'] = getattr(self, 'last_modified_by_id')
-        if hasattr(self, 'state') and self.state is not None:
-            _dict['state'] = self.state
+                _dict['grant'] = self.grant.to_dict()
         return _dict
 
     def _to_dict(self):
@@ -2790,182 +3639,104 @@ class V2Policy:
         return self.to_dict()
 
     def __str__(self) -> str:
-        """Return a `str` version of this V2Policy object."""
+        """Return a `str` version of this ControlResponseControl object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: 'V2Policy') -> bool:
+    def __eq__(self, other: 'ControlResponseControl') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: 'V2Policy') -> bool:
+    def __ne__(self, other: 'ControlResponseControl') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-    class StateEnum(str, Enum):
-        """
-        The policy state.
-        """
 
-        ACTIVE = 'active'
-        DELETED = 'deleted'
-
-
-class V2PolicyAttribute:
+class ControlResponseControlWithTranslatedRoles(ControlResponse):
     """
-    Resource/subject attribute associated with policy attributes.
+    Specifies the type of access granted by the policy with additional role information.
+
+    :attr GrantWithTranslatedRoles grant: Permission granted by the policy with
+          translated roles and additional role information.
+    """
+
+    def __init__(self, grant: 'GrantWithTranslatedRoles') -> None:
+        """
+        Initialize a ControlResponseControlWithTranslatedRoles object.
+
+        :param GrantWithTranslatedRoles grant: Permission granted by the policy
+               with translated roles and additional role information.
+        """
+        # pylint: disable=super-init-not-called
+        self.grant = grant
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'ControlResponseControlWithTranslatedRoles':
+        """Initialize a ControlResponseControlWithTranslatedRoles object from a json dictionary."""
+        args = {}
+        if 'grant' in _dict:
+            args['grant'] = GrantWithTranslatedRoles.from_dict(_dict.get('grant'))
+        else:
+            raise ValueError(
+                'Required property \'grant\' not present in ControlResponseControlWithTranslatedRoles JSON'
+            )
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a ControlResponseControlWithTranslatedRoles object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'grant') and self.grant is not None:
+            if isinstance(self.grant, dict):
+                _dict['grant'] = self.grant
+            else:
+                _dict['grant'] = self.grant.to_dict()
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this ControlResponseControlWithTranslatedRoles object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'ControlResponseControlWithTranslatedRoles') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'ControlResponseControlWithTranslatedRoles') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class V2PolicyRuleRuleAttribute(V2PolicyRule):
+    """
+    Rule that specifies additional access granted (e.g., time-based condition).
 
     :attr str key: The name of an attribute.
     :attr str operator: The operator of an attribute.
-    :attr object value: The value of an attribute; can be array, boolean, string, or
-          integer.
+    :attr object value: The value of an rule or resource attribute; can be boolean
+          or string for resource attribute. Can be a string or an array of strings (e.g.,
+          array of days to permit access) for rule attribute.
     """
 
     def __init__(self, key: str, operator: str, value: object) -> None:
         """
-        Initialize a V2PolicyAttribute object.
+        Initialize a V2PolicyRuleRuleAttribute object.
 
         :param str key: The name of an attribute.
         :param str operator: The operator of an attribute.
-        :param object value: The value of an attribute; can be array, boolean,
-               string, or integer.
-        """
-        self.key = key
-        self.operator = operator
-        self.value = value
-
-    @classmethod
-    def from_dict(cls, _dict: Dict) -> 'V2PolicyAttribute':
-        """Initialize a V2PolicyAttribute object from a json dictionary."""
-        args = {}
-        if 'key' in _dict:
-            args['key'] = _dict.get('key')
-        else:
-            raise ValueError('Required property \'key\' not present in V2PolicyAttribute JSON')
-        if 'operator' in _dict:
-            args['operator'] = _dict.get('operator')
-        else:
-            raise ValueError('Required property \'operator\' not present in V2PolicyAttribute JSON')
-        if 'value' in _dict:
-            args['value'] = _dict.get('value')
-        else:
-            raise ValueError('Required property \'value\' not present in V2PolicyAttribute JSON')
-        return cls(**args)
-
-    @classmethod
-    def _from_dict(cls, _dict):
-        """Initialize a V2PolicyAttribute object from a json dictionary."""
-        return cls.from_dict(_dict)
-
-    def to_dict(self) -> Dict:
-        """Return a json dictionary representing this model."""
-        _dict = {}
-        if hasattr(self, 'key') and self.key is not None:
-            _dict['key'] = self.key
-        if hasattr(self, 'operator') and self.operator is not None:
-            _dict['operator'] = self.operator
-        if hasattr(self, 'value') and self.value is not None:
-            _dict['value'] = self.value
-        return _dict
-
-    def _to_dict(self):
-        """Return a json dictionary representing this model."""
-        return self.to_dict()
-
-    def __str__(self) -> str:
-        """Return a `str` version of this V2PolicyAttribute object."""
-        return json.dumps(self.to_dict(), indent=2)
-
-    def __eq__(self, other: 'V2PolicyAttribute') -> bool:
-        """Return `true` when self and other are equal, false otherwise."""
-        if not isinstance(other, self.__class__):
-            return False
-        return self.__dict__ == other.__dict__
-
-    def __ne__(self, other: 'V2PolicyAttribute') -> bool:
-        """Return `true` when self and other are not equal, false otherwise."""
-        return not self == other
-
-
-class V2PolicyList:
-    """
-    A collection of policies.
-
-    :attr List[V2Policy] policies: (optional) List of policies.
-    """
-
-    def __init__(self, *, policies: List['V2Policy'] = None) -> None:
-        """
-        Initialize a V2PolicyList object.
-
-        :param List[V2Policy] policies: (optional) List of policies.
-        """
-        self.policies = policies
-
-    @classmethod
-    def from_dict(cls, _dict: Dict) -> 'V2PolicyList':
-        """Initialize a V2PolicyList object from a json dictionary."""
-        args = {}
-        if 'policies' in _dict:
-            args['policies'] = [V2Policy.from_dict(v) for v in _dict.get('policies')]
-        return cls(**args)
-
-    @classmethod
-    def _from_dict(cls, _dict):
-        """Initialize a V2PolicyList object from a json dictionary."""
-        return cls.from_dict(_dict)
-
-    def to_dict(self) -> Dict:
-        """Return a json dictionary representing this model."""
-        _dict = {}
-        if hasattr(self, 'policies') and self.policies is not None:
-            policies_list = []
-            for v in self.policies:
-                if isinstance(v, dict):
-                    policies_list.append(v)
-                else:
-                    policies_list.append(v.to_dict())
-            _dict['policies'] = policies_list
-        return _dict
-
-    def _to_dict(self):
-        """Return a json dictionary representing this model."""
-        return self.to_dict()
-
-    def __str__(self) -> str:
-        """Return a `str` version of this V2PolicyList object."""
-        return json.dumps(self.to_dict(), indent=2)
-
-    def __eq__(self, other: 'V2PolicyList') -> bool:
-        """Return `true` when self and other are equal, false otherwise."""
-        if not isinstance(other, self.__class__):
-            return False
-        return self.__dict__ == other.__dict__
-
-    def __ne__(self, other: 'V2PolicyList') -> bool:
-        """Return `true` when self and other are not equal, false otherwise."""
-        return not self == other
-
-
-class V2PolicyBaseRuleV2PolicyAttribute(V2PolicyBaseRule):
-    """
-    Resource/subject attribute associated with policy attributes.
-
-    :attr str key: The name of an attribute.
-    :attr str operator: The operator of an attribute.
-    :attr object value: The value of an attribute; can be array, boolean, string, or
-          integer.
-    """
-
-    def __init__(self, key: str, operator: str, value: object) -> None:
-        """
-        Initialize a V2PolicyBaseRuleV2PolicyAttribute object.
-
-        :param str key: The name of an attribute.
-        :param str operator: The operator of an attribute.
-        :param object value: The value of an attribute; can be array, boolean,
-               string, or integer.
+        :param object value: The value of an rule or resource attribute; can be
+               boolean or string for resource attribute. Can be a string or an array of
+               strings (e.g., array of days to permit access) for rule attribute.
         """
         # pylint: disable=super-init-not-called
         self.key = key
@@ -2973,26 +3744,26 @@ class V2PolicyBaseRuleV2PolicyAttribute(V2PolicyBaseRule):
         self.value = value
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseRuleV2PolicyAttribute':
-        """Initialize a V2PolicyBaseRuleV2PolicyAttribute object from a json dictionary."""
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyRuleRuleAttribute':
+        """Initialize a V2PolicyRuleRuleAttribute object from a json dictionary."""
         args = {}
         if 'key' in _dict:
             args['key'] = _dict.get('key')
         else:
-            raise ValueError('Required property \'key\' not present in V2PolicyBaseRuleV2PolicyAttribute JSON')
+            raise ValueError('Required property \'key\' not present in V2PolicyRuleRuleAttribute JSON')
         if 'operator' in _dict:
             args['operator'] = _dict.get('operator')
         else:
-            raise ValueError('Required property \'operator\' not present in V2PolicyBaseRuleV2PolicyAttribute JSON')
+            raise ValueError('Required property \'operator\' not present in V2PolicyRuleRuleAttribute JSON')
         if 'value' in _dict:
             args['value'] = _dict.get('value')
         else:
-            raise ValueError('Required property \'value\' not present in V2PolicyBaseRuleV2PolicyAttribute JSON')
+            raise ValueError('Required property \'value\' not present in V2PolicyRuleRuleAttribute JSON')
         return cls(**args)
 
     @classmethod
     def _from_dict(cls, _dict):
-        """Initialize a V2PolicyBaseRuleV2PolicyAttribute object from a json dictionary."""
+        """Initialize a V2PolicyRuleRuleAttribute object from a json dictionary."""
         return cls.from_dict(_dict)
 
     def to_dict(self) -> Dict:
@@ -3011,60 +3782,77 @@ class V2PolicyBaseRuleV2PolicyAttribute(V2PolicyBaseRule):
         return self.to_dict()
 
     def __str__(self) -> str:
-        """Return a `str` version of this V2PolicyBaseRuleV2PolicyAttribute object."""
+        """Return a `str` version of this V2PolicyRuleRuleAttribute object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: 'V2PolicyBaseRuleV2PolicyAttribute') -> bool:
+    def __eq__(self, other: 'V2PolicyRuleRuleAttribute') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: 'V2PolicyBaseRuleV2PolicyAttribute') -> bool:
+    def __ne__(self, other: 'V2PolicyRuleRuleAttribute') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
+    class OperatorEnum(str, Enum):
+        """
+        The operator of an attribute.
+        """
 
-class V2PolicyBaseRuleV2RuleWithConditions(V2PolicyBaseRule):
+        TIMELESSTHAN = 'timeLessThan'
+        TIMELESSTHANOREQUALS = 'timeLessThanOrEquals'
+        TIMEGREATERTHAN = 'timeGreaterThan'
+        TIMEGREATERTHANOREQUALS = 'timeGreaterThanOrEquals'
+        DATETIMELESSTHAN = 'dateTimeLessThan'
+        DATETIMELESSTHANOREQUALS = 'dateTimeLessThanOrEquals'
+        DATETIMEGREATERTHAN = 'dateTimeGreaterThan'
+        DATETIMEGREATERTHANOREQUALS = 'dateTimeGreaterThanOrEquals'
+        DAYOFWEEKEQUALS = 'dayOfWeekEquals'
+        DAYOFWEEKANYOF = 'dayOfWeekAnyOf'
+
+
+class V2PolicyRuleRuleWithConditions(V2PolicyRule):
     """
-    Policy rule that has 2 to 10 conditions.
+    Rule that specifies additional access granted (e.g., time-based condition) accross
+    multiple conditions.
 
     :attr str operator: Operator to evalute conditions.
-    :attr List[V2PolicyAttribute] conditions: List of conditions to associated with
-          a policy. Note that conditions can be nested up to 2 levels.
+    :attr List[RuleAttribute] conditions: List of conditions associated with a
+          policy, e.g., time-based-conditions that grant access over a certain time
+          period.
     """
 
-    def __init__(self, operator: str, conditions: List['V2PolicyAttribute']) -> None:
+    def __init__(self, operator: str, conditions: List['RuleAttribute']) -> None:
         """
-        Initialize a V2PolicyBaseRuleV2RuleWithConditions object.
+        Initialize a V2PolicyRuleRuleWithConditions object.
 
         :param str operator: Operator to evalute conditions.
-        :param List[V2PolicyAttribute] conditions: List of conditions to associated
-               with a policy. Note that conditions can be nested up to 2 levels.
+        :param List[RuleAttribute] conditions: List of conditions associated with a
+               policy, e.g., time-based-conditions that grant access over a certain time
+               period.
         """
         # pylint: disable=super-init-not-called
         self.operator = operator
         self.conditions = conditions
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseRuleV2RuleWithConditions':
-        """Initialize a V2PolicyBaseRuleV2RuleWithConditions object from a json dictionary."""
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyRuleRuleWithConditions':
+        """Initialize a V2PolicyRuleRuleWithConditions object from a json dictionary."""
         args = {}
         if 'operator' in _dict:
             args['operator'] = _dict.get('operator')
         else:
-            raise ValueError('Required property \'operator\' not present in V2PolicyBaseRuleV2RuleWithConditions JSON')
+            raise ValueError('Required property \'operator\' not present in V2PolicyRuleRuleWithConditions JSON')
         if 'conditions' in _dict:
-            args['conditions'] = [V2PolicyAttribute.from_dict(v) for v in _dict.get('conditions')]
+            args['conditions'] = [RuleAttribute.from_dict(v) for v in _dict.get('conditions')]
         else:
-            raise ValueError(
-                'Required property \'conditions\' not present in V2PolicyBaseRuleV2RuleWithConditions JSON'
-            )
+            raise ValueError('Required property \'conditions\' not present in V2PolicyRuleRuleWithConditions JSON')
         return cls(**args)
 
     @classmethod
     def _from_dict(cls, _dict):
-        """Initialize a V2PolicyBaseRuleV2RuleWithConditions object from a json dictionary."""
+        """Initialize a V2PolicyRuleRuleWithConditions object from a json dictionary."""
         return cls.from_dict(_dict)
 
     def to_dict(self) -> Dict:
@@ -3087,16 +3875,16 @@ class V2PolicyBaseRuleV2RuleWithConditions(V2PolicyBaseRule):
         return self.to_dict()
 
     def __str__(self) -> str:
-        """Return a `str` version of this V2PolicyBaseRuleV2RuleWithConditions object."""
+        """Return a `str` version of this V2PolicyRuleRuleWithConditions object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: 'V2PolicyBaseRuleV2RuleWithConditions') -> bool:
+    def __eq__(self, other: 'V2PolicyRuleRuleWithConditions') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: 'V2PolicyBaseRuleV2RuleWithConditions') -> bool:
+    def __ne__(self, other: 'V2PolicyRuleRuleWithConditions') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 

--- a/ibm_platform_services/iam_policy_management_v1.py
+++ b/ibm_platform_services/iam_policy_management_v1.py
@@ -799,6 +799,466 @@ class IamPolicyManagementV1(BaseService):
         response = self.send(request, **kwargs)
         return response
 
+    #########################
+    # v2Policies
+    #########################
+
+    def v2_list_policies(
+        self,
+        account_id: str,
+        *,
+        accept_language: str = None,
+        iam_id: str = None,
+        access_group_id: str = None,
+        type: str = None,
+        service_type: str = None,
+        service_name: str = None,
+        service_group_id: str = None,
+        format: str = None,
+        state: str = None,
+        **kwargs
+    ) -> DetailedResponse:
+        """
+        Get policies by attributes.
+
+        Get policies and filter by attributes. While managing policies, you may want to
+        retrieve policies in the account and filter by attribute values. This can be done
+        through query parameters. Currently, only the following attributes are supported:
+        account_id, iam_id, access_group_id, type, service_type, sort, format and state.
+        account_id is a required query parameter. Only policies that have the specified
+        attributes and that the caller has read access to are returned. If the caller does
+        not have read access to any policies an empty array is returned.
+
+        :param str account_id: The account GUID in which the policies belong to.
+        :param str accept_language: (optional) Language code for translations
+               * `default` - English
+               * `de` -  German (Standard)
+               * `en` - English
+               * `es` - Spanish (Spain)
+               * `fr` - French (Standard)
+               * `it` - Italian (Standard)
+               * `ja` - Japanese
+               * `ko` - Korean
+               * `pt-br` - Portuguese (Brazil)
+               * `zh-cn` - Chinese (Simplified, PRC)
+               * `zh-tw` - (Chinese, Taiwan).
+        :param str iam_id: (optional) Optional IAM ID used to identify the subject.
+        :param str access_group_id: (optional) Optional access group id.
+        :param str type: (optional) Optional type of policy.
+        :param str service_type: (optional) Optional type of service.
+        :param str service_name: (optional) Optional name of service.
+        :param str service_group_id: (optional) Optional ID of service group.
+        :param str format: (optional) Include additional data per policy returned
+               * `include_last_permit` - returns details of when the policy last granted a
+               permit decision and the number of times it has done so
+               * `display` - returns the list of all actions included in each of the
+               policy roles and translations for all relevant fields.
+        :param str state: (optional) The state of the policy.
+               * `active` - returns active policies
+               * `deleted` - returns non-active policies.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `V2PolicyList` object
+        """
+
+        if not account_id:
+            raise ValueError('account_id must be provided')
+        headers = {'Accept-Language': accept_language}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='v2_list_policies'
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'account_id': account_id,
+            'iam_id': iam_id,
+            'access_group_id': access_group_id,
+            'type': type,
+            'service_type': service_type,
+            'service_name': service_name,
+            'service_group_id': service_group_id,
+            'format': format,
+            'state': state,
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v2/policies'
+        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def v2_create_policy(
+        self,
+        type: str,
+        control: 'V2PolicyBaseControl',
+        *,
+        description: str = None,
+        subject: 'V2PolicyBaseSubject' = None,
+        resource: 'V2PolicyBaseResource' = None,
+        pattern: str = None,
+        rule: 'V2PolicyBaseRule' = None,
+        accept_language: str = None,
+        **kwargs
+    ) -> DetailedResponse:
+        """
+        Create a policy.
+
+        Creates a policy to grant access between a subject and a resource. Currently,
+        there is one type of a v2/policy: **access**. A policy administrator might want to
+        create an access policy which grants access to a user, service-id, or an access
+        group.
+        ### Access
+        To create an access policy, use **`"type": "access"`** in the body. The possible
+        subject attributes are **`iam_id`** and **`access_group_id`**. Use the
+        **`iam_id`** subject attribute for assigning access for a user or service-id. Use
+        the **`access_group_id`** subject attribute for assigning access for an access
+        group. The roles must be a subset of a service's or the platform's supported
+        roles. The resource attributes must be a subset of a service's or the platform's
+        supported attributes. The policy resource must include either the
+        **`serviceType`**, **`serviceName`**, **`resourceGroupId`** or
+        **`service_group_id`** attribute and the **`accountId`** attribute.` The rule
+        field can either specify single **`key`**, **`value`**, and **`operator`** or be
+        set of **`conditions`** with a combination **`operator`**.  The possible
+        combination operator are **`and`** and **`or`**. The rule field has a maximum of 2
+        levels of nested **`conditions`**. The operator for a rule can be used to specify
+        a time based restriction (e.g., access only during business hours, during the
+        Monday-Friday work week). For example, a policy can grant access Monday-Friday,
+        9:00am-5:00pm using the following rule:
+        ```json
+          "rule": {
+            "operator": "and",
+            "conditions": [{
+              "key": "{{environment.attributes.day_of_week}}",
+              "operator": "dayOfWeekAnyOf",
+              "value": [1, 2, 3, 4, 5]
+            },
+              "key": "{{environment.attributes.current_time}}",
+              "operator": "timeGreaterThanOrEquals",
+              "value": "09:00:00+00:00"
+            },
+              "key": "{{environment.attributes.current_time}}",
+              "operator": "timeLessThanOrEquals",
+              "value": "17:00:00+00:00"
+            }]
+          }
+        ``` Rules and conditions allow the following operators with **`key`**, **`value`**
+        :
+        ```
+          'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan',
+        'timeGreaterThanOrEquals',
+          'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan',
+        'dateGreaterThanOrEquals',
+          'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan',
+        'dateTimeGreaterThanOrEquals',
+          'dayOfWeekEquals', 'dayOfWeekAnyOf',
+          'monthEquals', 'monthAnyOf',
+          'dayOfMonthEquals', 'dayOfMonthAnyOf'
+        ``` The pattern field can be coupled with a rule that matches the pattern. For the
+        business hour rule example above, the **`pattern`** is
+        **`"time-based-restrictions:weekly"`**. The IAM Services group (`IAM`) is a subset
+        of account management services that includes the IAM platform services IAM
+        Identity, IAM Access Management, IAM Users Management, IAM Groups, and future IAM
+        services. If the subject is a locked service-id, the request will fail.
+        ### Attribute Operators
+        Currently, only the `stringEquals`, `stringMatch`, and `stringEquals` operators
+        are available. For more information, see [how to assign access by using wildcards
+        policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
+        ### Attribute Validations
+        Policy attribute values must be between 1 and 1,000 characters in length. If
+        location related attributes like geography, country, metro, region, satellite, and
+        locationvalues are supported by the service, they are validated against Global
+        Catalog locations.
+
+        :param str type: The policy type; either 'access' or 'authorization'.
+        :param V2PolicyBaseControl control: Specifies the type of access granted by
+               the policy.
+        :param str description: (optional) Customer-defined description.
+        :param V2PolicyBaseSubject subject: (optional) The subject attributes
+               associated with a policy.
+        :param V2PolicyBaseResource resource: (optional) The resource attributes
+               associated with a policy.
+        :param str pattern: (optional) Indicates pattern of rule.
+        :param V2PolicyBaseRule rule: (optional) Additional access conditions
+               associated with a policy.
+        :param str accept_language: (optional) Language code for translations
+               * `default` - English
+               * `de` -  German (Standard)
+               * `en` - English
+               * `es` - Spanish (Spain)
+               * `fr` - French (Standard)
+               * `it` - Italian (Standard)
+               * `ja` - Japanese
+               * `ko` - Korean
+               * `pt-br` - Portuguese (Brazil)
+               * `zh-cn` - Chinese (Simplified, PRC)
+               * `zh-tw` - (Chinese, Taiwan).
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `V2Policy` object
+        """
+
+        if type is None:
+            raise ValueError('type must be provided')
+        if control is None:
+            raise ValueError('control must be provided')
+        control = convert_model(control)
+        if subject is not None:
+            subject = convert_model(subject)
+        if resource is not None:
+            resource = convert_model(resource)
+        if rule is not None:
+            rule = convert_model(rule)
+        headers = {'Accept-Language': accept_language}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='v2_create_policy'
+        )
+        headers.update(sdk_headers)
+
+        data = {
+            'type': type,
+            'control': control,
+            'description': description,
+            'subject': subject,
+            'resource': resource,
+            'pattern': pattern,
+            'rule': rule,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v2/policies'
+        request = self.prepare_request(method='POST', url=url, headers=headers, data=data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def v2_update_policy(
+        self,
+        policy_id: str,
+        if_match: str,
+        type: str,
+        control: 'V2PolicyBaseControl',
+        *,
+        description: str = None,
+        subject: 'V2PolicyBaseSubject' = None,
+        resource: 'V2PolicyBaseResource' = None,
+        pattern: str = None,
+        rule: 'V2PolicyBaseRule' = None,
+        **kwargs
+    ) -> DetailedResponse:
+        """
+        Update a policy.
+
+        Update a policy to grant access between a subject and a resource. A policy
+        administrator might want to update an existing policy.
+        ### Access
+        To update an access policy, use **`"type": "access"`** in the body. The possible
+        subject attributes are **`iam_id`** and **`access_group_id`**. Use the
+        **`iam_id`** subject attribute for assigning access for a user or service-id. Use
+        the **`access_group_id`** subject attribute for assigning access for an access
+        group. The roles must be a subset of a service's or the platform's supported
+        roles. The resource attributes must be a subset of a service's or the platform's
+        supported attributes. The policy resource must include either the
+        **`serviceType`**, **`serviceName`**,  or **`resourceGroupId`** attribute and the
+        **`accountId`** attribute.` The rule field can either specify single **`key`**,
+        **`value`**, and **`operator`** or be set of **`conditions`** with a combination
+        **`operator`**.  The possible combination operator are **`and`** and **`or`**. The
+        rule field has a maximum of 2 levels of nested **`conditions`**. The operator for
+        a rule can be used to specify a time based restriction (e.g., access only during
+        business hours, during the Monday-Friday work week). For example, a policy can
+        grant access Monday-Friday, 9:00am-5:00pm using the following rule:
+        ```json
+          "rule": {
+            "operator": "and",
+            "conditions": [{
+              "key": "{{environment.attributes.day_of_week}}",
+              "operator": "dayOfWeekAnyOf",
+              "value": [1, 2, 3, 4, 5]
+            },
+              "key": "{{environment.attributes.current_time}}",
+              "operator": "timeGreaterThanOrEquals",
+              "value": "09:00:00+00:00"
+            },
+              "key": "{{environment.attributes.current_time}}",
+              "operator": "timeLessThanOrEquals",
+              "value": "17:00:00+00:00"
+            }]
+          }
+        ``` Rules and conditions allow the following operators with **`key`**, **`value`**
+        :
+        ```
+          'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan',
+        'timeGreaterThanOrEquals',
+          'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan',
+        'dateGreaterThanOrEquals',
+          'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan',
+        'dateTimeGreaterThanOrEquals',
+          'dayOfWeekEquals', 'dayOfWeekAnyOf',
+          'monthEquals', 'monthAnyOf',
+          'dayOfMonthEquals', 'dayOfMonthAnyOf'
+        ``` The pattern field can be coupled with a rule that matches the pattern. For the
+        business hour rule example above, the **`pattern`** is
+        **`"time-based-restrictions:weekly"`**. If the subject is a locked service-id, the
+        request will fail.
+        ### Attribute Operators
+        Currently, only the `stringEquals`, `stringMatch`, and `stringEquals` operators
+        are available. For more information, see [how to assign access by using wildcards
+        policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
+        ### Attribute Validations
+        Policy attribute values must be between 1 and 1,000 characters in length. If
+        location related attributes like geography, country, metro, region, satellite, and
+        locationvalues are supported by the service, they are validated against Global
+        Catalog locations.
+
+        :param str policy_id: The policy ID.
+        :param str if_match: The revision number for updating a policy and must
+               match the ETag value of the existing policy. The Etag can be retrieved
+               using the GET /v1/policies/{policy_id} API and looking at the ETag response
+               header.
+        :param str type: The policy type; either 'access' or 'authorization'.
+        :param V2PolicyBaseControl control: Specifies the type of access granted by
+               the policy.
+        :param str description: (optional) Customer-defined description.
+        :param V2PolicyBaseSubject subject: (optional) The subject attributes
+               associated with a policy.
+        :param V2PolicyBaseResource resource: (optional) The resource attributes
+               associated with a policy.
+        :param str pattern: (optional) Indicates pattern of rule.
+        :param V2PolicyBaseRule rule: (optional) Additional access conditions
+               associated with a policy.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `V2Policy` object
+        """
+
+        if not policy_id:
+            raise ValueError('policy_id must be provided')
+        if not if_match:
+            raise ValueError('if_match must be provided')
+        if type is None:
+            raise ValueError('type must be provided')
+        if control is None:
+            raise ValueError('control must be provided')
+        control = convert_model(control)
+        if subject is not None:
+            subject = convert_model(subject)
+        if resource is not None:
+            resource = convert_model(resource)
+        if rule is not None:
+            rule = convert_model(rule)
+        headers = {'If-Match': if_match}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='v2_update_policy'
+        )
+        headers.update(sdk_headers)
+
+        data = {
+            'type': type,
+            'control': control,
+            'description': description,
+            'subject': subject,
+            'resource': resource,
+            'pattern': pattern,
+            'rule': rule,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['policy_id']
+        path_param_values = self.encode_path_vars(policy_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/policies/{policy_id}'.format(**path_param_dict)
+        request = self.prepare_request(method='PUT', url=url, headers=headers, data=data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def v2_get_policy(self, policy_id: str, **kwargs) -> DetailedResponse:
+        """
+        Retrieve a policy by ID.
+
+        Retrieve a policy by providing a policy ID.
+
+        :param str policy_id: The policy ID.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `V2Policy` object
+        """
+
+        if not policy_id:
+            raise ValueError('policy_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='v2_get_policy'
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['policy_id']
+        path_param_values = self.encode_path_vars(policy_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/policies/{policy_id}'.format(**path_param_dict)
+        request = self.prepare_request(method='GET', url=url, headers=headers)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def v2_delete_policy(self, policy_id: str, **kwargs) -> DetailedResponse:
+        """
+        Delete a policy by ID.
+
+        Delete a policy by providing a policy ID. A policy cannot be deleted if the
+        subject ID contains a locked service ID. If the subject of the policy is a locked
+        service-id, the request will fail.
+
+        :param str policy_id: The policy ID.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse
+        """
+
+        if not policy_id:
+            raise ValueError('policy_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='v2_delete_policy'
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+
+        path_param_keys = ['policy_id']
+        path_param_values = self.encode_path_vars(policy_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/policies/{policy_id}'.format(**path_param_dict)
+        request = self.prepare_request(method='DELETE', url=url, headers=headers)
+
+        response = self.send(request, **kwargs)
+        return response
+
 
 class ListPoliciesEnums:
     """
@@ -859,9 +1319,317 @@ class ListPoliciesEnums:
         DELETED = 'deleted'
 
 
+class V2ListPoliciesEnums:
+    """
+    Enums for v2_list_policies parameters.
+    """
+
+    class Type(str, Enum):
+        """
+        Optional type of policy.
+        """
+
+        ACCESS = 'access'
+        AUTHORIZATION = 'authorization'
+
+    class ServiceType(str, Enum):
+        """
+        Optional type of service.
+        """
+
+        SERVICE = 'service'
+        PLATFORM_SERVICE = 'platform_service'
+
+    class Format(str, Enum):
+        """
+        Include additional data per policy returned
+        * `include_last_permit` - returns details of when the policy last granted a permit
+        decision and the number of times it has done so
+        * `display` - returns the list of all actions included in each of the policy roles
+        and translations for all relevant fields.
+        """
+
+        INCLUDE_LAST_PERMIT = 'include_last_permit'
+        DISPLAY = 'display'
+
+    class State(str, Enum):
+        """
+        The state of the policy.
+        * `active` - returns active policies
+        * `deleted` - returns non-active policies.
+        """
+
+        ACTIVE = 'active'
+        DELETED = 'deleted'
+
+
 ##############################################################################
 # Models
 ##############################################################################
+
+
+class V2PolicyBaseControl:
+    """
+    Specifies the type of access granted by the policy.
+
+    :attr V2PolicyBaseControlGrant grant: Permission granted by the policy.
+    """
+
+    def __init__(self, grant: 'V2PolicyBaseControlGrant') -> None:
+        """
+        Initialize a V2PolicyBaseControl object.
+
+        :param V2PolicyBaseControlGrant grant: Permission granted by the policy.
+        """
+        self.grant = grant
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseControl':
+        """Initialize a V2PolicyBaseControl object from a json dictionary."""
+        args = {}
+        if 'grant' in _dict:
+            args['grant'] = V2PolicyBaseControlGrant.from_dict(_dict.get('grant'))
+        else:
+            raise ValueError('Required property \'grant\' not present in V2PolicyBaseControl JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyBaseControl object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'grant') and self.grant is not None:
+            if isinstance(self.grant, dict):
+                _dict['grant'] = self.grant
+            else:
+                _dict['grant'] = self.grant.to_dict()
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyBaseControl object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyBaseControl') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyBaseControl') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class V2PolicyBaseControlGrant:
+    """
+    Permission granted by the policy.
+
+    :attr List[PolicyRole] roles: A set of role cloud resource names (CRNs) granted
+          by the policy.
+    """
+
+    def __init__(self, roles: List['PolicyRole']) -> None:
+        """
+        Initialize a V2PolicyBaseControlGrant object.
+
+        :param List[PolicyRole] roles: A set of role cloud resource names (CRNs)
+               granted by the policy.
+        """
+        self.roles = roles
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseControlGrant':
+        """Initialize a V2PolicyBaseControlGrant object from a json dictionary."""
+        args = {}
+        if 'roles' in _dict:
+            args['roles'] = [PolicyRole.from_dict(v) for v in _dict.get('roles')]
+        else:
+            raise ValueError('Required property \'roles\' not present in V2PolicyBaseControlGrant JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyBaseControlGrant object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'roles') and self.roles is not None:
+            roles_list = []
+            for v in self.roles:
+                if isinstance(v, dict):
+                    roles_list.append(v)
+                else:
+                    roles_list.append(v.to_dict())
+            _dict['roles'] = roles_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyBaseControlGrant object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyBaseControlGrant') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyBaseControlGrant') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class V2PolicyBaseResource:
+    """
+    The resource attributes associated with a policy.
+
+    :attr List[V2PolicyAttribute] attributes: (optional) List of resource attributes
+          associated with policy/.
+    """
+
+    def __init__(self, *, attributes: List['V2PolicyAttribute'] = None) -> None:
+        """
+        Initialize a V2PolicyBaseResource object.
+
+        :param List[V2PolicyAttribute] attributes: (optional) List of resource
+               attributes associated with policy/.
+        """
+        self.attributes = attributes
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseResource':
+        """Initialize a V2PolicyBaseResource object from a json dictionary."""
+        args = {}
+        if 'attributes' in _dict:
+            args['attributes'] = [V2PolicyAttribute.from_dict(v) for v in _dict.get('attributes')]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyBaseResource object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'attributes') and self.attributes is not None:
+            attributes_list = []
+            for v in self.attributes:
+                if isinstance(v, dict):
+                    attributes_list.append(v)
+                else:
+                    attributes_list.append(v.to_dict())
+            _dict['attributes'] = attributes_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyBaseResource object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyBaseResource') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyBaseResource') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class V2PolicyBaseRule:
+    """
+    Additional access conditions associated with a policy.
+
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize a V2PolicyBaseRule object.
+
+        """
+        msg = "Cannot instantiate base class. Instead, instantiate one of the defined subclasses: {0}".format(
+            ", ".join(['V2PolicyBaseRuleV2PolicyAttribute', 'V2PolicyBaseRuleV2RuleWithConditions'])
+        )
+        raise Exception(msg)
+
+
+class V2PolicyBaseSubject:
+    """
+    The subject attributes associated with a policy.
+
+    :attr List[V2PolicyAttribute] attributes: (optional) List of subject attributes
+          associated with policy/.
+    """
+
+    def __init__(self, *, attributes: List['V2PolicyAttribute'] = None) -> None:
+        """
+        Initialize a V2PolicyBaseSubject object.
+
+        :param List[V2PolicyAttribute] attributes: (optional) List of subject
+               attributes associated with policy/.
+        """
+        self.attributes = attributes
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseSubject':
+        """Initialize a V2PolicyBaseSubject object from a json dictionary."""
+        args = {}
+        if 'attributes' in _dict:
+            args['attributes'] = [V2PolicyAttribute.from_dict(v) for v in _dict.get('attributes')]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyBaseSubject object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'attributes') and self.attributes is not None:
+            attributes_list = []
+            for v in self.attributes:
+                if isinstance(v, dict):
+                    attributes_list.append(v)
+                else:
+                    attributes_list.append(v.to_dict())
+            _dict['attributes'] = attributes_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyBaseSubject object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyBaseSubject') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyBaseSubject') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
 
 
 class CustomRole:
@@ -1850,3 +2618,492 @@ class SubjectAttribute:
     def __ne__(self, other: 'SubjectAttribute') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
+
+
+class V2Policy:
+    """
+    The core set of properties associated with a policy.
+
+    :attr str id: (optional) The policy ID.
+    :attr str type: The policy type; either 'access' or 'authorization'.
+    :attr str description: (optional) Customer-defined description.
+    :attr V2PolicyBaseSubject subject: (optional) The subject attributes associated
+          with a policy.
+    :attr V2PolicyBaseControl control: Specifies the type of access granted by the
+          policy.
+    :attr V2PolicyBaseResource resource: (optional) The resource attributes
+          associated with a policy.
+    :attr str pattern: (optional) Indicates pattern of rule.
+    :attr V2PolicyBaseRule rule: (optional) Additional access conditions associated
+          with a policy.
+    :attr str href: (optional) The href link back to the policy.
+    :attr datetime created_at: (optional) The UTC timestamp when the policy was
+          created.
+    :attr str created_by_id: (optional) The iam ID of the entity that created the
+          policy.
+    :attr datetime last_modified_at: (optional) The UTC timestamp when the policy
+          was last modified.
+    :attr str last_modified_by_id: (optional) The iam ID of the entity that last
+          modified the policy.
+    :attr str state: (optional) The policy state.
+    """
+
+    def __init__(
+        self,
+        type: str,
+        control: 'V2PolicyBaseControl',
+        *,
+        id: str = None,
+        description: str = None,
+        subject: 'V2PolicyBaseSubject' = None,
+        resource: 'V2PolicyBaseResource' = None,
+        pattern: str = None,
+        rule: 'V2PolicyBaseRule' = None,
+        href: str = None,
+        created_at: datetime = None,
+        created_by_id: str = None,
+        last_modified_at: datetime = None,
+        last_modified_by_id: str = None,
+        state: str = None
+    ) -> None:
+        """
+        Initialize a V2Policy object.
+
+        :param str type: The policy type; either 'access' or 'authorization'.
+        :param V2PolicyBaseControl control: Specifies the type of access granted by
+               the policy.
+        :param str description: (optional) Customer-defined description.
+        :param V2PolicyBaseSubject subject: (optional) The subject attributes
+               associated with a policy.
+        :param V2PolicyBaseResource resource: (optional) The resource attributes
+               associated with a policy.
+        :param str pattern: (optional) Indicates pattern of rule.
+        :param V2PolicyBaseRule rule: (optional) Additional access conditions
+               associated with a policy.
+        :param str state: (optional) The policy state.
+        """
+        self.id = id
+        self.type = type
+        self.description = description
+        self.subject = subject
+        self.control = control
+        self.resource = resource
+        self.pattern = pattern
+        self.rule = rule
+        self.href = href
+        self.created_at = created_at
+        self.created_by_id = created_by_id
+        self.last_modified_at = last_modified_at
+        self.last_modified_by_id = last_modified_by_id
+        self.state = state
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2Policy':
+        """Initialize a V2Policy object from a json dictionary."""
+        args = {}
+        if 'id' in _dict:
+            args['id'] = _dict.get('id')
+        if 'type' in _dict:
+            args['type'] = _dict.get('type')
+        else:
+            raise ValueError('Required property \'type\' not present in V2Policy JSON')
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
+        if 'subject' in _dict:
+            args['subject'] = V2PolicyBaseSubject.from_dict(_dict.get('subject'))
+        if 'control' in _dict:
+            args['control'] = V2PolicyBaseControl.from_dict(_dict.get('control'))
+        else:
+            raise ValueError('Required property \'control\' not present in V2Policy JSON')
+        if 'resource' in _dict:
+            args['resource'] = V2PolicyBaseResource.from_dict(_dict.get('resource'))
+        if 'pattern' in _dict:
+            args['pattern'] = _dict.get('pattern')
+        if 'rule' in _dict:
+            args['rule'] = _dict.get('rule')
+        if 'href' in _dict:
+            args['href'] = _dict.get('href')
+        if 'created_at' in _dict:
+            args['created_at'] = string_to_datetime(_dict.get('created_at'))
+        if 'created_by_id' in _dict:
+            args['created_by_id'] = _dict.get('created_by_id')
+        if 'last_modified_at' in _dict:
+            args['last_modified_at'] = string_to_datetime(_dict.get('last_modified_at'))
+        if 'last_modified_by_id' in _dict:
+            args['last_modified_by_id'] = _dict.get('last_modified_by_id')
+        if 'state' in _dict:
+            args['state'] = _dict.get('state')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2Policy object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'id') and getattr(self, 'id') is not None:
+            _dict['id'] = getattr(self, 'id')
+        if hasattr(self, 'type') and self.type is not None:
+            _dict['type'] = self.type
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'subject') and self.subject is not None:
+            if isinstance(self.subject, dict):
+                _dict['subject'] = self.subject
+            else:
+                _dict['subject'] = self.subject.to_dict()
+        if hasattr(self, 'control') and self.control is not None:
+            if isinstance(self.control, dict):
+                _dict['control'] = self.control
+            else:
+                _dict['control'] = self.control.to_dict()
+        if hasattr(self, 'resource') and self.resource is not None:
+            if isinstance(self.resource, dict):
+                _dict['resource'] = self.resource
+            else:
+                _dict['resource'] = self.resource.to_dict()
+        if hasattr(self, 'pattern') and self.pattern is not None:
+            _dict['pattern'] = self.pattern
+        if hasattr(self, 'rule') and self.rule is not None:
+            if isinstance(self.rule, dict):
+                _dict['rule'] = self.rule
+            else:
+                _dict['rule'] = self.rule.to_dict()
+        if hasattr(self, 'href') and getattr(self, 'href') is not None:
+            _dict['href'] = getattr(self, 'href')
+        if hasattr(self, 'created_at') and getattr(self, 'created_at') is not None:
+            _dict['created_at'] = datetime_to_string(getattr(self, 'created_at'))
+        if hasattr(self, 'created_by_id') and getattr(self, 'created_by_id') is not None:
+            _dict['created_by_id'] = getattr(self, 'created_by_id')
+        if hasattr(self, 'last_modified_at') and getattr(self, 'last_modified_at') is not None:
+            _dict['last_modified_at'] = datetime_to_string(getattr(self, 'last_modified_at'))
+        if hasattr(self, 'last_modified_by_id') and getattr(self, 'last_modified_by_id') is not None:
+            _dict['last_modified_by_id'] = getattr(self, 'last_modified_by_id')
+        if hasattr(self, 'state') and self.state is not None:
+            _dict['state'] = self.state
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2Policy object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2Policy') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2Policy') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class StateEnum(str, Enum):
+        """
+        The policy state.
+        """
+
+        ACTIVE = 'active'
+        DELETED = 'deleted'
+
+
+class V2PolicyAttribute:
+    """
+    Resource/subject attribute associated with policy attributes.
+
+    :attr str key: The name of an attribute.
+    :attr str operator: The operator of an attribute.
+    :attr object value: The value of an attribute; can be array, boolean, string, or
+          integer.
+    """
+
+    def __init__(self, key: str, operator: str, value: object) -> None:
+        """
+        Initialize a V2PolicyAttribute object.
+
+        :param str key: The name of an attribute.
+        :param str operator: The operator of an attribute.
+        :param object value: The value of an attribute; can be array, boolean,
+               string, or integer.
+        """
+        self.key = key
+        self.operator = operator
+        self.value = value
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyAttribute':
+        """Initialize a V2PolicyAttribute object from a json dictionary."""
+        args = {}
+        if 'key' in _dict:
+            args['key'] = _dict.get('key')
+        else:
+            raise ValueError('Required property \'key\' not present in V2PolicyAttribute JSON')
+        if 'operator' in _dict:
+            args['operator'] = _dict.get('operator')
+        else:
+            raise ValueError('Required property \'operator\' not present in V2PolicyAttribute JSON')
+        if 'value' in _dict:
+            args['value'] = _dict.get('value')
+        else:
+            raise ValueError('Required property \'value\' not present in V2PolicyAttribute JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyAttribute object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'key') and self.key is not None:
+            _dict['key'] = self.key
+        if hasattr(self, 'operator') and self.operator is not None:
+            _dict['operator'] = self.operator
+        if hasattr(self, 'value') and self.value is not None:
+            _dict['value'] = self.value
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyAttribute object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyAttribute') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyAttribute') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class V2PolicyList:
+    """
+    A collection of policies.
+
+    :attr List[V2Policy] policies: (optional) List of policies.
+    """
+
+    def __init__(self, *, policies: List['V2Policy'] = None) -> None:
+        """
+        Initialize a V2PolicyList object.
+
+        :param List[V2Policy] policies: (optional) List of policies.
+        """
+        self.policies = policies
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyList':
+        """Initialize a V2PolicyList object from a json dictionary."""
+        args = {}
+        if 'policies' in _dict:
+            args['policies'] = [V2Policy.from_dict(v) for v in _dict.get('policies')]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyList object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'policies') and self.policies is not None:
+            policies_list = []
+            for v in self.policies:
+                if isinstance(v, dict):
+                    policies_list.append(v)
+                else:
+                    policies_list.append(v.to_dict())
+            _dict['policies'] = policies_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyList object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyList') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyList') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class V2PolicyBaseRuleV2PolicyAttribute(V2PolicyBaseRule):
+    """
+    Resource/subject attribute associated with policy attributes.
+
+    :attr str key: The name of an attribute.
+    :attr str operator: The operator of an attribute.
+    :attr object value: The value of an attribute; can be array, boolean, string, or
+          integer.
+    """
+
+    def __init__(self, key: str, operator: str, value: object) -> None:
+        """
+        Initialize a V2PolicyBaseRuleV2PolicyAttribute object.
+
+        :param str key: The name of an attribute.
+        :param str operator: The operator of an attribute.
+        :param object value: The value of an attribute; can be array, boolean,
+               string, or integer.
+        """
+        # pylint: disable=super-init-not-called
+        self.key = key
+        self.operator = operator
+        self.value = value
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseRuleV2PolicyAttribute':
+        """Initialize a V2PolicyBaseRuleV2PolicyAttribute object from a json dictionary."""
+        args = {}
+        if 'key' in _dict:
+            args['key'] = _dict.get('key')
+        else:
+            raise ValueError('Required property \'key\' not present in V2PolicyBaseRuleV2PolicyAttribute JSON')
+        if 'operator' in _dict:
+            args['operator'] = _dict.get('operator')
+        else:
+            raise ValueError('Required property \'operator\' not present in V2PolicyBaseRuleV2PolicyAttribute JSON')
+        if 'value' in _dict:
+            args['value'] = _dict.get('value')
+        else:
+            raise ValueError('Required property \'value\' not present in V2PolicyBaseRuleV2PolicyAttribute JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyBaseRuleV2PolicyAttribute object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'key') and self.key is not None:
+            _dict['key'] = self.key
+        if hasattr(self, 'operator') and self.operator is not None:
+            _dict['operator'] = self.operator
+        if hasattr(self, 'value') and self.value is not None:
+            _dict['value'] = self.value
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyBaseRuleV2PolicyAttribute object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyBaseRuleV2PolicyAttribute') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyBaseRuleV2PolicyAttribute') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class V2PolicyBaseRuleV2RuleWithConditions(V2PolicyBaseRule):
+    """
+    Policy rule that has 2 to 10 conditions.
+
+    :attr str operator: Operator to evalute conditions.
+    :attr List[V2PolicyAttribute] conditions: List of conditions to associated with
+          a policy. Note that conditions can be nested up to 2 levels.
+    """
+
+    def __init__(self, operator: str, conditions: List['V2PolicyAttribute']) -> None:
+        """
+        Initialize a V2PolicyBaseRuleV2RuleWithConditions object.
+
+        :param str operator: Operator to evalute conditions.
+        :param List[V2PolicyAttribute] conditions: List of conditions to associated
+               with a policy. Note that conditions can be nested up to 2 levels.
+        """
+        # pylint: disable=super-init-not-called
+        self.operator = operator
+        self.conditions = conditions
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'V2PolicyBaseRuleV2RuleWithConditions':
+        """Initialize a V2PolicyBaseRuleV2RuleWithConditions object from a json dictionary."""
+        args = {}
+        if 'operator' in _dict:
+            args['operator'] = _dict.get('operator')
+        else:
+            raise ValueError('Required property \'operator\' not present in V2PolicyBaseRuleV2RuleWithConditions JSON')
+        if 'conditions' in _dict:
+            args['conditions'] = [V2PolicyAttribute.from_dict(v) for v in _dict.get('conditions')]
+        else:
+            raise ValueError(
+                'Required property \'conditions\' not present in V2PolicyBaseRuleV2RuleWithConditions JSON'
+            )
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a V2PolicyBaseRuleV2RuleWithConditions object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'operator') and self.operator is not None:
+            _dict['operator'] = self.operator
+        if hasattr(self, 'conditions') and self.conditions is not None:
+            conditions_list = []
+            for v in self.conditions:
+                if isinstance(v, dict):
+                    conditions_list.append(v)
+                else:
+                    conditions_list.append(v.to_dict())
+            _dict['conditions'] = conditions_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this V2PolicyBaseRuleV2RuleWithConditions object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'V2PolicyBaseRuleV2RuleWithConditions') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'V2PolicyBaseRuleV2RuleWithConditions') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class OperatorEnum(str, Enum):
+        """
+        Operator to evalute conditions.
+        """
+
+        AND = 'and'
+        OR = 'or'

--- a/test/integration/test_iam_policy_management_v1.py
+++ b/test/integration/test_iam_policy_management_v1.py
@@ -71,6 +71,35 @@ class TestIamPolicyManagementV1(unittest.TestCase):
             tags=[resource_tag],
         )
 
+        cls.testV2PolicySubject = V2PolicyBaseSubject(
+            attributes=[V2PolicyAttribute(key='iam_id', value=cls.testUserId, operator='stringEquals')]
+        )
+        cls.testV2PolicyResource = V2PolicyBaseResource(
+            attributes=[
+                V2PolicyAttribute(key='accountId', value=cls.testAccountId, operator='stringEquals'),
+                V2PolicyAttribute(key='serviceType', value='service', operator='stringEquals'),
+            ],
+        )
+        cls.testV2PolicyControl = V2PolicyBaseControl(grant=V2PolicyBaseControlGrant(roles=[cls.testPolicyRole]))
+        cls.testV2PolicyRule = V2PolicyBaseRuleV2RuleWithConditions(
+            operator='and',
+            conditions=[
+                V2PolicyAttribute(
+                    key='{{environment.attributes.day_of_week}}', operator='dayOfWeekAnyOf', value=[1, 2, 3, 4, 5]
+                ),
+                V2PolicyAttribute(
+                    key='{{environment.attributes.current_time}}',
+                    operator='timeGreaterThanOrEquals',
+                    value='09:00:00+00:00',
+                ),
+                V2PolicyAttribute(
+                    key='{{environment.attributes.current_time}}',
+                    operator='timeLessThanOrEquals',
+                    value='17:00:00+00:00',
+                ),
+            ],
+        )
+
         cls.testCustomRoleId = ""
         cls.testCustomRoleETag = ""
         cls.testCustomRoleName = 'TestPythonRole' + str(random.randint(0, 99999))
@@ -104,10 +133,17 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         for policy in result.policies:
             now = datetime.now(timezone.utc)
             minutesDifference = (now - policy.created_at).seconds / 60
-            if policy.id == cls.testPolicyId or minutesDifference < 5:
-                response = cls.service.delete_policy(policy_id=policy.id)
-                assert response is not None
-                assert response.get_status_code() == 204
+
+            if "v2/policies" in policy.href:
+                if policy.id == cls.testPolicyId or minutesDifference < 5:
+                    response = cls.service.v2_delete_policy(policy_id=policy.id)
+                    assert response is not None
+                    assert response.get_status_code() == 204
+            else:
+                if policy.id == cls.testPolicyId or minutesDifference < 5:
+                    response = cls.service.delete_policy(policy_id=policy.id)
+                    assert response is not None
+                    assert response.get_status_code() == 204
 
         # cleanup custon role
         assert cls.testCustomRoleId is not None
@@ -333,3 +369,102 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert result is not None
         assert result.id == self.testPolicyId
         assert result.state == 'active'
+
+    def test_10_create_v2_access_policy(self):
+        self.testV2PolicyControl.grant.roles[0].role_id = self.testViewerRoleCrn
+        response = self.service.v2_create_policy(
+            type='access',
+            subject=self.testV2PolicySubject,
+            control=self.testV2PolicyControl,
+            resource=self.testV2PolicyResource,
+            pattern='time-based-restrictions:weekly',
+            rule=self.testV2PolicyRule,
+        )
+        assert response is not None
+        assert response.get_status_code() == 201
+
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        result = V2Policy.from_dict(result_dict)
+        assert result is not None
+        assert result.subject == self.testV2PolicySubject
+        assert result.resource == self.testV2PolicyResource
+        assert result.control == self.testV2PolicyControl
+
+        print('\nTest policy: ', result)
+
+        self.__class__.testPolicyId = result.id
+
+    def test_11_get_v2_access_policy(self):
+        assert self.testPolicyId
+        print("Policy ID: ", self.testPolicyId)
+
+        response = self.service.v2_get_policy(policy_id=self.testPolicyId)
+        assert response is not None
+        assert response.get_status_code() == 200
+
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        result = V2Policy.from_dict(result_dict)
+        assert result is not None
+        assert result.subject == self.testV2PolicySubject
+        assert result.resource == self.testV2PolicyResource
+        assert result.control.grant.roles[0].role_id == self.testViewerRoleCrn
+        assert result.state == 'active'
+
+        self.__class__.testPolicyETag = response.get_headers().get(self.etagHeader)
+
+    def test_12_update_v2_access_policy(self):
+        assert self.testPolicyId
+        assert self.testPolicyETag
+        print("Policy ID: ", self.testPolicyId)
+
+        self.testV2PolicyControl.grant.roles[0].role_id = self.testEditorRoleCrn
+
+        response = self.service.v2_update_policy(
+            policy_id=self.testPolicyId,
+            if_match=self.testPolicyETag,
+            type='access',
+            subject=self.testV2PolicySubject,
+            control=self.testV2PolicyControl,
+            resource=self.testV2PolicyResource,
+        )
+        assert response is not None
+        assert response.get_status_code() == 200
+
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        result = V2Policy.from_dict(result_dict)
+        assert result is not None
+        assert result.id == self.testPolicyId
+        assert result.subject == self.testV2PolicySubject
+        assert result.resource == self.testV2PolicyResource
+        assert result.control.grant.roles[0].role_id == self.testEditorRoleCrn
+
+        self.__class__.testPolicyETag = response.get_headers().get(self.etagHeader)
+
+    def test_13_list_v2_access_policies(self):
+        print("Policy ID: ", self.testPolicyId)
+
+        response = self.service.v2_list_policies(account_id=self.testAccountId, iam_id=self.testUserId)
+        assert response is not None
+        assert response.get_status_code() == 200
+
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        result = V2PolicyList.from_dict(result_dict)
+        assert result is not None
+
+        print("Policy list: ", result)
+
+        # Confirm the test policy is present
+        foundTestPolicy = False
+        for policy in result.policies:
+            if policy.id == self.testPolicyId:
+                foundTestPolicy = True
+                break
+        assert foundTestPolicy

--- a/test/integration/test_iam_policy_management_v1.py
+++ b/test/integration/test_iam_policy_management_v1.py
@@ -71,28 +71,31 @@ class TestIamPolicyManagementV1(unittest.TestCase):
             tags=[resource_tag],
         )
 
-        cls.testV2PolicySubject = V2PolicyBaseSubject(
-            attributes=[V2PolicyAttribute(key='iam_id', value=cls.testUserId, operator='stringEquals')]
+        cls.testV2PolicySubject = V2PolicySubject(
+            attributes=[V2PolicySubjectAttribute(key='iam_id', value=cls.testUserId + '2', operator='stringEquals')]
         )
-        cls.testV2PolicyResource = V2PolicyBaseResource(
+        cls.testV2PolicyResource = V2PolicyResource(
             attributes=[
-                V2PolicyAttribute(key='accountId', value=cls.testAccountId, operator='stringEquals'),
-                V2PolicyAttribute(key='serviceType', value='service', operator='stringEquals'),
+                V2PolicyResourceAttribute(key='accountId', value=cls.testAccountId, operator='stringEquals'),
+                V2PolicyResourceAttribute(key='serviceType', value='service', operator='stringEquals'),
             ],
+            tags=[V2PolicyResourceTag(key='project', value='prototype', operator='stringEquals')],
         )
-        cls.testV2PolicyControl = V2PolicyBaseControl(grant=V2PolicyBaseControlGrant(roles=[cls.testPolicyRole]))
-        cls.testV2PolicyRule = V2PolicyBaseRuleV2RuleWithConditions(
+        cls.testV2PolicyControl = Control(grant=V2PolicyGrant(roles=[cls.testPolicyRole]))
+        cls.testV2PolicyRule = V2PolicyRuleRuleWithConditions(
             operator='and',
             conditions=[
-                V2PolicyAttribute(
-                    key='{{environment.attributes.day_of_week}}', operator='dayOfWeekAnyOf', value=[1, 2, 3, 4, 5]
+                RuleAttribute(
+                    key='{{environment.attributes.day_of_week}}',
+                    operator='dayOfWeekAnyOf',
+                    value=['1+00:00', '2+00:00', '3+00:00', '4+00:00', '5+00:00'],
                 ),
-                V2PolicyAttribute(
+                RuleAttribute(
                     key='{{environment.attributes.current_time}}',
                     operator='timeGreaterThanOrEquals',
                     value='09:00:00+00:00',
                 ),
-                V2PolicyAttribute(
+                RuleAttribute(
                     key='{{environment.attributes.current_time}}',
                     operator='timeLessThanOrEquals',
                     value='17:00:00+00:00',
@@ -136,7 +139,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
 
             if "v2/policies" in policy.href:
                 if policy.id == cls.testPolicyId or minutesDifference < 5:
-                    response = cls.service.v2_delete_policy(policy_id=policy.id)
+                    response = cls.service.delete_v2_policy(id=policy.id)
                     assert response is not None
                     assert response.get_status_code() == 204
             else:
@@ -207,7 +210,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
 
         self.testPolicyRole.role_id = self.testEditorRoleCrn
 
-        response = self.service.update_policy(
+        response = self.service.replace_policy(
             policy_id=self.testPolicyId,
             if_match=self.testPolicyETag,
             type='access',
@@ -306,7 +309,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert self.testCustomRoleETag
         print("Custom Role ID: ", self.testCustomRoleId)
 
-        response = self.service.update_role(
+        response = self.service.replace_role(
             role_id=self.testCustomRoleId,
             if_match=self.testCustomRoleETag,
             display_name='Updated ' + self.testCustomRole.display_name,
@@ -358,7 +361,9 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert self.testPolicyETag
         print("Policy ID: ", self.testPolicyId)
 
-        response = self.service.patch_policy(policy_id=self.testPolicyId, if_match=self.testPolicyETag, state='active')
+        response = self.service.update_policy_state(
+            policy_id=self.testPolicyId, if_match=self.testPolicyETag, state='active'
+        )
         assert response is not None
         assert response.get_status_code() == 200
 
@@ -372,12 +377,12 @@ class TestIamPolicyManagementV1(unittest.TestCase):
 
     def test_10_create_v2_access_policy(self):
         self.testV2PolicyControl.grant.roles[0].role_id = self.testViewerRoleCrn
-        response = self.service.v2_create_policy(
+        response = self.service.create_v2_policy(
             type='access',
             subject=self.testV2PolicySubject,
             control=self.testV2PolicyControl,
             resource=self.testV2PolicyResource,
-            pattern='time-based-restrictions:weekly',
+            pattern='time-based-conditions:weekly:custom-hours',
             rule=self.testV2PolicyRule,
         )
         assert response is not None
@@ -390,7 +395,9 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert result is not None
         assert result.subject == self.testV2PolicySubject
         assert result.resource == self.testV2PolicyResource
-        assert result.control == self.testV2PolicyControl
+        assert result.control is not None
+        control = Control.from_dict(result.control)
+        assert control == self.testV2PolicyControl
 
         print('\nTest policy: ', result)
 
@@ -400,7 +407,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert self.testPolicyId
         print("Policy ID: ", self.testPolicyId)
 
-        response = self.service.v2_get_policy(policy_id=self.testPolicyId)
+        response = self.service.get_v2_policy(id=self.testPolicyId)
         assert response is not None
         assert response.get_status_code() == 200
 
@@ -411,7 +418,9 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert result is not None
         assert result.subject == self.testV2PolicySubject
         assert result.resource == self.testV2PolicyResource
-        assert result.control.grant.roles[0].role_id == self.testViewerRoleCrn
+        assert result.control is not None
+        control = Control.from_dict(result.control)
+        assert control.grant.roles[0].role_id == self.testViewerRoleCrn
         assert result.state == 'active'
 
         self.__class__.testPolicyETag = response.get_headers().get(self.etagHeader)
@@ -423,8 +432,8 @@ class TestIamPolicyManagementV1(unittest.TestCase):
 
         self.testV2PolicyControl.grant.roles[0].role_id = self.testEditorRoleCrn
 
-        response = self.service.v2_update_policy(
-            policy_id=self.testPolicyId,
+        response = self.service.replace_v2_policy(
+            id=self.testPolicyId,
             if_match=self.testPolicyETag,
             type='access',
             subject=self.testV2PolicySubject,
@@ -442,21 +451,24 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert result.id == self.testPolicyId
         assert result.subject == self.testV2PolicySubject
         assert result.resource == self.testV2PolicyResource
-        assert result.control.grant.roles[0].role_id == self.testEditorRoleCrn
+
+        assert result.control is not None
+        control = Control.from_dict(result.control)
+        assert control.grant.roles[0].role_id == self.testEditorRoleCrn
 
         self.__class__.testPolicyETag = response.get_headers().get(self.etagHeader)
 
     def test_13_list_v2_access_policies(self):
         print("Policy ID: ", self.testPolicyId)
 
-        response = self.service.v2_list_policies(account_id=self.testAccountId, iam_id=self.testUserId)
+        response = self.service.list_v2_policies(account_id=self.testAccountId, iam_id=self.testUserId + '2')
         assert response is not None
         assert response.get_status_code() == 200
 
         result_dict = response.get_result()
         assert result_dict is not None
 
-        result = V2PolicyList.from_dict(result_dict)
+        result = V2PolicyCollection.from_dict(result_dict)
         assert result is not None
 
         print("Policy list: ", result)

--- a/test/unit/test_iam_policy_management_v1.py
+++ b/test/unit/test_iam_policy_management_v1.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (C) Copyright IBM Corp. 2022.
+# (C) Copyright IBM Corp. 2023.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -449,15 +449,15 @@ class TestCreatePolicy:
         self.test_create_policy_value_error()
 
 
-class TestUpdatePolicy:
+class TestReplacePolicy:
     """
-    Test Class for update_policy
+    Test Class for replace_policy
     """
 
     @responses.activate
-    def test_update_policy_all_params(self):
+    def test_replace_policy_all_params(self):
         """
-        update_policy()
+        replace_policy()
         """
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
@@ -504,7 +504,7 @@ class TestUpdatePolicy:
         description = 'testString'
 
         # Invoke method
-        response = _service.update_policy(
+        response = _service.replace_policy(
             policy_id, if_match, type, subjects, roles, resources, description=description, headers={}
         )
 
@@ -519,19 +519,19 @@ class TestUpdatePolicy:
         assert req_body['resources'] == [policy_resource_model]
         assert req_body['description'] == 'testString'
 
-    def test_update_policy_all_params_with_retries(self):
-        # Enable retries and run test_update_policy_all_params.
+    def test_replace_policy_all_params_with_retries(self):
+        # Enable retries and run test_replace_policy_all_params.
         _service.enable_retries()
-        self.test_update_policy_all_params()
+        self.test_replace_policy_all_params()
 
-        # Disable retries and run test_update_policy_all_params.
+        # Disable retries and run test_replace_policy_all_params.
         _service.disable_retries()
-        self.test_update_policy_all_params()
+        self.test_replace_policy_all_params()
 
     @responses.activate
-    def test_update_policy_value_error(self):
+    def test_replace_policy_value_error(self):
         """
-        test_update_policy_value_error()
+        test_replace_policy_value_error()
         """
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
@@ -589,16 +589,16 @@ class TestUpdatePolicy:
         for param in req_param_dict.keys():
             req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
-                _service.update_policy(**req_copy)
+                _service.replace_policy(**req_copy)
 
-    def test_update_policy_value_error_with_retries(self):
-        # Enable retries and run test_update_policy_value_error.
+    def test_replace_policy_value_error_with_retries(self):
+        # Enable retries and run test_replace_policy_value_error.
         _service.enable_retries()
-        self.test_update_policy_value_error()
+        self.test_replace_policy_value_error()
 
-        # Disable retries and run test_update_policy_value_error.
+        # Disable retries and run test_replace_policy_value_error.
         _service.disable_retries()
-        self.test_update_policy_value_error()
+        self.test_replace_policy_value_error()
 
 
 class TestGetPolicy:
@@ -731,15 +731,15 @@ class TestDeletePolicy:
         self.test_delete_policy_value_error()
 
 
-class TestPatchPolicy:
+class TestUpdatePolicyState:
     """
-    Test Class for patch_policy
+    Test Class for update_policy_state
     """
 
     @responses.activate
-    def test_patch_policy_all_params(self):
+    def test_update_policy_state_all_params(self):
         """
-        patch_policy()
+        update_policy_state()
         """
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
@@ -752,7 +752,7 @@ class TestPatchPolicy:
         state = 'active'
 
         # Invoke method
-        response = _service.patch_policy(policy_id, if_match, state=state, headers={})
+        response = _service.update_policy_state(policy_id, if_match, state=state, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -761,19 +761,19 @@ class TestPatchPolicy:
         req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
         assert req_body['state'] == 'active'
 
-    def test_patch_policy_all_params_with_retries(self):
-        # Enable retries and run test_patch_policy_all_params.
+    def test_update_policy_state_all_params_with_retries(self):
+        # Enable retries and run test_update_policy_state_all_params.
         _service.enable_retries()
-        self.test_patch_policy_all_params()
+        self.test_update_policy_state_all_params()
 
-        # Disable retries and run test_patch_policy_all_params.
+        # Disable retries and run test_update_policy_state_all_params.
         _service.disable_retries()
-        self.test_patch_policy_all_params()
+        self.test_update_policy_state_all_params()
 
     @responses.activate
-    def test_patch_policy_value_error(self):
+    def test_update_policy_state_value_error(self):
         """
-        test_patch_policy_value_error()
+        test_update_policy_state_value_error()
         """
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
@@ -793,16 +793,16 @@ class TestPatchPolicy:
         for param in req_param_dict.keys():
             req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
-                _service.patch_policy(**req_copy)
+                _service.update_policy_state(**req_copy)
 
-    def test_patch_policy_value_error_with_retries(self):
-        # Enable retries and run test_patch_policy_value_error.
+    def test_update_policy_state_value_error_with_retries(self):
+        # Enable retries and run test_update_policy_state_value_error.
         _service.enable_retries()
-        self.test_patch_policy_value_error()
+        self.test_update_policy_state_value_error()
 
-        # Disable retries and run test_patch_policy_value_error.
+        # Disable retries and run test_update_policy_state_value_error.
         _service.disable_retries()
-        self.test_patch_policy_value_error()
+        self.test_update_policy_state_value_error()
 
 
 # endregion
@@ -1065,15 +1065,15 @@ class TestCreateRole:
         self.test_create_role_value_error()
 
 
-class TestUpdateRole:
+class TestReplaceRole:
     """
-    Test Class for update_role
+    Test Class for replace_role
     """
 
     @responses.activate
-    def test_update_role_all_params(self):
+    def test_replace_role_all_params(self):
         """
-        update_role()
+        replace_role()
         """
         # Set up mock
         url = preprocess_url('/v2/roles/testString')
@@ -1084,13 +1084,11 @@ class TestUpdateRole:
         role_id = 'testString'
         if_match = 'testString'
         display_name = 'testString'
-        description = 'testString'
         actions = ['testString']
+        description = 'testString'
 
         # Invoke method
-        response = _service.update_role(
-            role_id, if_match, display_name=display_name, description=description, actions=actions, headers={}
-        )
+        response = _service.replace_role(role_id, if_match, display_name, actions, description=description, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1098,22 +1096,22 @@ class TestUpdateRole:
         # Validate body params
         req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
         assert req_body['display_name'] == 'testString'
-        assert req_body['description'] == 'testString'
         assert req_body['actions'] == ['testString']
+        assert req_body['description'] == 'testString'
 
-    def test_update_role_all_params_with_retries(self):
-        # Enable retries and run test_update_role_all_params.
+    def test_replace_role_all_params_with_retries(self):
+        # Enable retries and run test_replace_role_all_params.
         _service.enable_retries()
-        self.test_update_role_all_params()
+        self.test_replace_role_all_params()
 
-        # Disable retries and run test_update_role_all_params.
+        # Disable retries and run test_replace_role_all_params.
         _service.disable_retries()
-        self.test_update_role_all_params()
+        self.test_replace_role_all_params()
 
     @responses.activate
-    def test_update_role_value_error(self):
+    def test_replace_role_value_error(self):
         """
-        test_update_role_value_error()
+        test_replace_role_value_error()
         """
         # Set up mock
         url = preprocess_url('/v2/roles/testString')
@@ -1124,27 +1122,29 @@ class TestUpdateRole:
         role_id = 'testString'
         if_match = 'testString'
         display_name = 'testString'
-        description = 'testString'
         actions = ['testString']
+        description = 'testString'
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
             "role_id": role_id,
             "if_match": if_match,
+            "display_name": display_name,
+            "actions": actions,
         }
         for param in req_param_dict.keys():
             req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
-                _service.update_role(**req_copy)
+                _service.replace_role(**req_copy)
 
-    def test_update_role_value_error_with_retries(self):
-        # Enable retries and run test_update_role_value_error.
+    def test_replace_role_value_error_with_retries(self):
+        # Enable retries and run test_replace_role_value_error.
         _service.enable_retries()
-        self.test_update_role_value_error()
+        self.test_replace_role_value_error()
 
-        # Disable retries and run test_update_role_value_error.
+        # Disable retries and run test_replace_role_value_error.
         _service.disable_retries()
-        self.test_update_role_value_error()
+        self.test_replace_role_value_error()
 
 
 class TestGetRole:
@@ -1316,19 +1316,19 @@ class TestNewInstance:
             )
 
 
-class TestV2ListPolicies:
+class TestListV2Policies:
     """
-    Test Class for v2_list_policies
+    Test Class for list_v2_policies
     """
 
     @responses.activate
-    def test_v2_list_policies_all_params(self):
+    def test_list_v2_policies_all_params(self):
         """
-        v2_list_policies()
+        list_v2_policies()
         """
         # Set up mock
         url = preprocess_url('/v2/policies')
-        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
+        mock_response = '{"policies": [{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}]}'
         responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
@@ -1344,7 +1344,7 @@ class TestV2ListPolicies:
         state = 'active'
 
         # Invoke method
-        response = _service.v2_list_policies(
+        response = _service.list_v2_policies(
             account_id,
             accept_language=accept_language,
             iam_id=iam_id,
@@ -1374,30 +1374,30 @@ class TestV2ListPolicies:
         assert 'format={}'.format(format) in query_string
         assert 'state={}'.format(state) in query_string
 
-    def test_v2_list_policies_all_params_with_retries(self):
-        # Enable retries and run test_v2_list_policies_all_params.
+    def test_list_v2_policies_all_params_with_retries(self):
+        # Enable retries and run test_list_v2_policies_all_params.
         _service.enable_retries()
-        self.test_v2_list_policies_all_params()
+        self.test_list_v2_policies_all_params()
 
-        # Disable retries and run test_v2_list_policies_all_params.
+        # Disable retries and run test_list_v2_policies_all_params.
         _service.disable_retries()
-        self.test_v2_list_policies_all_params()
+        self.test_list_v2_policies_all_params()
 
     @responses.activate
-    def test_v2_list_policies_required_params(self):
+    def test_list_v2_policies_required_params(self):
         """
-        test_v2_list_policies_required_params()
+        test_list_v2_policies_required_params()
         """
         # Set up mock
         url = preprocess_url('/v2/policies')
-        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
+        mock_response = '{"policies": [{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}]}'
         responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
         account_id = 'testString'
 
         # Invoke method
-        response = _service.v2_list_policies(account_id, headers={})
+        response = _service.list_v2_policies(account_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1407,23 +1407,23 @@ class TestV2ListPolicies:
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'account_id={}'.format(account_id) in query_string
 
-    def test_v2_list_policies_required_params_with_retries(self):
-        # Enable retries and run test_v2_list_policies_required_params.
+    def test_list_v2_policies_required_params_with_retries(self):
+        # Enable retries and run test_list_v2_policies_required_params.
         _service.enable_retries()
-        self.test_v2_list_policies_required_params()
+        self.test_list_v2_policies_required_params()
 
-        # Disable retries and run test_v2_list_policies_required_params.
+        # Disable retries and run test_list_v2_policies_required_params.
         _service.disable_retries()
-        self.test_v2_list_policies_required_params()
+        self.test_list_v2_policies_required_params()
 
     @responses.activate
-    def test_v2_list_policies_value_error(self):
+    def test_list_v2_policies_value_error(self):
         """
-        test_v2_list_policies_value_error()
+        test_list_v2_policies_value_error()
         """
         # Set up mock
         url = preprocess_url('/v2/policies')
-        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
+        mock_response = '{"policies": [{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}]}'
         responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
@@ -1436,79 +1436,92 @@ class TestV2ListPolicies:
         for param in req_param_dict.keys():
             req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
-                _service.v2_list_policies(**req_copy)
+                _service.list_v2_policies(**req_copy)
 
-    def test_v2_list_policies_value_error_with_retries(self):
-        # Enable retries and run test_v2_list_policies_value_error.
+    def test_list_v2_policies_value_error_with_retries(self):
+        # Enable retries and run test_list_v2_policies_value_error.
         _service.enable_retries()
-        self.test_v2_list_policies_value_error()
+        self.test_list_v2_policies_value_error()
 
-        # Disable retries and run test_v2_list_policies_value_error.
+        # Disable retries and run test_list_v2_policies_value_error.
         _service.disable_retries()
-        self.test_v2_list_policies_value_error()
+        self.test_list_v2_policies_value_error()
 
 
-class TestV2CreatePolicy:
+class TestCreateV2Policy:
     """
-    Test Class for v2_create_policy
+    Test Class for create_v2_policy
     """
 
     @responses.activate
-    def test_v2_create_policy_all_params(self):
+    def test_create_v2_policy_all_params(self):
         """
-        v2_create_policy()
+        create_v2_policy()
         """
         # Set up mock
         url = preprocess_url('/v2/policies')
-        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}'
         responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Construct a dict representation of a PolicyRole model
         policy_role_model = {}
         policy_role_model['role_id'] = 'testString'
 
-        # Construct a dict representation of a V2PolicyBaseControlGrant model
-        v2_policy_base_control_grant_model = {}
-        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+        # Construct a dict representation of a V2PolicyGrant model
+        v2_policy_grant_model = {}
+        v2_policy_grant_model['roles'] = [policy_role_model]
 
-        # Construct a dict representation of a V2PolicyBaseControl model
-        v2_policy_base_control_model = {}
-        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+        # Construct a dict representation of a Control model
+        control_model = {}
+        control_model['grant'] = v2_policy_grant_model
 
-        # Construct a dict representation of a V2PolicyAttribute model
-        v2_policy_attribute_model = {}
-        v2_policy_attribute_model['key'] = 'testString'
-        v2_policy_attribute_model['operator'] = 'testString'
-        v2_policy_attribute_model['value'] = 'testString'
+        # Construct a dict representation of a V2PolicySubjectAttribute model
+        v2_policy_subject_attribute_model = {}
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
 
-        # Construct a dict representation of a V2PolicyBaseSubject model
-        v2_policy_base_subject_model = {}
-        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+        # Construct a dict representation of a V2PolicySubject model
+        v2_policy_subject_model = {}
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
 
-        # Construct a dict representation of a V2PolicyBaseResource model
-        v2_policy_base_resource_model = {}
-        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+        # Construct a dict representation of a V2PolicyResourceAttribute model
+        v2_policy_resource_attribute_model = {}
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
 
-        # Construct a dict representation of a V2PolicyBaseRuleV2PolicyAttribute model
-        v2_policy_base_rule_model = {}
-        v2_policy_base_rule_model['key'] = 'testString'
-        v2_policy_base_rule_model['operator'] = 'testString'
-        v2_policy_base_rule_model['value'] = 'testString'
+        # Construct a dict representation of a V2PolicyResourceTag model
+        v2_policy_resource_tag_model = {}
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        # Construct a dict representation of a V2PolicyResource model
+        v2_policy_resource_model = {}
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        # Construct a dict representation of a V2PolicyRuleRuleAttribute model
+        v2_policy_rule_model = {}
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
 
         # Set up parameter values
-        type = 'testString'
-        control = v2_policy_base_control_model
+        control = control_model
+        type = 'access'
         description = 'testString'
-        subject = v2_policy_base_subject_model
-        resource = v2_policy_base_resource_model
+        subject = v2_policy_subject_model
+        resource = v2_policy_resource_model
         pattern = 'testString'
-        rule = v2_policy_base_rule_model
+        rule = v2_policy_rule_model
         accept_language = 'default'
 
         # Invoke method
-        response = _service.v2_create_policy(
-            type,
+        response = _service.create_v2_policy(
             control,
+            type,
             description=description,
             subject=subject,
             resource=resource,
@@ -1523,78 +1536,91 @@ class TestV2CreatePolicy:
         assert response.status_code == 201
         # Validate body params
         req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
-        assert req_body['type'] == 'testString'
-        assert req_body['control'] == v2_policy_base_control_model
+        assert req_body['control'] == control_model
+        assert req_body['type'] == 'access'
         assert req_body['description'] == 'testString'
-        assert req_body['subject'] == v2_policy_base_subject_model
-        assert req_body['resource'] == v2_policy_base_resource_model
+        assert req_body['subject'] == v2_policy_subject_model
+        assert req_body['resource'] == v2_policy_resource_model
         assert req_body['pattern'] == 'testString'
-        assert req_body['rule'] == v2_policy_base_rule_model
+        assert req_body['rule'] == v2_policy_rule_model
 
-    def test_v2_create_policy_all_params_with_retries(self):
-        # Enable retries and run test_v2_create_policy_all_params.
+    def test_create_v2_policy_all_params_with_retries(self):
+        # Enable retries and run test_create_v2_policy_all_params.
         _service.enable_retries()
-        self.test_v2_create_policy_all_params()
+        self.test_create_v2_policy_all_params()
 
-        # Disable retries and run test_v2_create_policy_all_params.
+        # Disable retries and run test_create_v2_policy_all_params.
         _service.disable_retries()
-        self.test_v2_create_policy_all_params()
+        self.test_create_v2_policy_all_params()
 
     @responses.activate
-    def test_v2_create_policy_required_params(self):
+    def test_create_v2_policy_required_params(self):
         """
-        test_v2_create_policy_required_params()
+        test_create_v2_policy_required_params()
         """
         # Set up mock
         url = preprocess_url('/v2/policies')
-        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}'
         responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Construct a dict representation of a PolicyRole model
         policy_role_model = {}
         policy_role_model['role_id'] = 'testString'
 
-        # Construct a dict representation of a V2PolicyBaseControlGrant model
-        v2_policy_base_control_grant_model = {}
-        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+        # Construct a dict representation of a V2PolicyGrant model
+        v2_policy_grant_model = {}
+        v2_policy_grant_model['roles'] = [policy_role_model]
 
-        # Construct a dict representation of a V2PolicyBaseControl model
-        v2_policy_base_control_model = {}
-        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+        # Construct a dict representation of a Control model
+        control_model = {}
+        control_model['grant'] = v2_policy_grant_model
 
-        # Construct a dict representation of a V2PolicyAttribute model
-        v2_policy_attribute_model = {}
-        v2_policy_attribute_model['key'] = 'testString'
-        v2_policy_attribute_model['operator'] = 'testString'
-        v2_policy_attribute_model['value'] = 'testString'
+        # Construct a dict representation of a V2PolicySubjectAttribute model
+        v2_policy_subject_attribute_model = {}
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
 
-        # Construct a dict representation of a V2PolicyBaseSubject model
-        v2_policy_base_subject_model = {}
-        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+        # Construct a dict representation of a V2PolicySubject model
+        v2_policy_subject_model = {}
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
 
-        # Construct a dict representation of a V2PolicyBaseResource model
-        v2_policy_base_resource_model = {}
-        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+        # Construct a dict representation of a V2PolicyResourceAttribute model
+        v2_policy_resource_attribute_model = {}
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
 
-        # Construct a dict representation of a V2PolicyBaseRuleV2PolicyAttribute model
-        v2_policy_base_rule_model = {}
-        v2_policy_base_rule_model['key'] = 'testString'
-        v2_policy_base_rule_model['operator'] = 'testString'
-        v2_policy_base_rule_model['value'] = 'testString'
+        # Construct a dict representation of a V2PolicyResourceTag model
+        v2_policy_resource_tag_model = {}
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        # Construct a dict representation of a V2PolicyResource model
+        v2_policy_resource_model = {}
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        # Construct a dict representation of a V2PolicyRuleRuleAttribute model
+        v2_policy_rule_model = {}
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
 
         # Set up parameter values
-        type = 'testString'
-        control = v2_policy_base_control_model
+        control = control_model
+        type = 'access'
         description = 'testString'
-        subject = v2_policy_base_subject_model
-        resource = v2_policy_base_resource_model
+        subject = v2_policy_subject_model
+        resource = v2_policy_resource_model
         pattern = 'testString'
-        rule = v2_policy_base_rule_model
+        rule = v2_policy_rule_model
 
         # Invoke method
-        response = _service.v2_create_policy(
-            type,
+        response = _service.create_v2_policy(
             control,
+            type,
             description=description,
             subject=subject,
             resource=resource,
@@ -1608,158 +1634,184 @@ class TestV2CreatePolicy:
         assert response.status_code == 201
         # Validate body params
         req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
-        assert req_body['type'] == 'testString'
-        assert req_body['control'] == v2_policy_base_control_model
+        assert req_body['control'] == control_model
+        assert req_body['type'] == 'access'
         assert req_body['description'] == 'testString'
-        assert req_body['subject'] == v2_policy_base_subject_model
-        assert req_body['resource'] == v2_policy_base_resource_model
+        assert req_body['subject'] == v2_policy_subject_model
+        assert req_body['resource'] == v2_policy_resource_model
         assert req_body['pattern'] == 'testString'
-        assert req_body['rule'] == v2_policy_base_rule_model
+        assert req_body['rule'] == v2_policy_rule_model
 
-    def test_v2_create_policy_required_params_with_retries(self):
-        # Enable retries and run test_v2_create_policy_required_params.
+    def test_create_v2_policy_required_params_with_retries(self):
+        # Enable retries and run test_create_v2_policy_required_params.
         _service.enable_retries()
-        self.test_v2_create_policy_required_params()
+        self.test_create_v2_policy_required_params()
 
-        # Disable retries and run test_v2_create_policy_required_params.
+        # Disable retries and run test_create_v2_policy_required_params.
         _service.disable_retries()
-        self.test_v2_create_policy_required_params()
+        self.test_create_v2_policy_required_params()
 
     @responses.activate
-    def test_v2_create_policy_value_error(self):
+    def test_create_v2_policy_value_error(self):
         """
-        test_v2_create_policy_value_error()
+        test_create_v2_policy_value_error()
         """
         # Set up mock
         url = preprocess_url('/v2/policies')
-        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}'
         responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Construct a dict representation of a PolicyRole model
         policy_role_model = {}
         policy_role_model['role_id'] = 'testString'
 
-        # Construct a dict representation of a V2PolicyBaseControlGrant model
-        v2_policy_base_control_grant_model = {}
-        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+        # Construct a dict representation of a V2PolicyGrant model
+        v2_policy_grant_model = {}
+        v2_policy_grant_model['roles'] = [policy_role_model]
 
-        # Construct a dict representation of a V2PolicyBaseControl model
-        v2_policy_base_control_model = {}
-        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+        # Construct a dict representation of a Control model
+        control_model = {}
+        control_model['grant'] = v2_policy_grant_model
 
-        # Construct a dict representation of a V2PolicyAttribute model
-        v2_policy_attribute_model = {}
-        v2_policy_attribute_model['key'] = 'testString'
-        v2_policy_attribute_model['operator'] = 'testString'
-        v2_policy_attribute_model['value'] = 'testString'
+        # Construct a dict representation of a V2PolicySubjectAttribute model
+        v2_policy_subject_attribute_model = {}
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
 
-        # Construct a dict representation of a V2PolicyBaseSubject model
-        v2_policy_base_subject_model = {}
-        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+        # Construct a dict representation of a V2PolicySubject model
+        v2_policy_subject_model = {}
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
 
-        # Construct a dict representation of a V2PolicyBaseResource model
-        v2_policy_base_resource_model = {}
-        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+        # Construct a dict representation of a V2PolicyResourceAttribute model
+        v2_policy_resource_attribute_model = {}
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
 
-        # Construct a dict representation of a V2PolicyBaseRuleV2PolicyAttribute model
-        v2_policy_base_rule_model = {}
-        v2_policy_base_rule_model['key'] = 'testString'
-        v2_policy_base_rule_model['operator'] = 'testString'
-        v2_policy_base_rule_model['value'] = 'testString'
+        # Construct a dict representation of a V2PolicyResourceTag model
+        v2_policy_resource_tag_model = {}
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        # Construct a dict representation of a V2PolicyResource model
+        v2_policy_resource_model = {}
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        # Construct a dict representation of a V2PolicyRuleRuleAttribute model
+        v2_policy_rule_model = {}
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
 
         # Set up parameter values
-        type = 'testString'
-        control = v2_policy_base_control_model
+        control = control_model
+        type = 'access'
         description = 'testString'
-        subject = v2_policy_base_subject_model
-        resource = v2_policy_base_resource_model
+        subject = v2_policy_subject_model
+        resource = v2_policy_resource_model
         pattern = 'testString'
-        rule = v2_policy_base_rule_model
+        rule = v2_policy_rule_model
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
-            "type": type,
             "control": control,
+            "type": type,
         }
         for param in req_param_dict.keys():
             req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
-                _service.v2_create_policy(**req_copy)
+                _service.create_v2_policy(**req_copy)
 
-    def test_v2_create_policy_value_error_with_retries(self):
-        # Enable retries and run test_v2_create_policy_value_error.
+    def test_create_v2_policy_value_error_with_retries(self):
+        # Enable retries and run test_create_v2_policy_value_error.
         _service.enable_retries()
-        self.test_v2_create_policy_value_error()
+        self.test_create_v2_policy_value_error()
 
-        # Disable retries and run test_v2_create_policy_value_error.
+        # Disable retries and run test_create_v2_policy_value_error.
         _service.disable_retries()
-        self.test_v2_create_policy_value_error()
+        self.test_create_v2_policy_value_error()
 
 
-class TestV2UpdatePolicy:
+class TestReplaceV2Policy:
     """
-    Test Class for v2_update_policy
+    Test Class for replace_v2_policy
     """
 
     @responses.activate
-    def test_v2_update_policy_all_params(self):
+    def test_replace_v2_policy_all_params(self):
         """
-        v2_update_policy()
+        replace_v2_policy()
         """
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
-        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}'
         responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
 
         # Construct a dict representation of a PolicyRole model
         policy_role_model = {}
         policy_role_model['role_id'] = 'testString'
 
-        # Construct a dict representation of a V2PolicyBaseControlGrant model
-        v2_policy_base_control_grant_model = {}
-        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+        # Construct a dict representation of a V2PolicyGrant model
+        v2_policy_grant_model = {}
+        v2_policy_grant_model['roles'] = [policy_role_model]
 
-        # Construct a dict representation of a V2PolicyBaseControl model
-        v2_policy_base_control_model = {}
-        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+        # Construct a dict representation of a Control model
+        control_model = {}
+        control_model['grant'] = v2_policy_grant_model
 
-        # Construct a dict representation of a V2PolicyAttribute model
-        v2_policy_attribute_model = {}
-        v2_policy_attribute_model['key'] = 'testString'
-        v2_policy_attribute_model['operator'] = 'testString'
-        v2_policy_attribute_model['value'] = 'testString'
+        # Construct a dict representation of a V2PolicySubjectAttribute model
+        v2_policy_subject_attribute_model = {}
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
 
-        # Construct a dict representation of a V2PolicyBaseSubject model
-        v2_policy_base_subject_model = {}
-        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+        # Construct a dict representation of a V2PolicySubject model
+        v2_policy_subject_model = {}
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
 
-        # Construct a dict representation of a V2PolicyBaseResource model
-        v2_policy_base_resource_model = {}
-        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+        # Construct a dict representation of a V2PolicyResourceAttribute model
+        v2_policy_resource_attribute_model = {}
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
 
-        # Construct a dict representation of a V2PolicyBaseRuleV2PolicyAttribute model
-        v2_policy_base_rule_model = {}
-        v2_policy_base_rule_model['key'] = 'testString'
-        v2_policy_base_rule_model['operator'] = 'testString'
-        v2_policy_base_rule_model['value'] = 'testString'
+        # Construct a dict representation of a V2PolicyResourceTag model
+        v2_policy_resource_tag_model = {}
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        # Construct a dict representation of a V2PolicyResource model
+        v2_policy_resource_model = {}
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        # Construct a dict representation of a V2PolicyRuleRuleAttribute model
+        v2_policy_rule_model = {}
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
 
         # Set up parameter values
-        policy_id = 'testString'
+        id = 'testString'
         if_match = 'testString'
-        type = 'testString'
-        control = v2_policy_base_control_model
+        control = control_model
+        type = 'access'
         description = 'testString'
-        subject = v2_policy_base_subject_model
-        resource = v2_policy_base_resource_model
+        subject = v2_policy_subject_model
+        resource = v2_policy_resource_model
         pattern = 'testString'
-        rule = v2_policy_base_rule_model
+        rule = v2_policy_rule_model
 
         # Invoke method
-        response = _service.v2_update_policy(
-            policy_id,
+        response = _service.replace_v2_policy(
+            id,
             if_match,
-            type,
             control,
+            type,
             description=description,
             subject=subject,
             resource=resource,
@@ -1773,226 +1825,239 @@ class TestV2UpdatePolicy:
         assert response.status_code == 200
         # Validate body params
         req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
-        assert req_body['type'] == 'testString'
-        assert req_body['control'] == v2_policy_base_control_model
+        assert req_body['control'] == control_model
+        assert req_body['type'] == 'access'
         assert req_body['description'] == 'testString'
-        assert req_body['subject'] == v2_policy_base_subject_model
-        assert req_body['resource'] == v2_policy_base_resource_model
+        assert req_body['subject'] == v2_policy_subject_model
+        assert req_body['resource'] == v2_policy_resource_model
         assert req_body['pattern'] == 'testString'
-        assert req_body['rule'] == v2_policy_base_rule_model
+        assert req_body['rule'] == v2_policy_rule_model
 
-    def test_v2_update_policy_all_params_with_retries(self):
-        # Enable retries and run test_v2_update_policy_all_params.
+    def test_replace_v2_policy_all_params_with_retries(self):
+        # Enable retries and run test_replace_v2_policy_all_params.
         _service.enable_retries()
-        self.test_v2_update_policy_all_params()
+        self.test_replace_v2_policy_all_params()
 
-        # Disable retries and run test_v2_update_policy_all_params.
+        # Disable retries and run test_replace_v2_policy_all_params.
         _service.disable_retries()
-        self.test_v2_update_policy_all_params()
+        self.test_replace_v2_policy_all_params()
 
     @responses.activate
-    def test_v2_update_policy_value_error(self):
+    def test_replace_v2_policy_value_error(self):
         """
-        test_v2_update_policy_value_error()
+        test_replace_v2_policy_value_error()
         """
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
-        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}'
         responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
 
         # Construct a dict representation of a PolicyRole model
         policy_role_model = {}
         policy_role_model['role_id'] = 'testString'
 
-        # Construct a dict representation of a V2PolicyBaseControlGrant model
-        v2_policy_base_control_grant_model = {}
-        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+        # Construct a dict representation of a V2PolicyGrant model
+        v2_policy_grant_model = {}
+        v2_policy_grant_model['roles'] = [policy_role_model]
 
-        # Construct a dict representation of a V2PolicyBaseControl model
-        v2_policy_base_control_model = {}
-        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+        # Construct a dict representation of a Control model
+        control_model = {}
+        control_model['grant'] = v2_policy_grant_model
 
-        # Construct a dict representation of a V2PolicyAttribute model
-        v2_policy_attribute_model = {}
-        v2_policy_attribute_model['key'] = 'testString'
-        v2_policy_attribute_model['operator'] = 'testString'
-        v2_policy_attribute_model['value'] = 'testString'
+        # Construct a dict representation of a V2PolicySubjectAttribute model
+        v2_policy_subject_attribute_model = {}
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
 
-        # Construct a dict representation of a V2PolicyBaseSubject model
-        v2_policy_base_subject_model = {}
-        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+        # Construct a dict representation of a V2PolicySubject model
+        v2_policy_subject_model = {}
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
 
-        # Construct a dict representation of a V2PolicyBaseResource model
-        v2_policy_base_resource_model = {}
-        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+        # Construct a dict representation of a V2PolicyResourceAttribute model
+        v2_policy_resource_attribute_model = {}
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
 
-        # Construct a dict representation of a V2PolicyBaseRuleV2PolicyAttribute model
-        v2_policy_base_rule_model = {}
-        v2_policy_base_rule_model['key'] = 'testString'
-        v2_policy_base_rule_model['operator'] = 'testString'
-        v2_policy_base_rule_model['value'] = 'testString'
+        # Construct a dict representation of a V2PolicyResourceTag model
+        v2_policy_resource_tag_model = {}
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        # Construct a dict representation of a V2PolicyResource model
+        v2_policy_resource_model = {}
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        # Construct a dict representation of a V2PolicyRuleRuleAttribute model
+        v2_policy_rule_model = {}
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
 
         # Set up parameter values
-        policy_id = 'testString'
+        id = 'testString'
         if_match = 'testString'
-        type = 'testString'
-        control = v2_policy_base_control_model
+        control = control_model
+        type = 'access'
         description = 'testString'
-        subject = v2_policy_base_subject_model
-        resource = v2_policy_base_resource_model
+        subject = v2_policy_subject_model
+        resource = v2_policy_resource_model
         pattern = 'testString'
-        rule = v2_policy_base_rule_model
+        rule = v2_policy_rule_model
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
-            "policy_id": policy_id,
+            "id": id,
             "if_match": if_match,
-            "type": type,
             "control": control,
+            "type": type,
         }
         for param in req_param_dict.keys():
             req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
-                _service.v2_update_policy(**req_copy)
+                _service.replace_v2_policy(**req_copy)
 
-    def test_v2_update_policy_value_error_with_retries(self):
-        # Enable retries and run test_v2_update_policy_value_error.
+    def test_replace_v2_policy_value_error_with_retries(self):
+        # Enable retries and run test_replace_v2_policy_value_error.
         _service.enable_retries()
-        self.test_v2_update_policy_value_error()
+        self.test_replace_v2_policy_value_error()
 
-        # Disable retries and run test_v2_update_policy_value_error.
+        # Disable retries and run test_replace_v2_policy_value_error.
         _service.disable_retries()
-        self.test_v2_update_policy_value_error()
+        self.test_replace_v2_policy_value_error()
 
 
-class TestV2GetPolicy:
+class TestGetV2Policy:
     """
-    Test Class for v2_get_policy
+    Test Class for get_v2_policy
     """
 
     @responses.activate
-    def test_v2_get_policy_all_params(self):
+    def test_get_v2_policy_all_params(self):
         """
-        v2_get_policy()
+        get_v2_policy()
         """
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
-        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}'
         responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
-        policy_id = 'testString'
+        id = 'testString'
 
         # Invoke method
-        response = _service.v2_get_policy(policy_id, headers={})
+        response = _service.get_v2_policy(id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
 
-    def test_v2_get_policy_all_params_with_retries(self):
-        # Enable retries and run test_v2_get_policy_all_params.
+    def test_get_v2_policy_all_params_with_retries(self):
+        # Enable retries and run test_get_v2_policy_all_params.
         _service.enable_retries()
-        self.test_v2_get_policy_all_params()
+        self.test_get_v2_policy_all_params()
 
-        # Disable retries and run test_v2_get_policy_all_params.
+        # Disable retries and run test_get_v2_policy_all_params.
         _service.disable_retries()
-        self.test_v2_get_policy_all_params()
+        self.test_get_v2_policy_all_params()
 
     @responses.activate
-    def test_v2_get_policy_value_error(self):
+    def test_get_v2_policy_value_error(self):
         """
-        test_v2_get_policy_value_error()
+        test_get_v2_policy_value_error()
         """
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
-        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}'
         responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
-        policy_id = 'testString'
+        id = 'testString'
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
-            "policy_id": policy_id,
+            "id": id,
         }
         for param in req_param_dict.keys():
             req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
-                _service.v2_get_policy(**req_copy)
+                _service.get_v2_policy(**req_copy)
 
-    def test_v2_get_policy_value_error_with_retries(self):
-        # Enable retries and run test_v2_get_policy_value_error.
+    def test_get_v2_policy_value_error_with_retries(self):
+        # Enable retries and run test_get_v2_policy_value_error.
         _service.enable_retries()
-        self.test_v2_get_policy_value_error()
+        self.test_get_v2_policy_value_error()
 
-        # Disable retries and run test_v2_get_policy_value_error.
+        # Disable retries and run test_get_v2_policy_value_error.
         _service.disable_retries()
-        self.test_v2_get_policy_value_error()
+        self.test_get_v2_policy_value_error()
 
 
-class TestV2DeletePolicy:
+class TestDeleteV2Policy:
     """
-    Test Class for v2_delete_policy
+    Test Class for delete_v2_policy
     """
 
     @responses.activate
-    def test_v2_delete_policy_all_params(self):
+    def test_delete_v2_policy_all_params(self):
         """
-        v2_delete_policy()
+        delete_v2_policy()
         """
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
         responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
-        policy_id = 'testString'
+        id = 'testString'
 
         # Invoke method
-        response = _service.v2_delete_policy(policy_id, headers={})
+        response = _service.delete_v2_policy(id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 204
 
-    def test_v2_delete_policy_all_params_with_retries(self):
-        # Enable retries and run test_v2_delete_policy_all_params.
+    def test_delete_v2_policy_all_params_with_retries(self):
+        # Enable retries and run test_delete_v2_policy_all_params.
         _service.enable_retries()
-        self.test_v2_delete_policy_all_params()
+        self.test_delete_v2_policy_all_params()
 
-        # Disable retries and run test_v2_delete_policy_all_params.
+        # Disable retries and run test_delete_v2_policy_all_params.
         _service.disable_retries()
-        self.test_v2_delete_policy_all_params()
+        self.test_delete_v2_policy_all_params()
 
     @responses.activate
-    def test_v2_delete_policy_value_error(self):
+    def test_delete_v2_policy_value_error(self):
         """
-        test_v2_delete_policy_value_error()
+        test_delete_v2_policy_value_error()
         """
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
         responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
-        policy_id = 'testString'
+        id = 'testString'
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
-            "policy_id": policy_id,
+            "id": id,
         }
         for param in req_param_dict.keys():
             req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
             with pytest.raises(ValueError):
-                _service.v2_delete_policy(**req_copy)
+                _service.delete_v2_policy(**req_copy)
 
-    def test_v2_delete_policy_value_error_with_retries(self):
-        # Enable retries and run test_v2_delete_policy_value_error.
+    def test_delete_v2_policy_value_error_with_retries(self):
+        # Enable retries and run test_delete_v2_policy_value_error.
         _service.enable_retries()
-        self.test_v2_delete_policy_value_error()
+        self.test_delete_v2_policy_value_error()
 
-        # Disable retries and run test_v2_delete_policy_value_error.
+        # Disable retries and run test_delete_v2_policy_value_error.
         _service.disable_retries()
-        self.test_v2_delete_policy_value_error()
+        self.test_delete_v2_policy_value_error()
 
 
 # endregion
@@ -2005,14 +2070,14 @@ class TestV2DeletePolicy:
 # Start of Model Tests
 ##############################################################################
 # region
-class TestModel_V2PolicyBaseControl:
+class TestModel_Control:
     """
-    Test Class for V2PolicyBaseControl
+    Test Class for Control
     """
 
-    def test_v2_policy_base_control_serialization(self):
+    def test_control_serialization(self):
         """
-        Test serialization/deserialization for V2PolicyBaseControl
+        Test serialization/deserialization for Control
         """
 
         # Construct dict forms of any model objects needed in order to build this model.
@@ -2020,138 +2085,576 @@ class TestModel_V2PolicyBaseControl:
         policy_role_model = {}  # PolicyRole
         policy_role_model['role_id'] = 'testString'
 
-        v2_policy_base_control_grant_model = {}  # V2PolicyBaseControlGrant
-        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+        v2_policy_grant_model = {}  # V2PolicyGrant
+        v2_policy_grant_model['roles'] = [policy_role_model]
 
-        # Construct a json representation of a V2PolicyBaseControl model
-        v2_policy_base_control_model_json = {}
-        v2_policy_base_control_model_json['grant'] = v2_policy_base_control_grant_model
+        # Construct a json representation of a Control model
+        control_model_json = {}
+        control_model_json['grant'] = v2_policy_grant_model
 
-        # Construct a model instance of V2PolicyBaseControl by calling from_dict on the json representation
-        v2_policy_base_control_model = V2PolicyBaseControl.from_dict(v2_policy_base_control_model_json)
-        assert v2_policy_base_control_model != False
+        # Construct a model instance of Control by calling from_dict on the json representation
+        control_model = Control.from_dict(control_model_json)
+        assert control_model != False
 
-        # Construct a model instance of V2PolicyBaseControl by calling from_dict on the json representation
-        v2_policy_base_control_model_dict = V2PolicyBaseControl.from_dict(v2_policy_base_control_model_json).__dict__
-        v2_policy_base_control_model2 = V2PolicyBaseControl(**v2_policy_base_control_model_dict)
+        # Construct a model instance of Control by calling from_dict on the json representation
+        control_model_dict = Control.from_dict(control_model_json).__dict__
+        control_model2 = Control(**control_model_dict)
 
         # Verify the model instances are equivalent
-        assert v2_policy_base_control_model == v2_policy_base_control_model2
+        assert control_model == control_model2
 
         # Convert model instance back to dict and verify no loss of data
-        v2_policy_base_control_model_json2 = v2_policy_base_control_model.to_dict()
-        assert v2_policy_base_control_model_json2 == v2_policy_base_control_model_json
+        control_model_json2 = control_model.to_dict()
+        assert control_model_json2 == control_model_json
 
 
-class TestModel_V2PolicyBaseControlGrant:
+class TestModel_GrantWithTranslatedRoles:
     """
-    Test Class for V2PolicyBaseControlGrant
+    Test Class for GrantWithTranslatedRoles
     """
 
-    def test_v2_policy_base_control_grant_serialization(self):
+    def test_grant_with_translated_roles_serialization(self):
         """
-        Test serialization/deserialization for V2PolicyBaseControlGrant
+        Test serialization/deserialization for GrantWithTranslatedRoles
         """
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        policy_role_model = {}  # PolicyRole
-        policy_role_model['role_id'] = 'testString'
+        role_action_model = {}  # RoleAction
+        role_action_model['id'] = 'testString'
+        role_action_model['display_name'] = 'testString'
+        role_action_model['description'] = 'testString'
 
-        # Construct a json representation of a V2PolicyBaseControlGrant model
-        v2_policy_base_control_grant_model_json = {}
-        v2_policy_base_control_grant_model_json['roles'] = [policy_role_model]
+        role_in_display_format_model = {}  # RoleInDisplayFormat
+        role_in_display_format_model['role_id'] = 'testString'
+        role_in_display_format_model['actions'] = [role_action_model]
 
-        # Construct a model instance of V2PolicyBaseControlGrant by calling from_dict on the json representation
-        v2_policy_base_control_grant_model = V2PolicyBaseControlGrant.from_dict(v2_policy_base_control_grant_model_json)
-        assert v2_policy_base_control_grant_model != False
+        # Construct a json representation of a GrantWithTranslatedRoles model
+        grant_with_translated_roles_model_json = {}
+        grant_with_translated_roles_model_json['roles'] = [role_in_display_format_model]
 
-        # Construct a model instance of V2PolicyBaseControlGrant by calling from_dict on the json representation
-        v2_policy_base_control_grant_model_dict = V2PolicyBaseControlGrant.from_dict(
-            v2_policy_base_control_grant_model_json
+        # Construct a model instance of GrantWithTranslatedRoles by calling from_dict on the json representation
+        grant_with_translated_roles_model = GrantWithTranslatedRoles.from_dict(grant_with_translated_roles_model_json)
+        assert grant_with_translated_roles_model != False
+
+        # Construct a model instance of GrantWithTranslatedRoles by calling from_dict on the json representation
+        grant_with_translated_roles_model_dict = GrantWithTranslatedRoles.from_dict(
+            grant_with_translated_roles_model_json
         ).__dict__
-        v2_policy_base_control_grant_model2 = V2PolicyBaseControlGrant(**v2_policy_base_control_grant_model_dict)
+        grant_with_translated_roles_model2 = GrantWithTranslatedRoles(**grant_with_translated_roles_model_dict)
 
         # Verify the model instances are equivalent
-        assert v2_policy_base_control_grant_model == v2_policy_base_control_grant_model2
+        assert grant_with_translated_roles_model == grant_with_translated_roles_model2
 
         # Convert model instance back to dict and verify no loss of data
-        v2_policy_base_control_grant_model_json2 = v2_policy_base_control_grant_model.to_dict()
-        assert v2_policy_base_control_grant_model_json2 == v2_policy_base_control_grant_model_json
+        grant_with_translated_roles_model_json2 = grant_with_translated_roles_model.to_dict()
+        assert grant_with_translated_roles_model_json2 == grant_with_translated_roles_model_json
 
 
-class TestModel_V2PolicyBaseResource:
+class TestModel_PolicyRole:
     """
-    Test Class for V2PolicyBaseResource
+    Test Class for PolicyRole
     """
 
-    def test_v2_policy_base_resource_serialization(self):
+    def test_policy_role_serialization(self):
         """
-        Test serialization/deserialization for V2PolicyBaseResource
+        Test serialization/deserialization for PolicyRole
+        """
+
+        # Construct a json representation of a PolicyRole model
+        policy_role_model_json = {}
+        policy_role_model_json['role_id'] = 'testString'
+
+        # Construct a model instance of PolicyRole by calling from_dict on the json representation
+        policy_role_model = PolicyRole.from_dict(policy_role_model_json)
+        assert policy_role_model != False
+
+        # Construct a model instance of PolicyRole by calling from_dict on the json representation
+        policy_role_model_dict = PolicyRole.from_dict(policy_role_model_json).__dict__
+        policy_role_model2 = PolicyRole(**policy_role_model_dict)
+
+        # Verify the model instances are equivalent
+        assert policy_role_model == policy_role_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_role_model_json2 = policy_role_model.to_dict()
+        assert policy_role_model_json2 == policy_role_model_json
+
+
+class TestModel_RoleAction:
+    """
+    Test Class for RoleAction
+    """
+
+    def test_role_action_serialization(self):
+        """
+        Test serialization/deserialization for RoleAction
+        """
+
+        # Construct a json representation of a RoleAction model
+        role_action_model_json = {}
+        role_action_model_json['id'] = 'testString'
+        role_action_model_json['display_name'] = 'testString'
+        role_action_model_json['description'] = 'testString'
+
+        # Construct a model instance of RoleAction by calling from_dict on the json representation
+        role_action_model = RoleAction.from_dict(role_action_model_json)
+        assert role_action_model != False
+
+        # Construct a model instance of RoleAction by calling from_dict on the json representation
+        role_action_model_dict = RoleAction.from_dict(role_action_model_json).__dict__
+        role_action_model2 = RoleAction(**role_action_model_dict)
+
+        # Verify the model instances are equivalent
+        assert role_action_model == role_action_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        role_action_model_json2 = role_action_model.to_dict()
+        assert role_action_model_json2 == role_action_model_json
+
+
+class TestModel_RoleInDisplayFormat:
+    """
+    Test Class for RoleInDisplayFormat
+    """
+
+    def test_role_in_display_format_serialization(self):
+        """
+        Test serialization/deserialization for RoleInDisplayFormat
         """
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        v2_policy_attribute_model = {}  # V2PolicyAttribute
-        v2_policy_attribute_model['key'] = 'testString'
-        v2_policy_attribute_model['operator'] = 'testString'
-        v2_policy_attribute_model['value'] = 'testString'
+        role_action_model = {}  # RoleAction
+        role_action_model['id'] = 'testString'
+        role_action_model['display_name'] = 'testString'
+        role_action_model['description'] = 'testString'
 
-        # Construct a json representation of a V2PolicyBaseResource model
-        v2_policy_base_resource_model_json = {}
-        v2_policy_base_resource_model_json['attributes'] = [v2_policy_attribute_model]
+        # Construct a json representation of a RoleInDisplayFormat model
+        role_in_display_format_model_json = {}
+        role_in_display_format_model_json['role_id'] = 'testString'
+        role_in_display_format_model_json['actions'] = [role_action_model]
 
-        # Construct a model instance of V2PolicyBaseResource by calling from_dict on the json representation
-        v2_policy_base_resource_model = V2PolicyBaseResource.from_dict(v2_policy_base_resource_model_json)
-        assert v2_policy_base_resource_model != False
+        # Construct a model instance of RoleInDisplayFormat by calling from_dict on the json representation
+        role_in_display_format_model = RoleInDisplayFormat.from_dict(role_in_display_format_model_json)
+        assert role_in_display_format_model != False
 
-        # Construct a model instance of V2PolicyBaseResource by calling from_dict on the json representation
-        v2_policy_base_resource_model_dict = V2PolicyBaseResource.from_dict(v2_policy_base_resource_model_json).__dict__
-        v2_policy_base_resource_model2 = V2PolicyBaseResource(**v2_policy_base_resource_model_dict)
+        # Construct a model instance of RoleInDisplayFormat by calling from_dict on the json representation
+        role_in_display_format_model_dict = RoleInDisplayFormat.from_dict(role_in_display_format_model_json).__dict__
+        role_in_display_format_model2 = RoleInDisplayFormat(**role_in_display_format_model_dict)
 
         # Verify the model instances are equivalent
-        assert v2_policy_base_resource_model == v2_policy_base_resource_model2
+        assert role_in_display_format_model == role_in_display_format_model2
 
         # Convert model instance back to dict and verify no loss of data
-        v2_policy_base_resource_model_json2 = v2_policy_base_resource_model.to_dict()
-        assert v2_policy_base_resource_model_json2 == v2_policy_base_resource_model_json
+        role_in_display_format_model_json2 = role_in_display_format_model.to_dict()
+        assert role_in_display_format_model_json2 == role_in_display_format_model_json
 
 
-class TestModel_V2PolicyBaseSubject:
+class TestModel_RuleAttribute:
     """
-    Test Class for V2PolicyBaseSubject
+    Test Class for RuleAttribute
     """
 
-    def test_v2_policy_base_subject_serialization(self):
+    def test_rule_attribute_serialization(self):
         """
-        Test serialization/deserialization for V2PolicyBaseSubject
+        Test serialization/deserialization for RuleAttribute
+        """
+
+        # Construct a json representation of a RuleAttribute model
+        rule_attribute_model_json = {}
+        rule_attribute_model_json['key'] = 'testString'
+        rule_attribute_model_json['operator'] = 'timeLessThan'
+        rule_attribute_model_json['value'] = 'testString'
+
+        # Construct a model instance of RuleAttribute by calling from_dict on the json representation
+        rule_attribute_model = RuleAttribute.from_dict(rule_attribute_model_json)
+        assert rule_attribute_model != False
+
+        # Construct a model instance of RuleAttribute by calling from_dict on the json representation
+        rule_attribute_model_dict = RuleAttribute.from_dict(rule_attribute_model_json).__dict__
+        rule_attribute_model2 = RuleAttribute(**rule_attribute_model_dict)
+
+        # Verify the model instances are equivalent
+        assert rule_attribute_model == rule_attribute_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        rule_attribute_model_json2 = rule_attribute_model.to_dict()
+        assert rule_attribute_model_json2 == rule_attribute_model_json
+
+
+class TestModel_V2Policy:
+    """
+    Test Class for V2Policy
+    """
+
+    def test_v2_policy_serialization(self):
+        """
+        Test serialization/deserialization for V2Policy
         """
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        v2_policy_attribute_model = {}  # V2PolicyAttribute
-        v2_policy_attribute_model['key'] = 'testString'
-        v2_policy_attribute_model['operator'] = 'testString'
-        v2_policy_attribute_model['value'] = 'testString'
+        v2_policy_subject_attribute_model = {}  # V2PolicySubjectAttribute
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
 
-        # Construct a json representation of a V2PolicyBaseSubject model
-        v2_policy_base_subject_model_json = {}
-        v2_policy_base_subject_model_json['attributes'] = [v2_policy_attribute_model]
+        v2_policy_subject_model = {}  # V2PolicySubject
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
 
-        # Construct a model instance of V2PolicyBaseSubject by calling from_dict on the json representation
-        v2_policy_base_subject_model = V2PolicyBaseSubject.from_dict(v2_policy_base_subject_model_json)
-        assert v2_policy_base_subject_model != False
+        v2_policy_resource_attribute_model = {}  # V2PolicyResourceAttribute
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
 
-        # Construct a model instance of V2PolicyBaseSubject by calling from_dict on the json representation
-        v2_policy_base_subject_model_dict = V2PolicyBaseSubject.from_dict(v2_policy_base_subject_model_json).__dict__
-        v2_policy_base_subject_model2 = V2PolicyBaseSubject(**v2_policy_base_subject_model_dict)
+        v2_policy_resource_tag_model = {}  # V2PolicyResourceTag
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        v2_policy_resource_model = {}  # V2PolicyResource
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        v2_policy_rule_model = {}  # V2PolicyRuleRuleAttribute
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
+
+        policy_role_model = {}  # PolicyRole
+        policy_role_model['role_id'] = 'testString'
+
+        v2_policy_grant_model = {}  # V2PolicyGrant
+        v2_policy_grant_model['roles'] = [policy_role_model]
+
+        control_response_model = {}  # ControlResponseControl
+        control_response_model['grant'] = v2_policy_grant_model
+
+        # Construct a json representation of a V2Policy model
+        v2_policy_model_json = {}
+        v2_policy_model_json['type'] = 'access'
+        v2_policy_model_json['description'] = 'testString'
+        v2_policy_model_json['subject'] = v2_policy_subject_model
+        v2_policy_model_json['resource'] = v2_policy_resource_model
+        v2_policy_model_json['pattern'] = 'testString'
+        v2_policy_model_json['rule'] = v2_policy_rule_model
+        v2_policy_model_json['control'] = control_response_model
+        v2_policy_model_json['state'] = 'active'
+        v2_policy_model_json['last_permit_at'] = 'testString'
+        v2_policy_model_json['last_permit_frequency'] = 38
+
+        # Construct a model instance of V2Policy by calling from_dict on the json representation
+        v2_policy_model = V2Policy.from_dict(v2_policy_model_json)
+        assert v2_policy_model != False
+
+        # Construct a model instance of V2Policy by calling from_dict on the json representation
+        v2_policy_model_dict = V2Policy.from_dict(v2_policy_model_json).__dict__
+        v2_policy_model2 = V2Policy(**v2_policy_model_dict)
 
         # Verify the model instances are equivalent
-        assert v2_policy_base_subject_model == v2_policy_base_subject_model2
+        assert v2_policy_model == v2_policy_model2
 
         # Convert model instance back to dict and verify no loss of data
-        v2_policy_base_subject_model_json2 = v2_policy_base_subject_model.to_dict()
-        assert v2_policy_base_subject_model_json2 == v2_policy_base_subject_model_json
+        v2_policy_model_json2 = v2_policy_model.to_dict()
+        assert v2_policy_model_json2 == v2_policy_model_json
+
+
+class TestModel_V2PolicyCollection:
+    """
+    Test Class for V2PolicyCollection
+    """
+
+    def test_v2_policy_collection_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyCollection
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_subject_attribute_model = {}  # V2PolicySubjectAttribute
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
+
+        v2_policy_subject_model = {}  # V2PolicySubject
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
+
+        v2_policy_resource_attribute_model = {}  # V2PolicyResourceAttribute
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
+
+        v2_policy_resource_tag_model = {}  # V2PolicyResourceTag
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        v2_policy_resource_model = {}  # V2PolicyResource
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        v2_policy_rule_model = {}  # V2PolicyRuleRuleAttribute
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
+
+        policy_role_model = {}  # PolicyRole
+        policy_role_model['role_id'] = 'testString'
+
+        v2_policy_grant_model = {}  # V2PolicyGrant
+        v2_policy_grant_model['roles'] = [policy_role_model]
+
+        control_response_model = {}  # ControlResponseControl
+        control_response_model['grant'] = v2_policy_grant_model
+
+        v2_policy_model = {}  # V2Policy
+        v2_policy_model['type'] = 'access'
+        v2_policy_model['description'] = 'testString'
+        v2_policy_model['subject'] = v2_policy_subject_model
+        v2_policy_model['resource'] = v2_policy_resource_model
+        v2_policy_model['pattern'] = 'testString'
+        v2_policy_model['rule'] = v2_policy_rule_model
+        v2_policy_model['control'] = control_response_model
+        v2_policy_model['state'] = 'active'
+        v2_policy_model['last_permit_at'] = 'testString'
+        v2_policy_model['last_permit_frequency'] = 38
+
+        # Construct a json representation of a V2PolicyCollection model
+        v2_policy_collection_model_json = {}
+        v2_policy_collection_model_json['policies'] = [v2_policy_model]
+
+        # Construct a model instance of V2PolicyCollection by calling from_dict on the json representation
+        v2_policy_collection_model = V2PolicyCollection.from_dict(v2_policy_collection_model_json)
+        assert v2_policy_collection_model != False
+
+        # Construct a model instance of V2PolicyCollection by calling from_dict on the json representation
+        v2_policy_collection_model_dict = V2PolicyCollection.from_dict(v2_policy_collection_model_json).__dict__
+        v2_policy_collection_model2 = V2PolicyCollection(**v2_policy_collection_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_collection_model == v2_policy_collection_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_collection_model_json2 = v2_policy_collection_model.to_dict()
+        assert v2_policy_collection_model_json2 == v2_policy_collection_model_json
+
+
+class TestModel_V2PolicyGrant:
+    """
+    Test Class for V2PolicyGrant
+    """
+
+    def test_v2_policy_grant_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyGrant
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        policy_role_model = {}  # PolicyRole
+        policy_role_model['role_id'] = 'testString'
+
+        # Construct a json representation of a V2PolicyGrant model
+        v2_policy_grant_model_json = {}
+        v2_policy_grant_model_json['roles'] = [policy_role_model]
+
+        # Construct a model instance of V2PolicyGrant by calling from_dict on the json representation
+        v2_policy_grant_model = V2PolicyGrant.from_dict(v2_policy_grant_model_json)
+        assert v2_policy_grant_model != False
+
+        # Construct a model instance of V2PolicyGrant by calling from_dict on the json representation
+        v2_policy_grant_model_dict = V2PolicyGrant.from_dict(v2_policy_grant_model_json).__dict__
+        v2_policy_grant_model2 = V2PolicyGrant(**v2_policy_grant_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_grant_model == v2_policy_grant_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_grant_model_json2 = v2_policy_grant_model.to_dict()
+        assert v2_policy_grant_model_json2 == v2_policy_grant_model_json
+
+
+class TestModel_V2PolicyResource:
+    """
+    Test Class for V2PolicyResource
+    """
+
+    def test_v2_policy_resource_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyResource
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_resource_attribute_model = {}  # V2PolicyResourceAttribute
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
+
+        v2_policy_resource_tag_model = {}  # V2PolicyResourceTag
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        # Construct a json representation of a V2PolicyResource model
+        v2_policy_resource_model_json = {}
+        v2_policy_resource_model_json['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model_json['tags'] = [v2_policy_resource_tag_model]
+
+        # Construct a model instance of V2PolicyResource by calling from_dict on the json representation
+        v2_policy_resource_model = V2PolicyResource.from_dict(v2_policy_resource_model_json)
+        assert v2_policy_resource_model != False
+
+        # Construct a model instance of V2PolicyResource by calling from_dict on the json representation
+        v2_policy_resource_model_dict = V2PolicyResource.from_dict(v2_policy_resource_model_json).__dict__
+        v2_policy_resource_model2 = V2PolicyResource(**v2_policy_resource_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_resource_model == v2_policy_resource_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_resource_model_json2 = v2_policy_resource_model.to_dict()
+        assert v2_policy_resource_model_json2 == v2_policy_resource_model_json
+
+
+class TestModel_V2PolicyResourceAttribute:
+    """
+    Test Class for V2PolicyResourceAttribute
+    """
+
+    def test_v2_policy_resource_attribute_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyResourceAttribute
+        """
+
+        # Construct a json representation of a V2PolicyResourceAttribute model
+        v2_policy_resource_attribute_model_json = {}
+        v2_policy_resource_attribute_model_json['key'] = 'testString'
+        v2_policy_resource_attribute_model_json['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model_json['value'] = 'testString'
+
+        # Construct a model instance of V2PolicyResourceAttribute by calling from_dict on the json representation
+        v2_policy_resource_attribute_model = V2PolicyResourceAttribute.from_dict(
+            v2_policy_resource_attribute_model_json
+        )
+        assert v2_policy_resource_attribute_model != False
+
+        # Construct a model instance of V2PolicyResourceAttribute by calling from_dict on the json representation
+        v2_policy_resource_attribute_model_dict = V2PolicyResourceAttribute.from_dict(
+            v2_policy_resource_attribute_model_json
+        ).__dict__
+        v2_policy_resource_attribute_model2 = V2PolicyResourceAttribute(**v2_policy_resource_attribute_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_resource_attribute_model == v2_policy_resource_attribute_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_resource_attribute_model_json2 = v2_policy_resource_attribute_model.to_dict()
+        assert v2_policy_resource_attribute_model_json2 == v2_policy_resource_attribute_model_json
+
+
+class TestModel_V2PolicyResourceTag:
+    """
+    Test Class for V2PolicyResourceTag
+    """
+
+    def test_v2_policy_resource_tag_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyResourceTag
+        """
+
+        # Construct a json representation of a V2PolicyResourceTag model
+        v2_policy_resource_tag_model_json = {}
+        v2_policy_resource_tag_model_json['key'] = 'testString'
+        v2_policy_resource_tag_model_json['value'] = 'testString'
+        v2_policy_resource_tag_model_json['operator'] = 'stringEquals'
+
+        # Construct a model instance of V2PolicyResourceTag by calling from_dict on the json representation
+        v2_policy_resource_tag_model = V2PolicyResourceTag.from_dict(v2_policy_resource_tag_model_json)
+        assert v2_policy_resource_tag_model != False
+
+        # Construct a model instance of V2PolicyResourceTag by calling from_dict on the json representation
+        v2_policy_resource_tag_model_dict = V2PolicyResourceTag.from_dict(v2_policy_resource_tag_model_json).__dict__
+        v2_policy_resource_tag_model2 = V2PolicyResourceTag(**v2_policy_resource_tag_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_resource_tag_model == v2_policy_resource_tag_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_resource_tag_model_json2 = v2_policy_resource_tag_model.to_dict()
+        assert v2_policy_resource_tag_model_json2 == v2_policy_resource_tag_model_json
+
+
+class TestModel_V2PolicySubject:
+    """
+    Test Class for V2PolicySubject
+    """
+
+    def test_v2_policy_subject_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicySubject
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_subject_attribute_model = {}  # V2PolicySubjectAttribute
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
+
+        # Construct a json representation of a V2PolicySubject model
+        v2_policy_subject_model_json = {}
+        v2_policy_subject_model_json['attributes'] = [v2_policy_subject_attribute_model]
+
+        # Construct a model instance of V2PolicySubject by calling from_dict on the json representation
+        v2_policy_subject_model = V2PolicySubject.from_dict(v2_policy_subject_model_json)
+        assert v2_policy_subject_model != False
+
+        # Construct a model instance of V2PolicySubject by calling from_dict on the json representation
+        v2_policy_subject_model_dict = V2PolicySubject.from_dict(v2_policy_subject_model_json).__dict__
+        v2_policy_subject_model2 = V2PolicySubject(**v2_policy_subject_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_subject_model == v2_policy_subject_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_subject_model_json2 = v2_policy_subject_model.to_dict()
+        assert v2_policy_subject_model_json2 == v2_policy_subject_model_json
+
+
+class TestModel_V2PolicySubjectAttribute:
+    """
+    Test Class for V2PolicySubjectAttribute
+    """
+
+    def test_v2_policy_subject_attribute_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicySubjectAttribute
+        """
+
+        # Construct a json representation of a V2PolicySubjectAttribute model
+        v2_policy_subject_attribute_model_json = {}
+        v2_policy_subject_attribute_model_json['key'] = 'testString'
+        v2_policy_subject_attribute_model_json['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model_json['value'] = 'testString'
+
+        # Construct a model instance of V2PolicySubjectAttribute by calling from_dict on the json representation
+        v2_policy_subject_attribute_model = V2PolicySubjectAttribute.from_dict(v2_policy_subject_attribute_model_json)
+        assert v2_policy_subject_attribute_model != False
+
+        # Construct a model instance of V2PolicySubjectAttribute by calling from_dict on the json representation
+        v2_policy_subject_attribute_model_dict = V2PolicySubjectAttribute.from_dict(
+            v2_policy_subject_attribute_model_json
+        ).__dict__
+        v2_policy_subject_attribute_model2 = V2PolicySubjectAttribute(**v2_policy_subject_attribute_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_subject_attribute_model == v2_policy_subject_attribute_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_subject_attribute_model_json2 = v2_policy_subject_attribute_model.to_dict()
+        assert v2_policy_subject_attribute_model_json2 == v2_policy_subject_attribute_model_json
 
 
 class TestModel_CustomRole:
@@ -2355,36 +2858,6 @@ class TestModel_PolicyResource:
         # Convert model instance back to dict and verify no loss of data
         policy_resource_model_json2 = policy_resource_model.to_dict()
         assert policy_resource_model_json2 == policy_resource_model_json
-
-
-class TestModel_PolicyRole:
-    """
-    Test Class for PolicyRole
-    """
-
-    def test_policy_role_serialization(self):
-        """
-        Test serialization/deserialization for PolicyRole
-        """
-
-        # Construct a json representation of a PolicyRole model
-        policy_role_model_json = {}
-        policy_role_model_json['role_id'] = 'testString'
-
-        # Construct a model instance of PolicyRole by calling from_dict on the json representation
-        policy_role_model = PolicyRole.from_dict(policy_role_model_json)
-        assert policy_role_model != False
-
-        # Construct a model instance of PolicyRole by calling from_dict on the json representation
-        policy_role_model_dict = PolicyRole.from_dict(policy_role_model_json).__dict__
-        policy_role_model2 = PolicyRole(**policy_role_model_dict)
-
-        # Verify the model instances are equivalent
-        assert policy_role_model == policy_role_model2
-
-        # Convert model instance back to dict and verify no loss of data
-        policy_role_model_json2 = policy_role_model.to_dict()
-        assert policy_role_model_json2 == policy_role_model_json
 
 
 class TestModel_PolicySubject:
@@ -2597,254 +3070,182 @@ class TestModel_SubjectAttribute:
         assert subject_attribute_model_json2 == subject_attribute_model_json
 
 
-class TestModel_V2Policy:
+class TestModel_ControlResponseControl:
     """
-    Test Class for V2Policy
+    Test Class for ControlResponseControl
     """
 
-    def test_v2_policy_serialization(self):
+    def test_control_response_control_serialization(self):
         """
-        Test serialization/deserialization for V2Policy
+        Test serialization/deserialization for ControlResponseControl
         """
 
         # Construct dict forms of any model objects needed in order to build this model.
-
-        v2_policy_attribute_model = {}  # V2PolicyAttribute
-        v2_policy_attribute_model['key'] = 'testString'
-        v2_policy_attribute_model['operator'] = 'testString'
-        v2_policy_attribute_model['value'] = 'testString'
-
-        v2_policy_base_subject_model = {}  # V2PolicyBaseSubject
-        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
 
         policy_role_model = {}  # PolicyRole
         policy_role_model['role_id'] = 'testString'
 
-        v2_policy_base_control_grant_model = {}  # V2PolicyBaseControlGrant
-        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+        v2_policy_grant_model = {}  # V2PolicyGrant
+        v2_policy_grant_model['roles'] = [policy_role_model]
 
-        v2_policy_base_control_model = {}  # V2PolicyBaseControl
-        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+        # Construct a json representation of a ControlResponseControl model
+        control_response_control_model_json = {}
+        control_response_control_model_json['grant'] = v2_policy_grant_model
 
-        v2_policy_base_resource_model = {}  # V2PolicyBaseResource
-        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+        # Construct a model instance of ControlResponseControl by calling from_dict on the json representation
+        control_response_control_model = ControlResponseControl.from_dict(control_response_control_model_json)
+        assert control_response_control_model != False
 
-        v2_policy_base_rule_model = {}  # V2PolicyBaseRuleV2PolicyAttribute
-        v2_policy_base_rule_model['key'] = 'testString'
-        v2_policy_base_rule_model['operator'] = 'testString'
-        v2_policy_base_rule_model['value'] = 'testString'
-
-        # Construct a json representation of a V2Policy model
-        v2_policy_model_json = {}
-        v2_policy_model_json['type'] = 'testString'
-        v2_policy_model_json['description'] = 'testString'
-        v2_policy_model_json['subject'] = v2_policy_base_subject_model
-        v2_policy_model_json['control'] = v2_policy_base_control_model
-        v2_policy_model_json['resource'] = v2_policy_base_resource_model
-        v2_policy_model_json['pattern'] = 'testString'
-        v2_policy_model_json['rule'] = v2_policy_base_rule_model
-        v2_policy_model_json['state'] = 'active'
-
-        # Construct a model instance of V2Policy by calling from_dict on the json representation
-        v2_policy_model = V2Policy.from_dict(v2_policy_model_json)
-        assert v2_policy_model != False
-
-        # Construct a model instance of V2Policy by calling from_dict on the json representation
-        v2_policy_model_dict = V2Policy.from_dict(v2_policy_model_json).__dict__
-        v2_policy_model2 = V2Policy(**v2_policy_model_dict)
+        # Construct a model instance of ControlResponseControl by calling from_dict on the json representation
+        control_response_control_model_dict = ControlResponseControl.from_dict(
+            control_response_control_model_json
+        ).__dict__
+        control_response_control_model2 = ControlResponseControl(**control_response_control_model_dict)
 
         # Verify the model instances are equivalent
-        assert v2_policy_model == v2_policy_model2
+        assert control_response_control_model == control_response_control_model2
 
         # Convert model instance back to dict and verify no loss of data
-        v2_policy_model_json2 = v2_policy_model.to_dict()
-        assert v2_policy_model_json2 == v2_policy_model_json
+        control_response_control_model_json2 = control_response_control_model.to_dict()
+        assert control_response_control_model_json2 == control_response_control_model_json
 
 
-class TestModel_V2PolicyAttribute:
+class TestModel_ControlResponseControlWithTranslatedRoles:
     """
-    Test Class for V2PolicyAttribute
+    Test Class for ControlResponseControlWithTranslatedRoles
     """
 
-    def test_v2_policy_attribute_serialization(self):
+    def test_control_response_control_with_translated_roles_serialization(self):
         """
-        Test serialization/deserialization for V2PolicyAttribute
-        """
-
-        # Construct a json representation of a V2PolicyAttribute model
-        v2_policy_attribute_model_json = {}
-        v2_policy_attribute_model_json['key'] = 'testString'
-        v2_policy_attribute_model_json['operator'] = 'testString'
-        v2_policy_attribute_model_json['value'] = 'testString'
-
-        # Construct a model instance of V2PolicyAttribute by calling from_dict on the json representation
-        v2_policy_attribute_model = V2PolicyAttribute.from_dict(v2_policy_attribute_model_json)
-        assert v2_policy_attribute_model != False
-
-        # Construct a model instance of V2PolicyAttribute by calling from_dict on the json representation
-        v2_policy_attribute_model_dict = V2PolicyAttribute.from_dict(v2_policy_attribute_model_json).__dict__
-        v2_policy_attribute_model2 = V2PolicyAttribute(**v2_policy_attribute_model_dict)
-
-        # Verify the model instances are equivalent
-        assert v2_policy_attribute_model == v2_policy_attribute_model2
-
-        # Convert model instance back to dict and verify no loss of data
-        v2_policy_attribute_model_json2 = v2_policy_attribute_model.to_dict()
-        assert v2_policy_attribute_model_json2 == v2_policy_attribute_model_json
-
-
-class TestModel_V2PolicyList:
-    """
-    Test Class for V2PolicyList
-    """
-
-    def test_v2_policy_list_serialization(self):
-        """
-        Test serialization/deserialization for V2PolicyList
+        Test serialization/deserialization for ControlResponseControlWithTranslatedRoles
         """
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        v2_policy_attribute_model = {}  # V2PolicyAttribute
-        v2_policy_attribute_model['key'] = 'testString'
-        v2_policy_attribute_model['operator'] = 'testString'
-        v2_policy_attribute_model['value'] = 'testString'
+        role_action_model = {}  # RoleAction
+        role_action_model['id'] = 'testString'
+        role_action_model['display_name'] = 'testString'
+        role_action_model['description'] = 'testString'
 
-        v2_policy_base_subject_model = {}  # V2PolicyBaseSubject
-        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+        role_in_display_format_model = {}  # RoleInDisplayFormat
+        role_in_display_format_model['role_id'] = 'testString'
+        role_in_display_format_model['actions'] = [role_action_model]
 
-        policy_role_model = {}  # PolicyRole
-        policy_role_model['role_id'] = 'testString'
+        grant_with_translated_roles_model = {}  # GrantWithTranslatedRoles
+        grant_with_translated_roles_model['roles'] = [role_in_display_format_model]
 
-        v2_policy_base_control_grant_model = {}  # V2PolicyBaseControlGrant
-        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+        # Construct a json representation of a ControlResponseControlWithTranslatedRoles model
+        control_response_control_with_translated_roles_model_json = {}
+        control_response_control_with_translated_roles_model_json['grant'] = grant_with_translated_roles_model
 
-        v2_policy_base_control_model = {}  # V2PolicyBaseControl
-        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
-
-        v2_policy_base_resource_model = {}  # V2PolicyBaseResource
-        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
-
-        v2_policy_base_rule_model = {}  # V2PolicyBaseRuleV2PolicyAttribute
-        v2_policy_base_rule_model['key'] = 'testString'
-        v2_policy_base_rule_model['operator'] = 'testString'
-        v2_policy_base_rule_model['value'] = 'testString'
-
-        v2_policy_model = {}  # V2Policy
-        v2_policy_model['type'] = 'testString'
-        v2_policy_model['description'] = 'testString'
-        v2_policy_model['subject'] = v2_policy_base_subject_model
-        v2_policy_model['control'] = v2_policy_base_control_model
-        v2_policy_model['resource'] = v2_policy_base_resource_model
-        v2_policy_model['pattern'] = 'testString'
-        v2_policy_model['rule'] = v2_policy_base_rule_model
-        v2_policy_model['state'] = 'active'
-
-        # Construct a json representation of a V2PolicyList model
-        v2_policy_list_model_json = {}
-        v2_policy_list_model_json['policies'] = [v2_policy_model]
-
-        # Construct a model instance of V2PolicyList by calling from_dict on the json representation
-        v2_policy_list_model = V2PolicyList.from_dict(v2_policy_list_model_json)
-        assert v2_policy_list_model != False
-
-        # Construct a model instance of V2PolicyList by calling from_dict on the json representation
-        v2_policy_list_model_dict = V2PolicyList.from_dict(v2_policy_list_model_json).__dict__
-        v2_policy_list_model2 = V2PolicyList(**v2_policy_list_model_dict)
-
-        # Verify the model instances are equivalent
-        assert v2_policy_list_model == v2_policy_list_model2
-
-        # Convert model instance back to dict and verify no loss of data
-        v2_policy_list_model_json2 = v2_policy_list_model.to_dict()
-        assert v2_policy_list_model_json2 == v2_policy_list_model_json
-
-
-class TestModel_V2PolicyBaseRuleV2PolicyAttribute:
-    """
-    Test Class for V2PolicyBaseRuleV2PolicyAttribute
-    """
-
-    def test_v2_policy_base_rule_v2_policy_attribute_serialization(self):
-        """
-        Test serialization/deserialization for V2PolicyBaseRuleV2PolicyAttribute
-        """
-
-        # Construct a json representation of a V2PolicyBaseRuleV2PolicyAttribute model
-        v2_policy_base_rule_v2_policy_attribute_model_json = {}
-        v2_policy_base_rule_v2_policy_attribute_model_json['key'] = 'testString'
-        v2_policy_base_rule_v2_policy_attribute_model_json['operator'] = 'testString'
-        v2_policy_base_rule_v2_policy_attribute_model_json['value'] = 'testString'
-
-        # Construct a model instance of V2PolicyBaseRuleV2PolicyAttribute by calling from_dict on the json representation
-        v2_policy_base_rule_v2_policy_attribute_model = V2PolicyBaseRuleV2PolicyAttribute.from_dict(
-            v2_policy_base_rule_v2_policy_attribute_model_json
+        # Construct a model instance of ControlResponseControlWithTranslatedRoles by calling from_dict on the json representation
+        control_response_control_with_translated_roles_model = ControlResponseControlWithTranslatedRoles.from_dict(
+            control_response_control_with_translated_roles_model_json
         )
-        assert v2_policy_base_rule_v2_policy_attribute_model != False
+        assert control_response_control_with_translated_roles_model != False
 
-        # Construct a model instance of V2PolicyBaseRuleV2PolicyAttribute by calling from_dict on the json representation
-        v2_policy_base_rule_v2_policy_attribute_model_dict = V2PolicyBaseRuleV2PolicyAttribute.from_dict(
-            v2_policy_base_rule_v2_policy_attribute_model_json
+        # Construct a model instance of ControlResponseControlWithTranslatedRoles by calling from_dict on the json representation
+        control_response_control_with_translated_roles_model_dict = ControlResponseControlWithTranslatedRoles.from_dict(
+            control_response_control_with_translated_roles_model_json
         ).__dict__
-        v2_policy_base_rule_v2_policy_attribute_model2 = V2PolicyBaseRuleV2PolicyAttribute(
-            **v2_policy_base_rule_v2_policy_attribute_model_dict
+        control_response_control_with_translated_roles_model2 = ControlResponseControlWithTranslatedRoles(
+            **control_response_control_with_translated_roles_model_dict
         )
 
         # Verify the model instances are equivalent
-        assert v2_policy_base_rule_v2_policy_attribute_model == v2_policy_base_rule_v2_policy_attribute_model2
-
-        # Convert model instance back to dict and verify no loss of data
-        v2_policy_base_rule_v2_policy_attribute_model_json2 = v2_policy_base_rule_v2_policy_attribute_model.to_dict()
-        assert v2_policy_base_rule_v2_policy_attribute_model_json2 == v2_policy_base_rule_v2_policy_attribute_model_json
-
-
-class TestModel_V2PolicyBaseRuleV2RuleWithConditions:
-    """
-    Test Class for V2PolicyBaseRuleV2RuleWithConditions
-    """
-
-    def test_v2_policy_base_rule_v2_rule_with_conditions_serialization(self):
-        """
-        Test serialization/deserialization for V2PolicyBaseRuleV2RuleWithConditions
-        """
-
-        # Construct dict forms of any model objects needed in order to build this model.
-
-        v2_policy_attribute_model = {}  # V2PolicyAttribute
-        v2_policy_attribute_model['key'] = 'testString'
-        v2_policy_attribute_model['operator'] = 'testString'
-        v2_policy_attribute_model['value'] = 'testString'
-
-        # Construct a json representation of a V2PolicyBaseRuleV2RuleWithConditions model
-        v2_policy_base_rule_v2_rule_with_conditions_model_json = {}
-        v2_policy_base_rule_v2_rule_with_conditions_model_json['operator'] = 'and'
-        v2_policy_base_rule_v2_rule_with_conditions_model_json['conditions'] = [v2_policy_attribute_model]
-
-        # Construct a model instance of V2PolicyBaseRuleV2RuleWithConditions by calling from_dict on the json representation
-        v2_policy_base_rule_v2_rule_with_conditions_model = V2PolicyBaseRuleV2RuleWithConditions.from_dict(
-            v2_policy_base_rule_v2_rule_with_conditions_model_json
-        )
-        assert v2_policy_base_rule_v2_rule_with_conditions_model != False
-
-        # Construct a model instance of V2PolicyBaseRuleV2RuleWithConditions by calling from_dict on the json representation
-        v2_policy_base_rule_v2_rule_with_conditions_model_dict = V2PolicyBaseRuleV2RuleWithConditions.from_dict(
-            v2_policy_base_rule_v2_rule_with_conditions_model_json
-        ).__dict__
-        v2_policy_base_rule_v2_rule_with_conditions_model2 = V2PolicyBaseRuleV2RuleWithConditions(
-            **v2_policy_base_rule_v2_rule_with_conditions_model_dict
+        assert (
+            control_response_control_with_translated_roles_model
+            == control_response_control_with_translated_roles_model2
         )
 
-        # Verify the model instances are equivalent
-        assert v2_policy_base_rule_v2_rule_with_conditions_model == v2_policy_base_rule_v2_rule_with_conditions_model2
-
         # Convert model instance back to dict and verify no loss of data
-        v2_policy_base_rule_v2_rule_with_conditions_model_json2 = (
-            v2_policy_base_rule_v2_rule_with_conditions_model.to_dict()
+        control_response_control_with_translated_roles_model_json2 = (
+            control_response_control_with_translated_roles_model.to_dict()
         )
         assert (
-            v2_policy_base_rule_v2_rule_with_conditions_model_json2
-            == v2_policy_base_rule_v2_rule_with_conditions_model_json
+            control_response_control_with_translated_roles_model_json2
+            == control_response_control_with_translated_roles_model_json
         )
+
+
+class TestModel_V2PolicyRuleRuleAttribute:
+    """
+    Test Class for V2PolicyRuleRuleAttribute
+    """
+
+    def test_v2_policy_rule_rule_attribute_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyRuleRuleAttribute
+        """
+
+        # Construct a json representation of a V2PolicyRuleRuleAttribute model
+        v2_policy_rule_rule_attribute_model_json = {}
+        v2_policy_rule_rule_attribute_model_json['key'] = 'testString'
+        v2_policy_rule_rule_attribute_model_json['operator'] = 'timeLessThan'
+        v2_policy_rule_rule_attribute_model_json['value'] = 'testString'
+
+        # Construct a model instance of V2PolicyRuleRuleAttribute by calling from_dict on the json representation
+        v2_policy_rule_rule_attribute_model = V2PolicyRuleRuleAttribute.from_dict(
+            v2_policy_rule_rule_attribute_model_json
+        )
+        assert v2_policy_rule_rule_attribute_model != False
+
+        # Construct a model instance of V2PolicyRuleRuleAttribute by calling from_dict on the json representation
+        v2_policy_rule_rule_attribute_model_dict = V2PolicyRuleRuleAttribute.from_dict(
+            v2_policy_rule_rule_attribute_model_json
+        ).__dict__
+        v2_policy_rule_rule_attribute_model2 = V2PolicyRuleRuleAttribute(**v2_policy_rule_rule_attribute_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_rule_rule_attribute_model == v2_policy_rule_rule_attribute_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_rule_rule_attribute_model_json2 = v2_policy_rule_rule_attribute_model.to_dict()
+        assert v2_policy_rule_rule_attribute_model_json2 == v2_policy_rule_rule_attribute_model_json
+
+
+class TestModel_V2PolicyRuleRuleWithConditions:
+    """
+    Test Class for V2PolicyRuleRuleWithConditions
+    """
+
+    def test_v2_policy_rule_rule_with_conditions_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyRuleRuleWithConditions
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        rule_attribute_model = {}  # RuleAttribute
+        rule_attribute_model['key'] = 'testString'
+        rule_attribute_model['operator'] = 'timeLessThan'
+        rule_attribute_model['value'] = 'testString'
+
+        # Construct a json representation of a V2PolicyRuleRuleWithConditions model
+        v2_policy_rule_rule_with_conditions_model_json = {}
+        v2_policy_rule_rule_with_conditions_model_json['operator'] = 'and'
+        v2_policy_rule_rule_with_conditions_model_json['conditions'] = [rule_attribute_model]
+
+        # Construct a model instance of V2PolicyRuleRuleWithConditions by calling from_dict on the json representation
+        v2_policy_rule_rule_with_conditions_model = V2PolicyRuleRuleWithConditions.from_dict(
+            v2_policy_rule_rule_with_conditions_model_json
+        )
+        assert v2_policy_rule_rule_with_conditions_model != False
+
+        # Construct a model instance of V2PolicyRuleRuleWithConditions by calling from_dict on the json representation
+        v2_policy_rule_rule_with_conditions_model_dict = V2PolicyRuleRuleWithConditions.from_dict(
+            v2_policy_rule_rule_with_conditions_model_json
+        ).__dict__
+        v2_policy_rule_rule_with_conditions_model2 = V2PolicyRuleRuleWithConditions(
+            **v2_policy_rule_rule_with_conditions_model_dict
+        )
+
+        # Verify the model instances are equivalent
+        assert v2_policy_rule_rule_with_conditions_model == v2_policy_rule_rule_with_conditions_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_rule_rule_with_conditions_model_json2 = v2_policy_rule_rule_with_conditions_model.to_dict()
+        assert v2_policy_rule_rule_with_conditions_model_json2 == v2_policy_rule_rule_with_conditions_model_json
 
 
 # endregion

--- a/test/unit/test_iam_policy_management_v1.py
+++ b/test/unit/test_iam_policy_management_v1.py
@@ -1282,11 +1282,878 @@ class TestDeleteRole:
 # End of Service: Roles
 ##############################################################################
 
+##############################################################################
+# Start of Service: V2Policies
+##############################################################################
+# region
+
+
+class TestNewInstance:
+    """
+    Test Class for new_instance
+    """
+
+    def test_new_instance(self):
+        """
+        new_instance()
+        """
+        os.environ['TEST_SERVICE_AUTH_TYPE'] = 'noAuth'
+
+        service = IamPolicyManagementV1.new_instance(
+            service_name='TEST_SERVICE',
+        )
+
+        assert service is not None
+        assert isinstance(service, IamPolicyManagementV1)
+
+    def test_new_instance_without_authenticator(self):
+        """
+        new_instance_without_authenticator()
+        """
+        with pytest.raises(ValueError, match='authenticator must be provided'):
+            service = IamPolicyManagementV1.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
+
+
+class TestV2ListPolicies:
+    """
+    Test Class for v2_list_policies
+    """
+
+    @responses.activate
+    def test_v2_list_policies_all_params(self):
+        """
+        v2_list_policies()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies')
+        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        account_id = 'testString'
+        accept_language = 'default'
+        iam_id = 'testString'
+        access_group_id = 'testString'
+        type = 'access'
+        service_type = 'service'
+        service_name = 'testString'
+        service_group_id = 'testString'
+        format = 'include_last_permit'
+        state = 'active'
+
+        # Invoke method
+        response = _service.v2_list_policies(
+            account_id,
+            accept_language=accept_language,
+            iam_id=iam_id,
+            access_group_id=access_group_id,
+            type=type,
+            service_type=service_type,
+            service_name=service_name,
+            service_group_id=service_group_id,
+            format=format,
+            state=state,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'account_id={}'.format(account_id) in query_string
+        assert 'iam_id={}'.format(iam_id) in query_string
+        assert 'access_group_id={}'.format(access_group_id) in query_string
+        assert 'type={}'.format(type) in query_string
+        assert 'service_type={}'.format(service_type) in query_string
+        assert 'service_name={}'.format(service_name) in query_string
+        assert 'service_group_id={}'.format(service_group_id) in query_string
+        assert 'format={}'.format(format) in query_string
+        assert 'state={}'.format(state) in query_string
+
+    def test_v2_list_policies_all_params_with_retries(self):
+        # Enable retries and run test_v2_list_policies_all_params.
+        _service.enable_retries()
+        self.test_v2_list_policies_all_params()
+
+        # Disable retries and run test_v2_list_policies_all_params.
+        _service.disable_retries()
+        self.test_v2_list_policies_all_params()
+
+    @responses.activate
+    def test_v2_list_policies_required_params(self):
+        """
+        test_v2_list_policies_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies')
+        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        account_id = 'testString'
+
+        # Invoke method
+        response = _service.v2_list_policies(account_id, headers={})
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'account_id={}'.format(account_id) in query_string
+
+    def test_v2_list_policies_required_params_with_retries(self):
+        # Enable retries and run test_v2_list_policies_required_params.
+        _service.enable_retries()
+        self.test_v2_list_policies_required_params()
+
+        # Disable retries and run test_v2_list_policies_required_params.
+        _service.disable_retries()
+        self.test_v2_list_policies_required_params()
+
+    @responses.activate
+    def test_v2_list_policies_value_error(self):
+        """
+        test_v2_list_policies_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies')
+        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        account_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "account_id": account_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.v2_list_policies(**req_copy)
+
+    def test_v2_list_policies_value_error_with_retries(self):
+        # Enable retries and run test_v2_list_policies_value_error.
+        _service.enable_retries()
+        self.test_v2_list_policies_value_error()
+
+        # Disable retries and run test_v2_list_policies_value_error.
+        _service.disable_retries()
+        self.test_v2_list_policies_value_error()
+
+
+class TestV2CreatePolicy:
+    """
+    Test Class for v2_create_policy
+    """
+
+    @responses.activate
+    def test_v2_create_policy_all_params(self):
+        """
+        v2_create_policy()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies')
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
+
+        # Construct a dict representation of a PolicyRole model
+        policy_role_model = {}
+        policy_role_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseControlGrant model
+        v2_policy_base_control_grant_model = {}
+        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+
+        # Construct a dict representation of a V2PolicyBaseControl model
+        v2_policy_base_control_model = {}
+        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+
+        # Construct a dict representation of a V2PolicyAttribute model
+        v2_policy_attribute_model = {}
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseSubject model
+        v2_policy_base_subject_model = {}
+        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseResource model
+        v2_policy_base_resource_model = {}
+        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseRuleV2PolicyAttribute model
+        v2_policy_base_rule_model = {}
+        v2_policy_base_rule_model['key'] = 'testString'
+        v2_policy_base_rule_model['operator'] = 'testString'
+        v2_policy_base_rule_model['value'] = 'testString'
+
+        # Set up parameter values
+        type = 'testString'
+        control = v2_policy_base_control_model
+        description = 'testString'
+        subject = v2_policy_base_subject_model
+        resource = v2_policy_base_resource_model
+        pattern = 'testString'
+        rule = v2_policy_base_rule_model
+        accept_language = 'default'
+
+        # Invoke method
+        response = _service.v2_create_policy(
+            type,
+            control,
+            description=description,
+            subject=subject,
+            resource=resource,
+            pattern=pattern,
+            rule=rule,
+            accept_language=accept_language,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['type'] == 'testString'
+        assert req_body['control'] == v2_policy_base_control_model
+        assert req_body['description'] == 'testString'
+        assert req_body['subject'] == v2_policy_base_subject_model
+        assert req_body['resource'] == v2_policy_base_resource_model
+        assert req_body['pattern'] == 'testString'
+        assert req_body['rule'] == v2_policy_base_rule_model
+
+    def test_v2_create_policy_all_params_with_retries(self):
+        # Enable retries and run test_v2_create_policy_all_params.
+        _service.enable_retries()
+        self.test_v2_create_policy_all_params()
+
+        # Disable retries and run test_v2_create_policy_all_params.
+        _service.disable_retries()
+        self.test_v2_create_policy_all_params()
+
+    @responses.activate
+    def test_v2_create_policy_required_params(self):
+        """
+        test_v2_create_policy_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies')
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
+
+        # Construct a dict representation of a PolicyRole model
+        policy_role_model = {}
+        policy_role_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseControlGrant model
+        v2_policy_base_control_grant_model = {}
+        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+
+        # Construct a dict representation of a V2PolicyBaseControl model
+        v2_policy_base_control_model = {}
+        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+
+        # Construct a dict representation of a V2PolicyAttribute model
+        v2_policy_attribute_model = {}
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseSubject model
+        v2_policy_base_subject_model = {}
+        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseResource model
+        v2_policy_base_resource_model = {}
+        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseRuleV2PolicyAttribute model
+        v2_policy_base_rule_model = {}
+        v2_policy_base_rule_model['key'] = 'testString'
+        v2_policy_base_rule_model['operator'] = 'testString'
+        v2_policy_base_rule_model['value'] = 'testString'
+
+        # Set up parameter values
+        type = 'testString'
+        control = v2_policy_base_control_model
+        description = 'testString'
+        subject = v2_policy_base_subject_model
+        resource = v2_policy_base_resource_model
+        pattern = 'testString'
+        rule = v2_policy_base_rule_model
+
+        # Invoke method
+        response = _service.v2_create_policy(
+            type,
+            control,
+            description=description,
+            subject=subject,
+            resource=resource,
+            pattern=pattern,
+            rule=rule,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['type'] == 'testString'
+        assert req_body['control'] == v2_policy_base_control_model
+        assert req_body['description'] == 'testString'
+        assert req_body['subject'] == v2_policy_base_subject_model
+        assert req_body['resource'] == v2_policy_base_resource_model
+        assert req_body['pattern'] == 'testString'
+        assert req_body['rule'] == v2_policy_base_rule_model
+
+    def test_v2_create_policy_required_params_with_retries(self):
+        # Enable retries and run test_v2_create_policy_required_params.
+        _service.enable_retries()
+        self.test_v2_create_policy_required_params()
+
+        # Disable retries and run test_v2_create_policy_required_params.
+        _service.disable_retries()
+        self.test_v2_create_policy_required_params()
+
+    @responses.activate
+    def test_v2_create_policy_value_error(self):
+        """
+        test_v2_create_policy_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies')
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
+
+        # Construct a dict representation of a PolicyRole model
+        policy_role_model = {}
+        policy_role_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseControlGrant model
+        v2_policy_base_control_grant_model = {}
+        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+
+        # Construct a dict representation of a V2PolicyBaseControl model
+        v2_policy_base_control_model = {}
+        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+
+        # Construct a dict representation of a V2PolicyAttribute model
+        v2_policy_attribute_model = {}
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseSubject model
+        v2_policy_base_subject_model = {}
+        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseResource model
+        v2_policy_base_resource_model = {}
+        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseRuleV2PolicyAttribute model
+        v2_policy_base_rule_model = {}
+        v2_policy_base_rule_model['key'] = 'testString'
+        v2_policy_base_rule_model['operator'] = 'testString'
+        v2_policy_base_rule_model['value'] = 'testString'
+
+        # Set up parameter values
+        type = 'testString'
+        control = v2_policy_base_control_model
+        description = 'testString'
+        subject = v2_policy_base_subject_model
+        resource = v2_policy_base_resource_model
+        pattern = 'testString'
+        rule = v2_policy_base_rule_model
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "type": type,
+            "control": control,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.v2_create_policy(**req_copy)
+
+    def test_v2_create_policy_value_error_with_retries(self):
+        # Enable retries and run test_v2_create_policy_value_error.
+        _service.enable_retries()
+        self.test_v2_create_policy_value_error()
+
+        # Disable retries and run test_v2_create_policy_value_error.
+        _service.disable_retries()
+        self.test_v2_create_policy_value_error()
+
+
+class TestV2UpdatePolicy:
+    """
+    Test Class for v2_update_policy
+    """
+
+    @responses.activate
+    def test_v2_update_policy_all_params(self):
+        """
+        v2_update_policy()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies/testString')
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
+
+        # Construct a dict representation of a PolicyRole model
+        policy_role_model = {}
+        policy_role_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseControlGrant model
+        v2_policy_base_control_grant_model = {}
+        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+
+        # Construct a dict representation of a V2PolicyBaseControl model
+        v2_policy_base_control_model = {}
+        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+
+        # Construct a dict representation of a V2PolicyAttribute model
+        v2_policy_attribute_model = {}
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseSubject model
+        v2_policy_base_subject_model = {}
+        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseResource model
+        v2_policy_base_resource_model = {}
+        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseRuleV2PolicyAttribute model
+        v2_policy_base_rule_model = {}
+        v2_policy_base_rule_model['key'] = 'testString'
+        v2_policy_base_rule_model['operator'] = 'testString'
+        v2_policy_base_rule_model['value'] = 'testString'
+
+        # Set up parameter values
+        policy_id = 'testString'
+        if_match = 'testString'
+        type = 'testString'
+        control = v2_policy_base_control_model
+        description = 'testString'
+        subject = v2_policy_base_subject_model
+        resource = v2_policy_base_resource_model
+        pattern = 'testString'
+        rule = v2_policy_base_rule_model
+
+        # Invoke method
+        response = _service.v2_update_policy(
+            policy_id,
+            if_match,
+            type,
+            control,
+            description=description,
+            subject=subject,
+            resource=resource,
+            pattern=pattern,
+            rule=rule,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['type'] == 'testString'
+        assert req_body['control'] == v2_policy_base_control_model
+        assert req_body['description'] == 'testString'
+        assert req_body['subject'] == v2_policy_base_subject_model
+        assert req_body['resource'] == v2_policy_base_resource_model
+        assert req_body['pattern'] == 'testString'
+        assert req_body['rule'] == v2_policy_base_rule_model
+
+    def test_v2_update_policy_all_params_with_retries(self):
+        # Enable retries and run test_v2_update_policy_all_params.
+        _service.enable_retries()
+        self.test_v2_update_policy_all_params()
+
+        # Disable retries and run test_v2_update_policy_all_params.
+        _service.disable_retries()
+        self.test_v2_update_policy_all_params()
+
+    @responses.activate
+    def test_v2_update_policy_value_error(self):
+        """
+        test_v2_update_policy_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies/testString')
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
+
+        # Construct a dict representation of a PolicyRole model
+        policy_role_model = {}
+        policy_role_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseControlGrant model
+        v2_policy_base_control_grant_model = {}
+        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+
+        # Construct a dict representation of a V2PolicyBaseControl model
+        v2_policy_base_control_model = {}
+        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+
+        # Construct a dict representation of a V2PolicyAttribute model
+        v2_policy_attribute_model = {}
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyBaseSubject model
+        v2_policy_base_subject_model = {}
+        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseResource model
+        v2_policy_base_resource_model = {}
+        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a dict representation of a V2PolicyBaseRuleV2PolicyAttribute model
+        v2_policy_base_rule_model = {}
+        v2_policy_base_rule_model['key'] = 'testString'
+        v2_policy_base_rule_model['operator'] = 'testString'
+        v2_policy_base_rule_model['value'] = 'testString'
+
+        # Set up parameter values
+        policy_id = 'testString'
+        if_match = 'testString'
+        type = 'testString'
+        control = v2_policy_base_control_model
+        description = 'testString'
+        subject = v2_policy_base_subject_model
+        resource = v2_policy_base_resource_model
+        pattern = 'testString'
+        rule = v2_policy_base_rule_model
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "policy_id": policy_id,
+            "if_match": if_match,
+            "type": type,
+            "control": control,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.v2_update_policy(**req_copy)
+
+    def test_v2_update_policy_value_error_with_retries(self):
+        # Enable retries and run test_v2_update_policy_value_error.
+        _service.enable_retries()
+        self.test_v2_update_policy_value_error()
+
+        # Disable retries and run test_v2_update_policy_value_error.
+        _service.disable_retries()
+        self.test_v2_update_policy_value_error()
+
+
+class TestV2GetPolicy:
+    """
+    Test Class for v2_get_policy
+    """
+
+    @responses.activate
+    def test_v2_get_policy_all_params(self):
+        """
+        v2_get_policy()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies/testString')
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        policy_id = 'testString'
+
+        # Invoke method
+        response = _service.v2_get_policy(policy_id, headers={})
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_v2_get_policy_all_params_with_retries(self):
+        # Enable retries and run test_v2_get_policy_all_params.
+        _service.enable_retries()
+        self.test_v2_get_policy_all_params()
+
+        # Disable retries and run test_v2_get_policy_all_params.
+        _service.disable_retries()
+        self.test_v2_get_policy_all_params()
+
+    @responses.activate
+    def test_v2_get_policy_value_error(self):
+        """
+        test_v2_get_policy_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies/testString')
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}]}}, "resource": {"attributes": [{"key": "key", "operator": "operator", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "operator", "value": "anyValue"}, "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        policy_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "policy_id": policy_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.v2_get_policy(**req_copy)
+
+    def test_v2_get_policy_value_error_with_retries(self):
+        # Enable retries and run test_v2_get_policy_value_error.
+        _service.enable_retries()
+        self.test_v2_get_policy_value_error()
+
+        # Disable retries and run test_v2_get_policy_value_error.
+        _service.disable_retries()
+        self.test_v2_get_policy_value_error()
+
+
+class TestV2DeletePolicy:
+    """
+    Test Class for v2_delete_policy
+    """
+
+    @responses.activate
+    def test_v2_delete_policy_all_params(self):
+        """
+        v2_delete_policy()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies/testString')
+        responses.add(responses.DELETE, url, status=204)
+
+        # Set up parameter values
+        policy_id = 'testString'
+
+        # Invoke method
+        response = _service.v2_delete_policy(policy_id, headers={})
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_v2_delete_policy_all_params_with_retries(self):
+        # Enable retries and run test_v2_delete_policy_all_params.
+        _service.enable_retries()
+        self.test_v2_delete_policy_all_params()
+
+        # Disable retries and run test_v2_delete_policy_all_params.
+        _service.disable_retries()
+        self.test_v2_delete_policy_all_params()
+
+    @responses.activate
+    def test_v2_delete_policy_value_error(self):
+        """
+        test_v2_delete_policy_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/policies/testString')
+        responses.add(responses.DELETE, url, status=204)
+
+        # Set up parameter values
+        policy_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "policy_id": policy_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.v2_delete_policy(**req_copy)
+
+    def test_v2_delete_policy_value_error_with_retries(self):
+        # Enable retries and run test_v2_delete_policy_value_error.
+        _service.enable_retries()
+        self.test_v2_delete_policy_value_error()
+
+        # Disable retries and run test_v2_delete_policy_value_error.
+        _service.disable_retries()
+        self.test_v2_delete_policy_value_error()
+
+
+# endregion
+##############################################################################
+# End of Service: V2Policies
+##############################################################################
+
 
 ##############################################################################
 # Start of Model Tests
 ##############################################################################
 # region
+class TestModel_V2PolicyBaseControl:
+    """
+    Test Class for V2PolicyBaseControl
+    """
+
+    def test_v2_policy_base_control_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyBaseControl
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        policy_role_model = {}  # PolicyRole
+        policy_role_model['role_id'] = 'testString'
+
+        v2_policy_base_control_grant_model = {}  # V2PolicyBaseControlGrant
+        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+
+        # Construct a json representation of a V2PolicyBaseControl model
+        v2_policy_base_control_model_json = {}
+        v2_policy_base_control_model_json['grant'] = v2_policy_base_control_grant_model
+
+        # Construct a model instance of V2PolicyBaseControl by calling from_dict on the json representation
+        v2_policy_base_control_model = V2PolicyBaseControl.from_dict(v2_policy_base_control_model_json)
+        assert v2_policy_base_control_model != False
+
+        # Construct a model instance of V2PolicyBaseControl by calling from_dict on the json representation
+        v2_policy_base_control_model_dict = V2PolicyBaseControl.from_dict(v2_policy_base_control_model_json).__dict__
+        v2_policy_base_control_model2 = V2PolicyBaseControl(**v2_policy_base_control_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_base_control_model == v2_policy_base_control_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_base_control_model_json2 = v2_policy_base_control_model.to_dict()
+        assert v2_policy_base_control_model_json2 == v2_policy_base_control_model_json
+
+
+class TestModel_V2PolicyBaseControlGrant:
+    """
+    Test Class for V2PolicyBaseControlGrant
+    """
+
+    def test_v2_policy_base_control_grant_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyBaseControlGrant
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        policy_role_model = {}  # PolicyRole
+        policy_role_model['role_id'] = 'testString'
+
+        # Construct a json representation of a V2PolicyBaseControlGrant model
+        v2_policy_base_control_grant_model_json = {}
+        v2_policy_base_control_grant_model_json['roles'] = [policy_role_model]
+
+        # Construct a model instance of V2PolicyBaseControlGrant by calling from_dict on the json representation
+        v2_policy_base_control_grant_model = V2PolicyBaseControlGrant.from_dict(v2_policy_base_control_grant_model_json)
+        assert v2_policy_base_control_grant_model != False
+
+        # Construct a model instance of V2PolicyBaseControlGrant by calling from_dict on the json representation
+        v2_policy_base_control_grant_model_dict = V2PolicyBaseControlGrant.from_dict(
+            v2_policy_base_control_grant_model_json
+        ).__dict__
+        v2_policy_base_control_grant_model2 = V2PolicyBaseControlGrant(**v2_policy_base_control_grant_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_base_control_grant_model == v2_policy_base_control_grant_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_base_control_grant_model_json2 = v2_policy_base_control_grant_model.to_dict()
+        assert v2_policy_base_control_grant_model_json2 == v2_policy_base_control_grant_model_json
+
+
+class TestModel_V2PolicyBaseResource:
+    """
+    Test Class for V2PolicyBaseResource
+    """
+
+    def test_v2_policy_base_resource_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyBaseResource
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_attribute_model = {}  # V2PolicyAttribute
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        # Construct a json representation of a V2PolicyBaseResource model
+        v2_policy_base_resource_model_json = {}
+        v2_policy_base_resource_model_json['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a model instance of V2PolicyBaseResource by calling from_dict on the json representation
+        v2_policy_base_resource_model = V2PolicyBaseResource.from_dict(v2_policy_base_resource_model_json)
+        assert v2_policy_base_resource_model != False
+
+        # Construct a model instance of V2PolicyBaseResource by calling from_dict on the json representation
+        v2_policy_base_resource_model_dict = V2PolicyBaseResource.from_dict(v2_policy_base_resource_model_json).__dict__
+        v2_policy_base_resource_model2 = V2PolicyBaseResource(**v2_policy_base_resource_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_base_resource_model == v2_policy_base_resource_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_base_resource_model_json2 = v2_policy_base_resource_model.to_dict()
+        assert v2_policy_base_resource_model_json2 == v2_policy_base_resource_model_json
+
+
+class TestModel_V2PolicyBaseSubject:
+    """
+    Test Class for V2PolicyBaseSubject
+    """
+
+    def test_v2_policy_base_subject_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyBaseSubject
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_attribute_model = {}  # V2PolicyAttribute
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        # Construct a json representation of a V2PolicyBaseSubject model
+        v2_policy_base_subject_model_json = {}
+        v2_policy_base_subject_model_json['attributes'] = [v2_policy_attribute_model]
+
+        # Construct a model instance of V2PolicyBaseSubject by calling from_dict on the json representation
+        v2_policy_base_subject_model = V2PolicyBaseSubject.from_dict(v2_policy_base_subject_model_json)
+        assert v2_policy_base_subject_model != False
+
+        # Construct a model instance of V2PolicyBaseSubject by calling from_dict on the json representation
+        v2_policy_base_subject_model_dict = V2PolicyBaseSubject.from_dict(v2_policy_base_subject_model_json).__dict__
+        v2_policy_base_subject_model2 = V2PolicyBaseSubject(**v2_policy_base_subject_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_base_subject_model == v2_policy_base_subject_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_base_subject_model_json2 = v2_policy_base_subject_model.to_dict()
+        assert v2_policy_base_subject_model_json2 == v2_policy_base_subject_model_json
+
+
 class TestModel_CustomRole:
     """
     Test Class for CustomRole
@@ -1728,6 +2595,256 @@ class TestModel_SubjectAttribute:
         # Convert model instance back to dict and verify no loss of data
         subject_attribute_model_json2 = subject_attribute_model.to_dict()
         assert subject_attribute_model_json2 == subject_attribute_model_json
+
+
+class TestModel_V2Policy:
+    """
+    Test Class for V2Policy
+    """
+
+    def test_v2_policy_serialization(self):
+        """
+        Test serialization/deserialization for V2Policy
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_attribute_model = {}  # V2PolicyAttribute
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        v2_policy_base_subject_model = {}  # V2PolicyBaseSubject
+        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+
+        policy_role_model = {}  # PolicyRole
+        policy_role_model['role_id'] = 'testString'
+
+        v2_policy_base_control_grant_model = {}  # V2PolicyBaseControlGrant
+        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+
+        v2_policy_base_control_model = {}  # V2PolicyBaseControl
+        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+
+        v2_policy_base_resource_model = {}  # V2PolicyBaseResource
+        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+
+        v2_policy_base_rule_model = {}  # V2PolicyBaseRuleV2PolicyAttribute
+        v2_policy_base_rule_model['key'] = 'testString'
+        v2_policy_base_rule_model['operator'] = 'testString'
+        v2_policy_base_rule_model['value'] = 'testString'
+
+        # Construct a json representation of a V2Policy model
+        v2_policy_model_json = {}
+        v2_policy_model_json['type'] = 'testString'
+        v2_policy_model_json['description'] = 'testString'
+        v2_policy_model_json['subject'] = v2_policy_base_subject_model
+        v2_policy_model_json['control'] = v2_policy_base_control_model
+        v2_policy_model_json['resource'] = v2_policy_base_resource_model
+        v2_policy_model_json['pattern'] = 'testString'
+        v2_policy_model_json['rule'] = v2_policy_base_rule_model
+        v2_policy_model_json['state'] = 'active'
+
+        # Construct a model instance of V2Policy by calling from_dict on the json representation
+        v2_policy_model = V2Policy.from_dict(v2_policy_model_json)
+        assert v2_policy_model != False
+
+        # Construct a model instance of V2Policy by calling from_dict on the json representation
+        v2_policy_model_dict = V2Policy.from_dict(v2_policy_model_json).__dict__
+        v2_policy_model2 = V2Policy(**v2_policy_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_model == v2_policy_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_model_json2 = v2_policy_model.to_dict()
+        assert v2_policy_model_json2 == v2_policy_model_json
+
+
+class TestModel_V2PolicyAttribute:
+    """
+    Test Class for V2PolicyAttribute
+    """
+
+    def test_v2_policy_attribute_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyAttribute
+        """
+
+        # Construct a json representation of a V2PolicyAttribute model
+        v2_policy_attribute_model_json = {}
+        v2_policy_attribute_model_json['key'] = 'testString'
+        v2_policy_attribute_model_json['operator'] = 'testString'
+        v2_policy_attribute_model_json['value'] = 'testString'
+
+        # Construct a model instance of V2PolicyAttribute by calling from_dict on the json representation
+        v2_policy_attribute_model = V2PolicyAttribute.from_dict(v2_policy_attribute_model_json)
+        assert v2_policy_attribute_model != False
+
+        # Construct a model instance of V2PolicyAttribute by calling from_dict on the json representation
+        v2_policy_attribute_model_dict = V2PolicyAttribute.from_dict(v2_policy_attribute_model_json).__dict__
+        v2_policy_attribute_model2 = V2PolicyAttribute(**v2_policy_attribute_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_attribute_model == v2_policy_attribute_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_attribute_model_json2 = v2_policy_attribute_model.to_dict()
+        assert v2_policy_attribute_model_json2 == v2_policy_attribute_model_json
+
+
+class TestModel_V2PolicyList:
+    """
+    Test Class for V2PolicyList
+    """
+
+    def test_v2_policy_list_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyList
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_attribute_model = {}  # V2PolicyAttribute
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        v2_policy_base_subject_model = {}  # V2PolicyBaseSubject
+        v2_policy_base_subject_model['attributes'] = [v2_policy_attribute_model]
+
+        policy_role_model = {}  # PolicyRole
+        policy_role_model['role_id'] = 'testString'
+
+        v2_policy_base_control_grant_model = {}  # V2PolicyBaseControlGrant
+        v2_policy_base_control_grant_model['roles'] = [policy_role_model]
+
+        v2_policy_base_control_model = {}  # V2PolicyBaseControl
+        v2_policy_base_control_model['grant'] = v2_policy_base_control_grant_model
+
+        v2_policy_base_resource_model = {}  # V2PolicyBaseResource
+        v2_policy_base_resource_model['attributes'] = [v2_policy_attribute_model]
+
+        v2_policy_base_rule_model = {}  # V2PolicyBaseRuleV2PolicyAttribute
+        v2_policy_base_rule_model['key'] = 'testString'
+        v2_policy_base_rule_model['operator'] = 'testString'
+        v2_policy_base_rule_model['value'] = 'testString'
+
+        v2_policy_model = {}  # V2Policy
+        v2_policy_model['type'] = 'testString'
+        v2_policy_model['description'] = 'testString'
+        v2_policy_model['subject'] = v2_policy_base_subject_model
+        v2_policy_model['control'] = v2_policy_base_control_model
+        v2_policy_model['resource'] = v2_policy_base_resource_model
+        v2_policy_model['pattern'] = 'testString'
+        v2_policy_model['rule'] = v2_policy_base_rule_model
+        v2_policy_model['state'] = 'active'
+
+        # Construct a json representation of a V2PolicyList model
+        v2_policy_list_model_json = {}
+        v2_policy_list_model_json['policies'] = [v2_policy_model]
+
+        # Construct a model instance of V2PolicyList by calling from_dict on the json representation
+        v2_policy_list_model = V2PolicyList.from_dict(v2_policy_list_model_json)
+        assert v2_policy_list_model != False
+
+        # Construct a model instance of V2PolicyList by calling from_dict on the json representation
+        v2_policy_list_model_dict = V2PolicyList.from_dict(v2_policy_list_model_json).__dict__
+        v2_policy_list_model2 = V2PolicyList(**v2_policy_list_model_dict)
+
+        # Verify the model instances are equivalent
+        assert v2_policy_list_model == v2_policy_list_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_list_model_json2 = v2_policy_list_model.to_dict()
+        assert v2_policy_list_model_json2 == v2_policy_list_model_json
+
+
+class TestModel_V2PolicyBaseRuleV2PolicyAttribute:
+    """
+    Test Class for V2PolicyBaseRuleV2PolicyAttribute
+    """
+
+    def test_v2_policy_base_rule_v2_policy_attribute_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyBaseRuleV2PolicyAttribute
+        """
+
+        # Construct a json representation of a V2PolicyBaseRuleV2PolicyAttribute model
+        v2_policy_base_rule_v2_policy_attribute_model_json = {}
+        v2_policy_base_rule_v2_policy_attribute_model_json['key'] = 'testString'
+        v2_policy_base_rule_v2_policy_attribute_model_json['operator'] = 'testString'
+        v2_policy_base_rule_v2_policy_attribute_model_json['value'] = 'testString'
+
+        # Construct a model instance of V2PolicyBaseRuleV2PolicyAttribute by calling from_dict on the json representation
+        v2_policy_base_rule_v2_policy_attribute_model = V2PolicyBaseRuleV2PolicyAttribute.from_dict(
+            v2_policy_base_rule_v2_policy_attribute_model_json
+        )
+        assert v2_policy_base_rule_v2_policy_attribute_model != False
+
+        # Construct a model instance of V2PolicyBaseRuleV2PolicyAttribute by calling from_dict on the json representation
+        v2_policy_base_rule_v2_policy_attribute_model_dict = V2PolicyBaseRuleV2PolicyAttribute.from_dict(
+            v2_policy_base_rule_v2_policy_attribute_model_json
+        ).__dict__
+        v2_policy_base_rule_v2_policy_attribute_model2 = V2PolicyBaseRuleV2PolicyAttribute(
+            **v2_policy_base_rule_v2_policy_attribute_model_dict
+        )
+
+        # Verify the model instances are equivalent
+        assert v2_policy_base_rule_v2_policy_attribute_model == v2_policy_base_rule_v2_policy_attribute_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_base_rule_v2_policy_attribute_model_json2 = v2_policy_base_rule_v2_policy_attribute_model.to_dict()
+        assert v2_policy_base_rule_v2_policy_attribute_model_json2 == v2_policy_base_rule_v2_policy_attribute_model_json
+
+
+class TestModel_V2PolicyBaseRuleV2RuleWithConditions:
+    """
+    Test Class for V2PolicyBaseRuleV2RuleWithConditions
+    """
+
+    def test_v2_policy_base_rule_v2_rule_with_conditions_serialization(self):
+        """
+        Test serialization/deserialization for V2PolicyBaseRuleV2RuleWithConditions
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_attribute_model = {}  # V2PolicyAttribute
+        v2_policy_attribute_model['key'] = 'testString'
+        v2_policy_attribute_model['operator'] = 'testString'
+        v2_policy_attribute_model['value'] = 'testString'
+
+        # Construct a json representation of a V2PolicyBaseRuleV2RuleWithConditions model
+        v2_policy_base_rule_v2_rule_with_conditions_model_json = {}
+        v2_policy_base_rule_v2_rule_with_conditions_model_json['operator'] = 'and'
+        v2_policy_base_rule_v2_rule_with_conditions_model_json['conditions'] = [v2_policy_attribute_model]
+
+        # Construct a model instance of V2PolicyBaseRuleV2RuleWithConditions by calling from_dict on the json representation
+        v2_policy_base_rule_v2_rule_with_conditions_model = V2PolicyBaseRuleV2RuleWithConditions.from_dict(
+            v2_policy_base_rule_v2_rule_with_conditions_model_json
+        )
+        assert v2_policy_base_rule_v2_rule_with_conditions_model != False
+
+        # Construct a model instance of V2PolicyBaseRuleV2RuleWithConditions by calling from_dict on the json representation
+        v2_policy_base_rule_v2_rule_with_conditions_model_dict = V2PolicyBaseRuleV2RuleWithConditions.from_dict(
+            v2_policy_base_rule_v2_rule_with_conditions_model_json
+        ).__dict__
+        v2_policy_base_rule_v2_rule_with_conditions_model2 = V2PolicyBaseRuleV2RuleWithConditions(
+            **v2_policy_base_rule_v2_rule_with_conditions_model_dict
+        )
+
+        # Verify the model instances are equivalent
+        assert v2_policy_base_rule_v2_rule_with_conditions_model == v2_policy_base_rule_v2_rule_with_conditions_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        v2_policy_base_rule_v2_rule_with_conditions_model_json2 = (
+            v2_policy_base_rule_v2_rule_with_conditions_model.to_dict()
+        )
+        assert (
+            v2_policy_base_rule_v2_rule_with_conditions_model_json2
+            == v2_policy_base_rule_v2_rule_with_conditions_model_json
+        )
 
 
 # endregion


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
Code to support new v2/policies API has been introduced. The new v2/policies API will have new JSON fields and existing v1/fields have been changed.

v1/policies API will continue to be supported.


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
PR's are currently open for staging and production docs. They are:
Staging: https://github.ibm.com/cloud-api-docs/iam-access-management/pull/139 - Merged
Production: https://github.ibm.com/cloud-api-docs/iam-access-management/pull/140 - Not Merged

## Current vs new behavior  
Current behavior will remain same (v1 will continue to be supported). New behavior is v2/policies support which allows for time based restriction policies using new rule field (an integration test has been added of this example).

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No


## Other information
See:
Issue: https://github.ibm.com/IAM/AM-issues/issues/925
TRI: https://github.ibm.com/IAM/architecture/blob/master/TRIDocs/Access-Management/Smart-Policies/smart_policies.md