### PR TITLE
feat(Enterprise Billing Units): add start and limit parameters to billing unit APIs

### DIFF
--- a/ibm_platform_services/enterprise_billing_units_v1.py
+++ b/ibm_platform_services/enterprise_billing_units_v1.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# (C) Copyright IBM Corp. 2020.
+# (C) Copyright IBM Corp. 2023.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# IBM OpenAPI SDK Code Generator Version: 99-SNAPSHOT-629bbb97-20201207-171303
+# IBM OpenAPI SDK Code Generator Version: 3.62.0-a2a22f95-20221115-162524
 
 """
 Billing units for IBM Cloud enterprises
+
+API Version: 1.0.0
 """
 
 from datetime import datetime
@@ -25,7 +27,7 @@ from enum import Enum
 from typing import Dict, List
 import json
 
-from ibm_cloud_sdk_core import BaseService, DetailedResponse
+from ibm_cloud_sdk_core import BaseService, DetailedResponse, get_query_param
 from ibm_cloud_sdk_core.authenticators.authenticator import Authenticator
 from ibm_cloud_sdk_core.get_authenticator import get_authenticator_from_environment
 from ibm_cloud_sdk_core.utils import datetime_to_string, string_to_datetime
@@ -36,7 +38,6 @@ from .common import get_sdk_headers
 # Service
 ##############################################################################
 
-
 class EnterpriseBillingUnitsV1(BaseService):
     """The Enterprise Billing Units V1 service."""
 
@@ -44,37 +45,44 @@ class EnterpriseBillingUnitsV1(BaseService):
     DEFAULT_SERVICE_NAME = 'enterprise_billing_units'
 
     @classmethod
-    def new_instance(
-        cls,
-        service_name: str = DEFAULT_SERVICE_NAME,
-    ) -> 'EnterpriseBillingUnitsV1':
+    def new_instance(cls,
+                     service_name: str = DEFAULT_SERVICE_NAME,
+                    ) -> 'EnterpriseBillingUnitsV1':
         """
         Return a new client for the Enterprise Billing Units service using the
                specified parameters and external configuration.
         """
         authenticator = get_authenticator_from_environment(service_name)
-        service = cls(authenticator)
+        service = cls(
+            authenticator
+            )
         service.configure_service(service_name)
         return service
 
-    def __init__(
-        self,
-        authenticator: Authenticator = None,
-    ) -> None:
+    def __init__(self,
+                 authenticator: Authenticator = None,
+                ) -> None:
         """
         Construct a new client for the Enterprise Billing Units service.
 
         :param Authenticator authenticator: The authenticator specifies the authentication mechanism.
-               Get up to date information from https://github.com/IBM/python-sdk-core/blob/master/README.md
+               Get up to date information from https://github.com/IBM/python-sdk-core/blob/main/README.md
                about initializing the authenticator of your choice.
         """
-        BaseService.__init__(self, service_url=self.DEFAULT_SERVICE_URL, authenticator=authenticator)
+        BaseService.__init__(self,
+                             service_url=self.DEFAULT_SERVICE_URL,
+                             authenticator=authenticator)
+
 
     #########################
     # Billing Units
     #########################
 
-    def get_billing_unit(self, billing_unit_id: str, **kwargs) -> DetailedResponse:
+
+    def get_billing_unit(self,
+        billing_unit_id: str,
+        **kwargs
+    ) -> DetailedResponse:
         """
         Get billing unit by ID.
 
@@ -86,29 +94,39 @@ class EnterpriseBillingUnitsV1(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `BillingUnit` object
         """
 
-        if billing_unit_id is None:
+        if not billing_unit_id:
             raise ValueError('billing_unit_id must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='get_billing_unit'
-        )
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='get_billing_unit')
         headers.update(sdk_headers)
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['billing_unit_id']
         path_param_values = self.encode_path_vars(billing_unit_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
         url = '/v1/billing-units/{billing_unit_id}'.format(**path_param_dict)
-        request = self.prepare_request(method='GET', url=url, headers=headers)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers)
 
-        response = self.send(request)
+        response = self.send(request, **kwargs)
         return response
 
-    def list_billing_units(
-        self, *, account_id: str = None, enterprise_id: str = None, account_group_id: str = None, **kwargs
+
+    def list_billing_units(self,
+        *,
+        account_id: str = None,
+        enterprise_id: str = None,
+        account_group_id: str = None,
+        limit: int = None,
+        start: int = None,
+        **kwargs
     ) -> DetailedResponse:
         """
         List billing units.
@@ -119,34 +137,55 @@ class EnterpriseBillingUnitsV1(BaseService):
         :param str account_id: (optional) The enterprise account ID.
         :param str enterprise_id: (optional) The enterprise ID.
         :param str account_group_id: (optional) The account group ID.
+        :param int limit: (optional) Return results up to this limit. Valid values
+               are between 0 and 100.
+        :param int start: (optional) The pagination offset. This will be the index
+               of the first returned result.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `BillingUnitsList` object
         """
 
         headers = {}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='list_billing_units'
-        )
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='list_billing_units')
         headers.update(sdk_headers)
 
-        params = {'account_id': account_id, 'enterprise_id': enterprise_id, 'account_group_id': account_group_id}
+        params = {
+            'account_id': account_id,
+            'enterprise_id': enterprise_id,
+            'account_group_id': account_group_id,
+            'limit': limit,
+            'start': start
+        }
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         url = '/v1/billing-units'
-        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
 
-        response = self.send(request)
+        response = self.send(request, **kwargs)
         return response
 
     #########################
     # Billing Options
     #########################
 
-    def list_billing_options(self, billing_unit_id: str, **kwargs) -> DetailedResponse:
+
+    def list_billing_options(self,
+        billing_unit_id: str,
+        *,
+        limit: int = None,
+        start: int = None,
+        **kwargs
+    ) -> DetailedResponse:
         """
         List billing options.
 
@@ -154,37 +193,56 @@ class EnterpriseBillingUnitsV1(BaseService):
         offers that are available to a billing unit.
 
         :param str billing_unit_id: The billing unit ID.
+        :param int limit: (optional) Return results up to this limit. Valid values
+               are between 0 and 100.
+        :param int start: (optional) The pagination offset. This will be the index
+               of the first returned result.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `BillingOptionsList` object
         """
 
-        if billing_unit_id is None:
+        if not billing_unit_id:
             raise ValueError('billing_unit_id must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='list_billing_options'
-        )
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='list_billing_options')
         headers.update(sdk_headers)
 
-        params = {'billing_unit_id': billing_unit_id}
+        params = {
+            'billing_unit_id': billing_unit_id,
+            'limit': limit,
+            'start': start
+        }
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         url = '/v1/billing-options'
-        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
 
-        response = self.send(request)
+        response = self.send(request, **kwargs)
         return response
 
     #########################
     # Credit Pools
     #########################
 
-    def get_credit_pools(
-        self, billing_unit_id: str, *, date: str = None, type: str = None, **kwargs
+
+    def get_credit_pools(self,
+        billing_unit_id: str,
+        *,
+        date: str = None,
+        type: str = None,
+        limit: int = None,
+        start: int = None,
+        **kwargs
     ) -> DetailedResponse:
         """
         Get credit pools.
@@ -198,29 +256,43 @@ class EnterpriseBillingUnitsV1(BaseService):
         :param str date: (optional) The date in the format of YYYY-MM.
         :param str type: (optional) Filters the credit pool by type, either
                `PLATFORM` or `SUPPORT`.
+        :param int limit: (optional) Return results up to this limit. Valid values
+               are between 0 and 100.
+        :param int start: (optional) The pagination offset. This will be the index
+               of the first returned result.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `CreditPoolsList` object
         """
 
-        if billing_unit_id is None:
+        if not billing_unit_id:
             raise ValueError('billing_unit_id must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(
-            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='get_credit_pools'
-        )
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V1',
+                                      operation_id='get_credit_pools')
         headers.update(sdk_headers)
 
-        params = {'billing_unit_id': billing_unit_id, 'date': date, 'type': type}
+        params = {
+            'billing_unit_id': billing_unit_id,
+            'date': date,
+            'type': type,
+            'limit': limit,
+            'start': start
+        }
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         url = '/v1/credit-pools'
-        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
 
-        response = self.send(request)
+        response = self.send(request, **kwargs)
         return response
 
 
@@ -229,7 +301,7 @@ class EnterpriseBillingUnitsV1(BaseService):
 ##############################################################################
 
 
-class BillingOption:
+class BillingOption():
     """
     Information about a billing option.
 
@@ -256,23 +328,21 @@ class BillingOption:
           updated.
     """
 
-    def __init__(
-        self,
-        *,
-        id: str = None,
-        billing_unit_id: str = None,
-        start_date: datetime = None,
-        end_date: datetime = None,
-        state: str = None,
-        type: str = None,
-        category: str = None,
-        payment_instrument: dict = None,
-        duration_in_months: int = None,
-        line_item_id: int = None,
-        billing_system: dict = None,
-        renewal_mode_code: str = None,
-        updated_at: datetime = None
-    ) -> None:
+    def __init__(self,
+                 *,
+                 id: str = None,
+                 billing_unit_id: str = None,
+                 start_date: datetime = None,
+                 end_date: datetime = None,
+                 state: str = None,
+                 type: str = None,
+                 category: str = None,
+                 payment_instrument: dict = None,
+                 duration_in_months: int = None,
+                 line_item_id: int = None,
+                 billing_system: dict = None,
+                 renewal_mode_code: str = None,
+                 updated_at: datetime = None) -> None:
         """
         Initialize a BillingOption object.
 
@@ -403,31 +473,30 @@ class BillingOption:
         The state of the billing option. The valid values include `ACTIVE, `SUSPENDED`,
         and `CANCELED`.
         """
-
         ACTIVE = 'ACTIVE'
         SUSPENDED = 'SUSPENDED'
         CANCELED = 'CANCELED'
+
 
     class TypeEnum(str, Enum):
         """
         The type of billing option. The valid values are `SUBSCRIPTION` and `OFFER`.
         """
-
         SUBSCRIPTION = 'SUBSCRIPTION'
         OFFER = 'OFFER'
+
 
     class CategoryEnum(str, Enum):
         """
         The category of the billing option. The valid values are `PLATFORM`, `SERVICE`,
         and `SUPPORT`.
         """
-
         PLATFORM = 'PLATFORM'
         SERVICE = 'SERVICE'
         SUPPORT = 'SUPPORT'
 
 
-class BillingOptionsList:
+class BillingOptionsList():
     """
     A search result containing zero or more billing options.
 
@@ -438,9 +507,11 @@ class BillingOptionsList:
     :attr List[BillingOption] resources: (optional) A list of billing units found.
     """
 
-    def __init__(
-        self, *, rows_count: int = None, next_url: str = None, resources: List['BillingOption'] = None
-    ) -> None:
+    def __init__(self,
+                 *,
+                 rows_count: int = None,
+                 next_url: str = None,
+                 resources: List['BillingOption'] = None) -> None:
         """
         Initialize a BillingOptionsList object.
 
@@ -464,7 +535,7 @@ class BillingOptionsList:
         if 'next_url' in _dict:
             args['next_url'] = _dict.get('next_url')
         if 'resources' in _dict:
-            args['resources'] = [BillingOption.from_dict(x) for x in _dict.get('resources')]
+            args['resources'] = [BillingOption.from_dict(v) for v in _dict.get('resources')]
         return cls(**args)
 
     @classmethod
@@ -480,7 +551,13 @@ class BillingOptionsList:
         if hasattr(self, 'next_url') and self.next_url is not None:
             _dict['next_url'] = self.next_url
         if hasattr(self, 'resources') and self.resources is not None:
-            _dict['resources'] = [x.to_dict() for x in self.resources]
+            resources_list = []
+            for v in self.resources:
+                if isinstance(v, dict):
+                    resources_list.append(v)
+                else:
+                    resources_list.append(v.to_dict())
+            _dict['resources'] = resources_list
         return _dict
 
     def _to_dict(self):
@@ -501,8 +578,7 @@ class BillingOptionsList:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class BillingUnit:
+class BillingUnit():
     """
     Information about a billing unit.
 
@@ -520,18 +596,16 @@ class BillingUnit:
     :attr datetime created_at: (optional) The creation date of the billing unit.
     """
 
-    def __init__(
-        self,
-        *,
-        id: str = None,
-        crn: str = None,
-        name: str = None,
-        enterprise_id: str = None,
-        currency_code: str = None,
-        country_code: str = None,
-        master: bool = None,
-        created_at: datetime = None
-    ) -> None:
+    def __init__(self,
+                 *,
+                 id: str = None,
+                 crn: str = None,
+                 name: str = None,
+                 enterprise_id: str = None,
+                 currency_code: str = None,
+                 country_code: str = None,
+                 master: bool = None,
+                 created_at: datetime = None) -> None:
         """
         Initialize a BillingUnit object.
 
@@ -625,8 +699,7 @@ class BillingUnit:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class BillingUnitsList:
+class BillingUnitsList():
     """
     A search result contining zero or more billing units.
 
@@ -637,7 +710,11 @@ class BillingUnitsList:
     :attr List[BillingUnit] resources: (optional) A list of billing units found.
     """
 
-    def __init__(self, *, rows_count: int = None, next_url: str = None, resources: List['BillingUnit'] = None) -> None:
+    def __init__(self,
+                 *,
+                 rows_count: int = None,
+                 next_url: str = None,
+                 resources: List['BillingUnit'] = None) -> None:
         """
         Initialize a BillingUnitsList object.
 
@@ -661,7 +738,7 @@ class BillingUnitsList:
         if 'next_url' in _dict:
             args['next_url'] = _dict.get('next_url')
         if 'resources' in _dict:
-            args['resources'] = [BillingUnit.from_dict(x) for x in _dict.get('resources')]
+            args['resources'] = [BillingUnit.from_dict(v) for v in _dict.get('resources')]
         return cls(**args)
 
     @classmethod
@@ -677,7 +754,13 @@ class BillingUnitsList:
         if hasattr(self, 'next_url') and self.next_url is not None:
             _dict['next_url'] = self.next_url
         if hasattr(self, 'resources') and self.resources is not None:
-            _dict['resources'] = [x.to_dict() for x in self.resources]
+            resources_list = []
+            for v in self.resources:
+                if isinstance(v, dict):
+                    resources_list.append(v)
+                else:
+                    resources_list.append(v.to_dict())
+            _dict['resources'] = resources_list
         return _dict
 
     def _to_dict(self):
@@ -698,8 +781,7 @@ class BillingUnitsList:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class CreditPool:
+class CreditPool():
     """
     The credit pool for a billing unit.
 
@@ -715,15 +797,13 @@ class CreditPool:
           credit pool.
     """
 
-    def __init__(
-        self,
-        *,
-        type: str = None,
-        currency_code: str = None,
-        billing_unit_id: str = None,
-        term_credits: List['TermCredits'] = None,
-        overage: 'CreditPoolOverage' = None
-    ) -> None:
+    def __init__(self,
+                 *,
+                 type: str = None,
+                 currency_code: str = None,
+                 billing_unit_id: str = None,
+                 term_credits: List['TermCredits'] = None,
+                 overage: 'CreditPoolOverage' = None) -> None:
         """
         Initialize a CreditPool object.
 
@@ -756,7 +836,7 @@ class CreditPool:
         if 'billing_unit_id' in _dict:
             args['billing_unit_id'] = _dict.get('billing_unit_id')
         if 'term_credits' in _dict:
-            args['term_credits'] = [TermCredits.from_dict(x) for x in _dict.get('term_credits')]
+            args['term_credits'] = [TermCredits.from_dict(v) for v in _dict.get('term_credits')]
         if 'overage' in _dict:
             args['overage'] = CreditPoolOverage.from_dict(_dict.get('overage'))
         return cls(**args)
@@ -776,9 +856,18 @@ class CreditPool:
         if hasattr(self, 'billing_unit_id') and self.billing_unit_id is not None:
             _dict['billing_unit_id'] = self.billing_unit_id
         if hasattr(self, 'term_credits') and self.term_credits is not None:
-            _dict['term_credits'] = [x.to_dict() for x in self.term_credits]
+            term_credits_list = []
+            for v in self.term_credits:
+                if isinstance(v, dict):
+                    term_credits_list.append(v)
+                else:
+                    term_credits_list.append(v.to_dict())
+            _dict['term_credits'] = term_credits_list
         if hasattr(self, 'overage') and self.overage is not None:
-            _dict['overage'] = self.overage.to_dict()
+            if isinstance(self.overage, dict):
+                _dict['overage'] = self.overage
+            else:
+                _dict['overage'] = self.overage.to_dict()
         return _dict
 
     def _to_dict(self):
@@ -803,12 +892,11 @@ class CreditPool:
         """
         The type of credit, either `PLATFORM` or `SUPPORT`.
         """
-
         PLATFORM = 'PLATFORM'
         SUPPORT = 'SUPPORT'
 
 
-class CreditPoolOverage:
+class CreditPoolOverage():
     """
     Overage that was generated on the credit pool.
 
@@ -817,7 +905,10 @@ class CreditPoolOverage:
           overage.
     """
 
-    def __init__(self, *, cost: float = None, resources: List[dict] = None) -> None:
+    def __init__(self,
+                 *,
+                 cost: float = None,
+                 resources: List[dict] = None) -> None:
         """
         Initialize a CreditPoolOverage object.
 
@@ -870,8 +961,7 @@ class CreditPoolOverage:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class CreditPoolsList:
+class CreditPoolsList():
     """
     A search result containing zero or more credit pools.
 
@@ -883,7 +973,11 @@ class CreditPoolsList:
           query.
     """
 
-    def __init__(self, *, rows_count: int = None, next_url: str = None, resources: List['CreditPool'] = None) -> None:
+    def __init__(self,
+                 *,
+                 rows_count: int = None,
+                 next_url: str = None,
+                 resources: List['CreditPool'] = None) -> None:
         """
         Initialize a CreditPoolsList object.
 
@@ -908,7 +1002,7 @@ class CreditPoolsList:
         if 'next_url' in _dict:
             args['next_url'] = _dict.get('next_url')
         if 'resources' in _dict:
-            args['resources'] = [CreditPool.from_dict(x) for x in _dict.get('resources')]
+            args['resources'] = [CreditPool.from_dict(v) for v in _dict.get('resources')]
         return cls(**args)
 
     @classmethod
@@ -924,7 +1018,13 @@ class CreditPoolsList:
         if hasattr(self, 'next_url') and self.next_url is not None:
             _dict['next_url'] = self.next_url
         if hasattr(self, 'resources') and self.resources is not None:
-            _dict['resources'] = [x.to_dict() for x in self.resources]
+            resources_list = []
+            for v in self.resources:
+                if isinstance(v, dict):
+                    resources_list.append(v)
+                else:
+                    resources_list.append(v.to_dict())
+            _dict['resources'] = resources_list
         return _dict
 
     def _to_dict(self):
@@ -945,8 +1045,7 @@ class CreditPoolsList:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-
-class TermCredits:
+class TermCredits():
     """
     The subscription term that is active in the current month.
 
@@ -968,19 +1067,17 @@ class TermCredits:
           during the month.
     """
 
-    def __init__(
-        self,
-        *,
-        billing_option_id: str = None,
-        category: str = None,
-        start_date: datetime = None,
-        end_date: datetime = None,
-        total_credits: float = None,
-        starting_balance: float = None,
-        used_credits: float = None,
-        current_balance: float = None,
-        resources: List[dict] = None
-    ) -> None:
+    def __init__(self,
+                 *,
+                 billing_option_id: str = None,
+                 category: str = None,
+                 start_date: datetime = None,
+                 end_date: datetime = None,
+                 total_credits: float = None,
+                 starting_balance: float = None,
+                 used_credits: float = None,
+                 current_balance: float = None,
+                 resources: List[dict] = None) -> None:
         """
         Initialize a TermCredits object.
 
@@ -1089,8 +1186,230 @@ class TermCredits:
         The category of the credit pool. The valid values are `PLATFORM`, `OFFER`, or
         `SERVICE` for platform credit and `SUPPORT` for support credit.
         """
-
         PLATFORM = 'PLATFORM'
         OFFER = 'OFFER'
         SERVICE = 'SERVICE'
         SUPPORT = 'SUPPORT'
+
+
+##############################################################################
+# Pagers
+##############################################################################
+
+class BillingUnitsPager():
+    """
+    BillingUnitsPager can be used to simplify the use of the "list_billing_units" method.
+    """
+
+    def __init__(self,
+                 *,
+                 client: EnterpriseBillingUnitsV1,
+                 account_id: str = None,
+                 enterprise_id: str = None,
+                 account_group_id: str = None,
+                 limit: int = None,
+    ) -> None:
+        """
+        Initialize a BillingUnitsPager object.
+        :param str account_id: (optional) The enterprise account ID.
+        :param str enterprise_id: (optional) The enterprise ID.
+        :param str account_group_id: (optional) The account group ID.
+        :param int limit: (optional) Return results up to this limit. Valid values
+               are between 0 and 100.
+        """
+        self._has_next = True
+        self._client = client
+        self._page_context = { 'next': None }
+        self._account_id = account_id
+        self._enterprise_id = enterprise_id
+        self._account_group_id = account_group_id
+        self._limit = limit
+
+    def has_next(self) -> bool:
+        """
+        Returns true if there are potentially more results to be retrieved.
+        """
+        return self._has_next
+
+    def get_next(self) -> List[dict]:
+        """
+        Returns the next page of results.
+        :return: A List[dict], where each element is a dict that represents an instance of BillingUnit.
+        :rtype: List[dict]
+        """
+        if not self.has_next():
+            raise StopIteration(message='No more results available')
+
+        result = self._client.list_billing_units(
+            account_id=self._account_id,
+            enterprise_id=self._enterprise_id,
+            account_group_id=self._account_group_id,
+            limit=self._limit,
+            start=self._page_context.get('next'),
+        ).get_result()
+
+        next = None
+        next_page_link = result.get('next_url')
+        if next_page_link is not None:
+            next = get_query_param(next_page_link, 'start')
+        self._page_context['next'] = next
+        if next is None:
+            self._has_next = False
+
+        return result.get('resources')
+
+    def get_all(self) -> List[dict]:
+        """
+        Returns all results by invoking get_next() repeatedly
+        until all pages of results have been retrieved.
+        :return: A List[dict], where each element is a dict that represents an instance of BillingUnit.
+        :rtype: List[dict]
+        """
+        results = []
+        while self.has_next():
+            next_page = self.get_next()
+            results.extend(next_page)
+        return results
+
+class BillingOptionsPager():
+    """
+    BillingOptionsPager can be used to simplify the use of the "list_billing_options" method.
+    """
+
+    def __init__(self,
+                 *,
+                 client: EnterpriseBillingUnitsV1,
+                 billing_unit_id: str,
+                 limit: int = None,
+    ) -> None:
+        """
+        Initialize a BillingOptionsPager object.
+        :param str billing_unit_id: The billing unit ID.
+        :param int limit: (optional) Return results up to this limit. Valid values
+               are between 0 and 100.
+        """
+        self._has_next = True
+        self._client = client
+        self._page_context = { 'next': None }
+        self._billing_unit_id = billing_unit_id
+        self._limit = limit
+
+    def has_next(self) -> bool:
+        """
+        Returns true if there are potentially more results to be retrieved.
+        """
+        return self._has_next
+
+    def get_next(self) -> List[dict]:
+        """
+        Returns the next page of results.
+        :return: A List[dict], where each element is a dict that represents an instance of BillingOption.
+        :rtype: List[dict]
+        """
+        if not self.has_next():
+            raise StopIteration(message='No more results available')
+
+        result = self._client.list_billing_options(
+            billing_unit_id=self._billing_unit_id,
+            limit=self._limit,
+            start=self._page_context.get('next'),
+        ).get_result()
+
+        next = None
+        next_page_link = result.get('next_url')
+        if next_page_link is not None:
+            next = get_query_param(next_page_link, 'start')
+        self._page_context['next'] = next
+        if next is None:
+            self._has_next = False
+
+        return result.get('resources')
+
+    def get_all(self) -> List[dict]:
+        """
+        Returns all results by invoking get_next() repeatedly
+        until all pages of results have been retrieved.
+        :return: A List[dict], where each element is a dict that represents an instance of BillingOption.
+        :rtype: List[dict]
+        """
+        results = []
+        while self.has_next():
+            next_page = self.get_next()
+            results.extend(next_page)
+        return results
+
+class GetCreditPoolsPager():
+    """
+    GetCreditPoolsPager can be used to simplify the use of the "get_credit_pools" method.
+    """
+
+    def __init__(self,
+                 *,
+                 client: EnterpriseBillingUnitsV1,
+                 billing_unit_id: str,
+                 date: str = None,
+                 type: str = None,
+                 limit: int = None,
+    ) -> None:
+        """
+        Initialize a GetCreditPoolsPager object.
+        :param str billing_unit_id: The ID of the billing unit.
+        :param str date: (optional) The date in the format of YYYY-MM.
+        :param str type: (optional) Filters the credit pool by type, either
+               `PLATFORM` or `SUPPORT`.
+        :param int limit: (optional) Return results up to this limit. Valid values
+               are between 0 and 100.
+        """
+        self._has_next = True
+        self._client = client
+        self._page_context = { 'next': None }
+        self._billing_unit_id = billing_unit_id
+        self._date = date
+        self._type = type
+        self._limit = limit
+
+    def has_next(self) -> bool:
+        """
+        Returns true if there are potentially more results to be retrieved.
+        """
+        return self._has_next
+
+    def get_next(self) -> List[dict]:
+        """
+        Returns the next page of results.
+        :return: A List[dict], where each element is a dict that represents an instance of CreditPool.
+        :rtype: List[dict]
+        """
+        if not self.has_next():
+            raise StopIteration(message='No more results available')
+
+        result = self._client.get_credit_pools(
+            billing_unit_id=self._billing_unit_id,
+            date=self._date,
+            type=self._type,
+            limit=self._limit,
+            start=self._page_context.get('next'),
+        ).get_result()
+
+        next = None
+        next_page_link = result.get('next_url')
+        if next_page_link is not None:
+            next = get_query_param(next_page_link, 'start')
+        self._page_context['next'] = next
+        if next is None:
+            self._has_next = False
+
+        return result.get('resources')
+
+    def get_all(self) -> List[dict]:
+        """
+        Returns all results by invoking get_next() repeatedly
+        until all pages of results have been retrieved.
+        :return: A List[dict], where each element is a dict that represents an instance of CreditPool.
+        :rtype: List[dict]
+        """
+        results = []
+        while self.has_next():
+            next_page = self.get_next()
+            results.extend(next_page)
+        return results

--- a/test/unit/test_enterprise_billing_units_v1.py
+++ b/test/unit/test_enterprise_billing_units_v1.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (C) Copyright IBM Corp. 2020.
+# (C) Copyright IBM Corp. 2023.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,8 +19,10 @@ Unit Tests for EnterpriseBillingUnitsV1
 
 from datetime import datetime, timezone
 from ibm_cloud_sdk_core.authenticators.no_auth_authenticator import NoAuthAuthenticator
+from ibm_cloud_sdk_core.utils import datetime_to_string, string_to_datetime
 import inspect
 import json
+import os
 import pytest
 import re
 import requests
@@ -29,30 +31,76 @@ import urllib
 from ibm_platform_services.enterprise_billing_units_v1 import *
 
 
-service = EnterpriseBillingUnitsV1(authenticator=NoAuthAuthenticator())
+_service = EnterpriseBillingUnitsV1(
+    authenticator=NoAuthAuthenticator()
+)
 
-base_url = 'https://billing.cloud.ibm.com'
-service.set_service_url(base_url)
+_base_url = 'https://billing.cloud.ibm.com'
+_service.set_service_url(_base_url)
+
+
+def preprocess_url(operation_path: str):
+    """
+    Returns the request url associated with the specified operation path.
+    This will be base_url concatenated with a quoted version of operation_path.
+    The returned request URL is used to register the mock response so it needs
+    to match the request URL that is formed by the requests library.
+    """
+    # First, unquote the path since it might have some quoted/escaped characters in it
+    # due to how the generator inserts the operation paths into the unit test code.
+    operation_path = urllib.parse.unquote(operation_path)
+
+    # Next, quote the path using urllib so that we approximate what will
+    # happen during request processing.
+    operation_path = urllib.parse.quote(operation_path, safe='/')
+
+    # Finally, form the request URL from the base URL and operation path.
+    request_url = _base_url + operation_path
+
+    # If the request url does NOT end with a /, then just return it as-is.
+    # Otherwise, return a regular expression that matches one or more trailing /.
+    if re.fullmatch('.*/+', request_url) is None:
+        return request_url
+    else:
+        return re.compile(request_url.rstrip('/') + '/+')
+
 
 ##############################################################################
 # Start of Service: BillingUnits
 ##############################################################################
 # region
 
+class TestNewInstance():
+    """
+    Test Class for new_instance
+    """
 
-class TestGetBillingUnit:
+    def test_new_instance(self):
+        """
+        new_instance()
+        """
+        os.environ['TEST_SERVICE_AUTH_TYPE'] = 'noAuth'
+
+        service = EnterpriseBillingUnitsV1.new_instance(
+            service_name='TEST_SERVICE',
+        )
+
+        assert service is not None
+        assert isinstance(service, EnterpriseBillingUnitsV1)
+
+    def test_new_instance_without_authenticator(self):
+        """
+        new_instance_without_authenticator()
+        """
+        with pytest.raises(ValueError, match='authenticator must be provided'):
+            service = EnterpriseBillingUnitsV1.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
+
+class TestGetBillingUnit():
     """
     Test Class for get_billing_unit
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_get_billing_unit_all_params(self):
@@ -60,19 +108,35 @@ class TestGetBillingUnit:
         get_billing_unit()
         """
         # Set up mock
-        url = self.preprocess_url(base_url + '/v1/billing-units/testString')
-        mock_response = '{"id": "id", "crn": "crn:v1:bluemix:public:billing::a/<<enterprise_account_id>>::billing-unit:<<billing_unit_id>>", "name": "name", "enterprise_id": "enterprise_id", "currency_code": "USD", "country_code": "USA", "master": true, "created_at": "2019-01-01T12:00:00"}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        url = preprocess_url('/v1/billing-units/testString')
+        mock_response = '{"id": "id", "crn": "crn:v1:bluemix:public:billing::a/<<enterprise_account_id>>::billing-unit:<<billing_unit_id>>", "name": "name", "enterprise_id": "enterprise_id", "currency_code": "USD", "country_code": "USA", "master": true, "created_at": "2019-05-01T00:00:00.000Z"}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         billing_unit_id = 'testString'
 
         # Invoke method
-        response = service.get_billing_unit(billing_unit_id, headers={})
+        response = _service.get_billing_unit(
+            billing_unit_id,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
+
+    def test_get_billing_unit_all_params_with_retries(self):
+        # Enable retries and run test_get_billing_unit_all_params.
+        _service.enable_retries()
+        self.test_get_billing_unit_all_params()
+
+        # Disable retries and run test_get_billing_unit_all_params.
+        _service.disable_retries()
+        self.test_get_billing_unit_all_params()
 
     @responses.activate
     def test_get_billing_unit_value_error(self):
@@ -80,9 +144,13 @@ class TestGetBillingUnit:
         test_get_billing_unit_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(base_url + '/v1/billing-units/testString')
-        mock_response = '{"id": "id", "crn": "crn:v1:bluemix:public:billing::a/<<enterprise_account_id>>::billing-unit:<<billing_unit_id>>", "name": "name", "enterprise_id": "enterprise_id", "currency_code": "USD", "country_code": "USA", "master": true, "created_at": "2019-01-01T12:00:00"}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        url = preprocess_url('/v1/billing-units/testString')
+        mock_response = '{"id": "id", "crn": "crn:v1:bluemix:public:billing::a/<<enterprise_account_id>>::billing-unit:<<billing_unit_id>>", "name": "name", "enterprise_id": "enterprise_id", "currency_code": "USD", "country_code": "USA", "master": true, "created_at": "2019-05-01T00:00:00.000Z"}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         billing_unit_id = 'testString'
@@ -92,24 +160,23 @@ class TestGetBillingUnit:
             "billing_unit_id": billing_unit_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
-                service.get_billing_unit(**req_copy)
+                _service.get_billing_unit(**req_copy)
 
+    def test_get_billing_unit_value_error_with_retries(self):
+        # Enable retries and run test_get_billing_unit_value_error.
+        _service.enable_retries()
+        self.test_get_billing_unit_value_error()
 
-class TestListBillingUnits:
+        # Disable retries and run test_get_billing_unit_value_error.
+        _service.disable_retries()
+        self.test_get_billing_unit_value_error()
+
+class TestListBillingUnits():
     """
     Test Class for list_billing_units
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_list_billing_units_all_params(self):
@@ -117,29 +184,51 @@ class TestListBillingUnits:
         list_billing_units()
         """
         # Set up mock
-        url = self.preprocess_url(base_url + '/v1/billing-units')
-        mock_response = '{"rows_count": 10, "next_url": "next_url", "resources": [{"id": "id", "crn": "crn:v1:bluemix:public:billing::a/<<enterprise_account_id>>::billing-unit:<<billing_unit_id>>", "name": "name", "enterprise_id": "enterprise_id", "currency_code": "USD", "country_code": "USA", "master": true, "created_at": "2019-01-01T12:00:00"}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        url = preprocess_url('/v1/billing-units')
+        mock_response = '{"rows_count": 10, "next_url": "next_url", "resources": [{"id": "id", "crn": "crn:v1:bluemix:public:billing::a/<<enterprise_account_id>>::billing-unit:<<billing_unit_id>>", "name": "name", "enterprise_id": "enterprise_id", "currency_code": "USD", "country_code": "USA", "master": true, "created_at": "2019-05-01T00:00:00.000Z"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         account_id = 'testString'
         enterprise_id = 'testString'
         account_group_id = 'testString'
+        limit = 1
+        start = 38
 
         # Invoke method
-        response = service.list_billing_units(
-            account_id=account_id, enterprise_id=enterprise_id, account_group_id=account_group_id, headers={}
+        response = _service.list_billing_units(
+            account_id=account_id,
+            enterprise_id=enterprise_id,
+            account_group_id=account_group_id,
+            limit=limit,
+            start=start,
+            headers={}
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = responses.calls[0].request.url.split('?',1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'account_id={}'.format(account_id) in query_string
         assert 'enterprise_id={}'.format(enterprise_id) in query_string
         assert 'account_group_id={}'.format(account_group_id) in query_string
+        assert 'limit={}'.format(limit) in query_string
+        assert 'start={}'.format(start) in query_string
+
+    def test_list_billing_units_all_params_with_retries(self):
+        # Enable retries and run test_list_billing_units_all_params.
+        _service.enable_retries()
+        self.test_list_billing_units_all_params()
+
+        # Disable retries and run test_list_billing_units_all_params.
+        _service.disable_retries()
+        self.test_list_billing_units_all_params()
 
     @responses.activate
     def test_list_billing_units_required_params(self):
@@ -147,17 +236,97 @@ class TestListBillingUnits:
         test_list_billing_units_required_params()
         """
         # Set up mock
-        url = self.preprocess_url(base_url + '/v1/billing-units')
-        mock_response = '{"rows_count": 10, "next_url": "next_url", "resources": [{"id": "id", "crn": "crn:v1:bluemix:public:billing::a/<<enterprise_account_id>>::billing-unit:<<billing_unit_id>>", "name": "name", "enterprise_id": "enterprise_id", "currency_code": "USD", "country_code": "USA", "master": true, "created_at": "2019-01-01T12:00:00"}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        url = preprocess_url('/v1/billing-units')
+        mock_response = '{"rows_count": 10, "next_url": "next_url", "resources": [{"id": "id", "crn": "crn:v1:bluemix:public:billing::a/<<enterprise_account_id>>::billing-unit:<<billing_unit_id>>", "name": "name", "enterprise_id": "enterprise_id", "currency_code": "USD", "country_code": "USA", "master": true, "created_at": "2019-05-01T00:00:00.000Z"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Invoke method
-        response = service.list_billing_units()
+        response = _service.list_billing_units()
+
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
 
+    def test_list_billing_units_required_params_with_retries(self):
+        # Enable retries and run test_list_billing_units_required_params.
+        _service.enable_retries()
+        self.test_list_billing_units_required_params()
+
+        # Disable retries and run test_list_billing_units_required_params.
+        _service.disable_retries()
+        self.test_list_billing_units_required_params()
+
+    @responses.activate
+    def test_list_billing_units_with_pager_get_next(self):
+        """
+        test_list_billing_units_with_pager_get_next()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v1/billing-units')
+        mock_response1 = '{"total_count":2,"limit":1,"next_url":"https://myhost.com/somePath?start=1","resources":[{"id":"id","crn":"crn:v1:bluemix:public:billing::a/<<enterprise_account_id>>::billing-unit:<<billing_unit_id>>","name":"name","enterprise_id":"enterprise_id","currency_code":"USD","country_code":"USA","master":true,"created_at":"2019-05-01T00:00:00.000Z"}]}'
+        mock_response2 = '{"total_count":2,"limit":1,"resources":[{"id":"id","crn":"crn:v1:bluemix:public:billing::a/<<enterprise_account_id>>::billing-unit:<<billing_unit_id>>","name":"name","enterprise_id":"enterprise_id","currency_code":"USD","country_code":"USA","master":true,"created_at":"2019-05-01T00:00:00.000Z"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response1,
+                      content_type='application/json',
+                      status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response2,
+                      content_type='application/json',
+                      status=200)
+
+        # Exercise the pager class for this operation
+        all_results = []
+        pager = BillingUnitsPager(
+            client=_service,
+            account_id='testString',
+            enterprise_id='testString',
+            account_group_id='testString',
+            limit=10,
+        )
+        while pager.has_next():
+            next_page = pager.get_next()
+            assert next_page is not None
+            all_results.extend(next_page)
+        assert len(all_results) == 2
+
+    @responses.activate
+    def test_list_billing_units_with_pager_get_all(self):
+        """
+        test_list_billing_units_with_pager_get_all()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v1/billing-units')
+        mock_response1 = '{"total_count":2,"limit":1,"next_url":"https://myhost.com/somePath?start=1","resources":[{"id":"id","crn":"crn:v1:bluemix:public:billing::a/<<enterprise_account_id>>::billing-unit:<<billing_unit_id>>","name":"name","enterprise_id":"enterprise_id","currency_code":"USD","country_code":"USA","master":true,"created_at":"2019-05-01T00:00:00.000Z"}]}'
+        mock_response2 = '{"total_count":2,"limit":1,"resources":[{"id":"id","crn":"crn:v1:bluemix:public:billing::a/<<enterprise_account_id>>::billing-unit:<<billing_unit_id>>","name":"name","enterprise_id":"enterprise_id","currency_code":"USD","country_code":"USA","master":true,"created_at":"2019-05-01T00:00:00.000Z"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response1,
+                      content_type='application/json',
+                      status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response2,
+                      content_type='application/json',
+                      status=200)
+
+        # Exercise the pager class for this operation
+        pager = BillingUnitsPager(
+            client=_service,
+            account_id='testString',
+            enterprise_id='testString',
+            account_group_id='testString',
+            limit=10,
+        )
+        all_results = pager.get_all()
+        assert all_results is not None
+        assert len(all_results) == 2
 
 # endregion
 ##############################################################################
@@ -169,20 +338,37 @@ class TestListBillingUnits:
 ##############################################################################
 # region
 
+class TestNewInstance():
+    """
+    Test Class for new_instance
+    """
 
-class TestListBillingOptions:
+    def test_new_instance(self):
+        """
+        new_instance()
+        """
+        os.environ['TEST_SERVICE_AUTH_TYPE'] = 'noAuth'
+
+        service = EnterpriseBillingUnitsV1.new_instance(
+            service_name='TEST_SERVICE',
+        )
+
+        assert service is not None
+        assert isinstance(service, EnterpriseBillingUnitsV1)
+
+    def test_new_instance_without_authenticator(self):
+        """
+        new_instance_without_authenticator()
+        """
+        with pytest.raises(ValueError, match='authenticator must be provided'):
+            service = EnterpriseBillingUnitsV1.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
+
+class TestListBillingOptions():
     """
     Test Class for list_billing_options
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_list_billing_options_all_params(self):
@@ -190,23 +376,85 @@ class TestListBillingOptions:
         list_billing_options()
         """
         # Set up mock
-        url = self.preprocess_url(base_url + '/v1/billing-options')
-        mock_response = '{"rows_count": 10, "next_url": "next_url", "resources": [{"id": "id", "billing_unit_id": "billing_unit_id", "start_date": "2019-01-01T12:00:00", "end_date": "2019-01-01T12:00:00", "state": "ACTIVE", "type": "SUBSCRIPTION", "category": "PLATFORM", "payment_instrument": {"mapKey": {"anyKey": "anyValue"}}, "duration_in_months": 11, "line_item_id": 10, "billing_system": {"mapKey": {"anyKey": "anyValue"}}, "renewal_mode_code": "renewal_mode_code", "updated_at": "2019-01-01T12:00:00"}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        url = preprocess_url('/v1/billing-options')
+        mock_response = '{"rows_count": 10, "next_url": "next_url", "resources": [{"id": "id", "billing_unit_id": "billing_unit_id", "start_date": "2019-05-01T00:00:00.000Z", "end_date": "2020-05-01T00:00:00.000Z", "state": "ACTIVE", "type": "SUBSCRIPTION", "category": "PLATFORM", "payment_instrument": {"anyKey": "anyValue"}, "duration_in_months": 11, "line_item_id": 10, "billing_system": {"anyKey": "anyValue"}, "renewal_mode_code": "renewal_mode_code", "updated_at": "2019-06-01T00:00:00.000Z"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         billing_unit_id = 'testString'
+        limit = 1
+        start = 38
 
         # Invoke method
-        response = service.list_billing_options(billing_unit_id, headers={})
+        response = _service.list_billing_options(
+            billing_unit_id,
+            limit=limit,
+            start=start,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = responses.calls[0].request.url.split('?',1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'billing_unit_id={}'.format(billing_unit_id) in query_string
+        assert 'limit={}'.format(limit) in query_string
+        assert 'start={}'.format(start) in query_string
+
+    def test_list_billing_options_all_params_with_retries(self):
+        # Enable retries and run test_list_billing_options_all_params.
+        _service.enable_retries()
+        self.test_list_billing_options_all_params()
+
+        # Disable retries and run test_list_billing_options_all_params.
+        _service.disable_retries()
+        self.test_list_billing_options_all_params()
+
+    @responses.activate
+    def test_list_billing_options_required_params(self):
+        """
+        test_list_billing_options_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/billing-options')
+        mock_response = '{"rows_count": 10, "next_url": "next_url", "resources": [{"id": "id", "billing_unit_id": "billing_unit_id", "start_date": "2019-05-01T00:00:00.000Z", "end_date": "2020-05-01T00:00:00.000Z", "state": "ACTIVE", "type": "SUBSCRIPTION", "category": "PLATFORM", "payment_instrument": {"anyKey": "anyValue"}, "duration_in_months": 11, "line_item_id": 10, "billing_system": {"anyKey": "anyValue"}, "renewal_mode_code": "renewal_mode_code", "updated_at": "2019-06-01T00:00:00.000Z"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        billing_unit_id = 'testString'
+
+        # Invoke method
+        response = _service.list_billing_options(
+            billing_unit_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'billing_unit_id={}'.format(billing_unit_id) in query_string
+
+    def test_list_billing_options_required_params_with_retries(self):
+        # Enable retries and run test_list_billing_options_required_params.
+        _service.enable_retries()
+        self.test_list_billing_options_required_params()
+
+        # Disable retries and run test_list_billing_options_required_params.
+        _service.disable_retries()
+        self.test_list_billing_options_required_params()
 
     @responses.activate
     def test_list_billing_options_value_error(self):
@@ -214,9 +462,13 @@ class TestListBillingOptions:
         test_list_billing_options_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(base_url + '/v1/billing-options')
-        mock_response = '{"rows_count": 10, "next_url": "next_url", "resources": [{"id": "id", "billing_unit_id": "billing_unit_id", "start_date": "2019-01-01T12:00:00", "end_date": "2019-01-01T12:00:00", "state": "ACTIVE", "type": "SUBSCRIPTION", "category": "PLATFORM", "payment_instrument": {"mapKey": {"anyKey": "anyValue"}}, "duration_in_months": 11, "line_item_id": 10, "billing_system": {"mapKey": {"anyKey": "anyValue"}}, "renewal_mode_code": "renewal_mode_code", "updated_at": "2019-01-01T12:00:00"}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        url = preprocess_url('/v1/billing-options')
+        mock_response = '{"rows_count": 10, "next_url": "next_url", "resources": [{"id": "id", "billing_unit_id": "billing_unit_id", "start_date": "2019-05-01T00:00:00.000Z", "end_date": "2020-05-01T00:00:00.000Z", "state": "ACTIVE", "type": "SUBSCRIPTION", "category": "PLATFORM", "payment_instrument": {"anyKey": "anyValue"}, "duration_in_months": 11, "line_item_id": 10, "billing_system": {"anyKey": "anyValue"}, "renewal_mode_code": "renewal_mode_code", "updated_at": "2019-06-01T00:00:00.000Z"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         billing_unit_id = 'testString'
@@ -226,10 +478,81 @@ class TestListBillingOptions:
             "billing_unit_id": billing_unit_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
-                service.list_billing_options(**req_copy)
+                _service.list_billing_options(**req_copy)
 
+    def test_list_billing_options_value_error_with_retries(self):
+        # Enable retries and run test_list_billing_options_value_error.
+        _service.enable_retries()
+        self.test_list_billing_options_value_error()
+
+        # Disable retries and run test_list_billing_options_value_error.
+        _service.disable_retries()
+        self.test_list_billing_options_value_error()
+
+    @responses.activate
+    def test_list_billing_options_with_pager_get_next(self):
+        """
+        test_list_billing_options_with_pager_get_next()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v1/billing-options')
+        mock_response1 = '{"total_count":2,"limit":1,"next_url":"https://myhost.com/somePath?start=1","resources":[{"id":"id","billing_unit_id":"billing_unit_id","start_date":"2019-05-01T00:00:00.000Z","end_date":"2020-05-01T00:00:00.000Z","state":"ACTIVE","type":"SUBSCRIPTION","category":"PLATFORM","payment_instrument":{"anyKey":"anyValue"},"duration_in_months":11,"line_item_id":10,"billing_system":{"anyKey":"anyValue"},"renewal_mode_code":"renewal_mode_code","updated_at":"2019-06-01T00:00:00.000Z"}]}'
+        mock_response2 = '{"total_count":2,"limit":1,"resources":[{"id":"id","billing_unit_id":"billing_unit_id","start_date":"2019-05-01T00:00:00.000Z","end_date":"2020-05-01T00:00:00.000Z","state":"ACTIVE","type":"SUBSCRIPTION","category":"PLATFORM","payment_instrument":{"anyKey":"anyValue"},"duration_in_months":11,"line_item_id":10,"billing_system":{"anyKey":"anyValue"},"renewal_mode_code":"renewal_mode_code","updated_at":"2019-06-01T00:00:00.000Z"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response1,
+                      content_type='application/json',
+                      status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response2,
+                      content_type='application/json',
+                      status=200)
+
+        # Exercise the pager class for this operation
+        all_results = []
+        pager = BillingOptionsPager(
+            client=_service,
+            billing_unit_id='testString',
+            limit=10,
+        )
+        while pager.has_next():
+            next_page = pager.get_next()
+            assert next_page is not None
+            all_results.extend(next_page)
+        assert len(all_results) == 2
+
+    @responses.activate
+    def test_list_billing_options_with_pager_get_all(self):
+        """
+        test_list_billing_options_with_pager_get_all()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v1/billing-options')
+        mock_response1 = '{"total_count":2,"limit":1,"next_url":"https://myhost.com/somePath?start=1","resources":[{"id":"id","billing_unit_id":"billing_unit_id","start_date":"2019-05-01T00:00:00.000Z","end_date":"2020-05-01T00:00:00.000Z","state":"ACTIVE","type":"SUBSCRIPTION","category":"PLATFORM","payment_instrument":{"anyKey":"anyValue"},"duration_in_months":11,"line_item_id":10,"billing_system":{"anyKey":"anyValue"},"renewal_mode_code":"renewal_mode_code","updated_at":"2019-06-01T00:00:00.000Z"}]}'
+        mock_response2 = '{"total_count":2,"limit":1,"resources":[{"id":"id","billing_unit_id":"billing_unit_id","start_date":"2019-05-01T00:00:00.000Z","end_date":"2020-05-01T00:00:00.000Z","state":"ACTIVE","type":"SUBSCRIPTION","category":"PLATFORM","payment_instrument":{"anyKey":"anyValue"},"duration_in_months":11,"line_item_id":10,"billing_system":{"anyKey":"anyValue"},"renewal_mode_code":"renewal_mode_code","updated_at":"2019-06-01T00:00:00.000Z"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response1,
+                      content_type='application/json',
+                      status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response2,
+                      content_type='application/json',
+                      status=200)
+
+        # Exercise the pager class for this operation
+        pager = BillingOptionsPager(
+            client=_service,
+            billing_unit_id='testString',
+            limit=10,
+        )
+        all_results = pager.get_all()
+        assert all_results is not None
+        assert len(all_results) == 2
 
 # endregion
 ##############################################################################
@@ -241,20 +564,37 @@ class TestListBillingOptions:
 ##############################################################################
 # region
 
+class TestNewInstance():
+    """
+    Test Class for new_instance
+    """
 
-class TestGetCreditPools:
+    def test_new_instance(self):
+        """
+        new_instance()
+        """
+        os.environ['TEST_SERVICE_AUTH_TYPE'] = 'noAuth'
+
+        service = EnterpriseBillingUnitsV1.new_instance(
+            service_name='TEST_SERVICE',
+        )
+
+        assert service is not None
+        assert isinstance(service, EnterpriseBillingUnitsV1)
+
+    def test_new_instance_without_authenticator(self):
+        """
+        new_instance_without_authenticator()
+        """
+        with pytest.raises(ValueError, match='authenticator must be provided'):
+            service = EnterpriseBillingUnitsV1.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
+
+class TestGetCreditPools():
     """
     Test Class for get_credit_pools
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_get_credit_pools_all_params(self):
@@ -262,27 +602,51 @@ class TestGetCreditPools:
         get_credit_pools()
         """
         # Set up mock
-        url = self.preprocess_url(base_url + '/v1/credit-pools')
-        mock_response = '{"rows_count": 2, "next_url": "next_url", "resources": [{"type": "PLATFORM", "currency_code": "USD", "billing_unit_id": "billing_unit_id", "term_credits": [{"billing_option_id": "JWX986YRGFSHACQUEFOI", "category": "PLATFORM", "start_date": "2019-01-01T12:00:00", "end_date": "2019-01-01T12:00:00", "total_credits": 10000, "starting_balance": 9000, "used_credits": 9500, "current_balance": 0, "resources": [{"mapKey": {"anyKey": "anyValue"}}]}], "overage": {"cost": 500, "resources": [{"mapKey": {"anyKey": "anyValue"}}]}}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        url = preprocess_url('/v1/credit-pools')
+        mock_response = '{"rows_count": 2, "next_url": "next_url", "resources": [{"type": "PLATFORM", "currency_code": "USD", "billing_unit_id": "billing_unit_id", "term_credits": [{"billing_option_id": "JWX986YRGFSHACQUEFOI", "category": "PLATFORM", "start_date": "2019-05-01T00:00:00.000Z", "end_date": "2020-04-30T23:59:29.999Z", "total_credits": 10000, "starting_balance": 9000, "used_credits": 9500, "current_balance": 0, "resources": [{"anyKey": "anyValue"}]}], "overage": {"cost": 500, "resources": [{"anyKey": "anyValue"}]}}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         billing_unit_id = 'testString'
         date = 'testString'
         type = 'testString'
+        limit = 1
+        start = 38
 
         # Invoke method
-        response = service.get_credit_pools(billing_unit_id, date=date, type=type, headers={})
+        response = _service.get_credit_pools(
+            billing_unit_id,
+            date=date,
+            type=type,
+            limit=limit,
+            start=start,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = responses.calls[0].request.url.split('?',1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'billing_unit_id={}'.format(billing_unit_id) in query_string
         assert 'date={}'.format(date) in query_string
         assert 'type={}'.format(type) in query_string
+        assert 'limit={}'.format(limit) in query_string
+        assert 'start={}'.format(start) in query_string
+
+    def test_get_credit_pools_all_params_with_retries(self):
+        # Enable retries and run test_get_credit_pools_all_params.
+        _service.enable_retries()
+        self.test_get_credit_pools_all_params()
+
+        # Disable retries and run test_get_credit_pools_all_params.
+        _service.disable_retries()
+        self.test_get_credit_pools_all_params()
 
     @responses.activate
     def test_get_credit_pools_required_params(self):
@@ -290,23 +654,39 @@ class TestGetCreditPools:
         test_get_credit_pools_required_params()
         """
         # Set up mock
-        url = self.preprocess_url(base_url + '/v1/credit-pools')
-        mock_response = '{"rows_count": 2, "next_url": "next_url", "resources": [{"type": "PLATFORM", "currency_code": "USD", "billing_unit_id": "billing_unit_id", "term_credits": [{"billing_option_id": "JWX986YRGFSHACQUEFOI", "category": "PLATFORM", "start_date": "2019-01-01T12:00:00", "end_date": "2019-01-01T12:00:00", "total_credits": 10000, "starting_balance": 9000, "used_credits": 9500, "current_balance": 0, "resources": [{"mapKey": {"anyKey": "anyValue"}}]}], "overage": {"cost": 500, "resources": [{"mapKey": {"anyKey": "anyValue"}}]}}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        url = preprocess_url('/v1/credit-pools')
+        mock_response = '{"rows_count": 2, "next_url": "next_url", "resources": [{"type": "PLATFORM", "currency_code": "USD", "billing_unit_id": "billing_unit_id", "term_credits": [{"billing_option_id": "JWX986YRGFSHACQUEFOI", "category": "PLATFORM", "start_date": "2019-05-01T00:00:00.000Z", "end_date": "2020-04-30T23:59:29.999Z", "total_credits": 10000, "starting_balance": 9000, "used_credits": 9500, "current_balance": 0, "resources": [{"anyKey": "anyValue"}]}], "overage": {"cost": 500, "resources": [{"anyKey": "anyValue"}]}}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         billing_unit_id = 'testString'
 
         # Invoke method
-        response = service.get_credit_pools(billing_unit_id, headers={})
+        response = _service.get_credit_pools(
+            billing_unit_id,
+            headers={}
+        )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = responses.calls[0].request.url.split('?',1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'billing_unit_id={}'.format(billing_unit_id) in query_string
+
+    def test_get_credit_pools_required_params_with_retries(self):
+        # Enable retries and run test_get_credit_pools_required_params.
+        _service.enable_retries()
+        self.test_get_credit_pools_required_params()
+
+        # Disable retries and run test_get_credit_pools_required_params.
+        _service.disable_retries()
+        self.test_get_credit_pools_required_params()
 
     @responses.activate
     def test_get_credit_pools_value_error(self):
@@ -314,9 +694,13 @@ class TestGetCreditPools:
         test_get_credit_pools_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(base_url + '/v1/credit-pools')
-        mock_response = '{"rows_count": 2, "next_url": "next_url", "resources": [{"type": "PLATFORM", "currency_code": "USD", "billing_unit_id": "billing_unit_id", "term_credits": [{"billing_option_id": "JWX986YRGFSHACQUEFOI", "category": "PLATFORM", "start_date": "2019-01-01T12:00:00", "end_date": "2019-01-01T12:00:00", "total_credits": 10000, "starting_balance": 9000, "used_credits": 9500, "current_balance": 0, "resources": [{"mapKey": {"anyKey": "anyValue"}}]}], "overage": {"cost": 500, "resources": [{"mapKey": {"anyKey": "anyValue"}}]}}]}'
-        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+        url = preprocess_url('/v1/credit-pools')
+        mock_response = '{"rows_count": 2, "next_url": "next_url", "resources": [{"type": "PLATFORM", "currency_code": "USD", "billing_unit_id": "billing_unit_id", "term_credits": [{"billing_option_id": "JWX986YRGFSHACQUEFOI", "category": "PLATFORM", "start_date": "2019-05-01T00:00:00.000Z", "end_date": "2020-04-30T23:59:29.999Z", "total_credits": 10000, "starting_balance": 9000, "used_credits": 9500, "current_balance": 0, "resources": [{"anyKey": "anyValue"}]}], "overage": {"cost": 500, "resources": [{"anyKey": "anyValue"}]}}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
 
         # Set up parameter values
         billing_unit_id = 'testString'
@@ -326,10 +710,85 @@ class TestGetCreditPools:
             "billing_unit_id": billing_unit_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
             with pytest.raises(ValueError):
-                service.get_credit_pools(**req_copy)
+                _service.get_credit_pools(**req_copy)
 
+    def test_get_credit_pools_value_error_with_retries(self):
+        # Enable retries and run test_get_credit_pools_value_error.
+        _service.enable_retries()
+        self.test_get_credit_pools_value_error()
+
+        # Disable retries and run test_get_credit_pools_value_error.
+        _service.disable_retries()
+        self.test_get_credit_pools_value_error()
+
+    @responses.activate
+    def test_get_credit_pools_with_pager_get_next(self):
+        """
+        test_get_credit_pools_with_pager_get_next()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v1/credit-pools')
+        mock_response1 = '{"total_count":2,"limit":1,"next_url":"https://myhost.com/somePath?start=1","resources":[{"type":"PLATFORM","currency_code":"USD","billing_unit_id":"billing_unit_id","term_credits":[{"billing_option_id":"JWX986YRGFSHACQUEFOI","category":"PLATFORM","start_date":"2019-05-01T00:00:00.000Z","end_date":"2020-04-30T23:59:29.999Z","total_credits":10000,"starting_balance":9000,"used_credits":9500,"current_balance":0,"resources":[{"anyKey":"anyValue"}]}],"overage":{"cost":500,"resources":[{"anyKey":"anyValue"}]}}]}'
+        mock_response2 = '{"total_count":2,"limit":1,"resources":[{"type":"PLATFORM","currency_code":"USD","billing_unit_id":"billing_unit_id","term_credits":[{"billing_option_id":"JWX986YRGFSHACQUEFOI","category":"PLATFORM","start_date":"2019-05-01T00:00:00.000Z","end_date":"2020-04-30T23:59:29.999Z","total_credits":10000,"starting_balance":9000,"used_credits":9500,"current_balance":0,"resources":[{"anyKey":"anyValue"}]}],"overage":{"cost":500,"resources":[{"anyKey":"anyValue"}]}}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response1,
+                      content_type='application/json',
+                      status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response2,
+                      content_type='application/json',
+                      status=200)
+
+        # Exercise the pager class for this operation
+        all_results = []
+        pager = GetCreditPoolsPager(
+            client=_service,
+            billing_unit_id='testString',
+            date='testString',
+            type='testString',
+            limit=10,
+        )
+        while pager.has_next():
+            next_page = pager.get_next()
+            assert next_page is not None
+            all_results.extend(next_page)
+        assert len(all_results) == 2
+
+    @responses.activate
+    def test_get_credit_pools_with_pager_get_all(self):
+        """
+        test_get_credit_pools_with_pager_get_all()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v1/credit-pools')
+        mock_response1 = '{"total_count":2,"limit":1,"next_url":"https://myhost.com/somePath?start=1","resources":[{"type":"PLATFORM","currency_code":"USD","billing_unit_id":"billing_unit_id","term_credits":[{"billing_option_id":"JWX986YRGFSHACQUEFOI","category":"PLATFORM","start_date":"2019-05-01T00:00:00.000Z","end_date":"2020-04-30T23:59:29.999Z","total_credits":10000,"starting_balance":9000,"used_credits":9500,"current_balance":0,"resources":[{"anyKey":"anyValue"}]}],"overage":{"cost":500,"resources":[{"anyKey":"anyValue"}]}}]}'
+        mock_response2 = '{"total_count":2,"limit":1,"resources":[{"type":"PLATFORM","currency_code":"USD","billing_unit_id":"billing_unit_id","term_credits":[{"billing_option_id":"JWX986YRGFSHACQUEFOI","category":"PLATFORM","start_date":"2019-05-01T00:00:00.000Z","end_date":"2020-04-30T23:59:29.999Z","total_credits":10000,"starting_balance":9000,"used_credits":9500,"current_balance":0,"resources":[{"anyKey":"anyValue"}]}],"overage":{"cost":500,"resources":[{"anyKey":"anyValue"}]}}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response1,
+                      content_type='application/json',
+                      status=200)
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response2,
+                      content_type='application/json',
+                      status=200)
+
+        # Exercise the pager class for this operation
+        pager = GetCreditPoolsPager(
+            client=_service,
+            billing_unit_id='testString',
+            date='testString',
+            type='testString',
+            limit=10,
+        )
+        all_results = pager.get_all()
+        assert all_results is not None
+        assert len(all_results) == 2
 
 # endregion
 ##############################################################################
@@ -341,7 +800,7 @@ class TestGetCreditPools:
 # Start of Model Tests
 ##############################################################################
 # region
-class TestBillingOption:
+class TestModel_BillingOption():
     """
     Test Class for BillingOption
     """
@@ -355,17 +814,17 @@ class TestBillingOption:
         billing_option_model_json = {}
         billing_option_model_json['id'] = 'testString'
         billing_option_model_json['billing_unit_id'] = 'testString'
-        billing_option_model_json['start_date'] = '2020-01-28T18:40:40.123456Z'
-        billing_option_model_json['end_date'] = '2020-01-28T18:40:40.123456Z'
+        billing_option_model_json['start_date'] = '2019-05-01T00:00:00Z'
+        billing_option_model_json['end_date'] = '2020-05-01T00:00:00Z'
         billing_option_model_json['state'] = 'ACTIVE'
         billing_option_model_json['type'] = 'SUBSCRIPTION'
         billing_option_model_json['category'] = 'PLATFORM'
-        billing_option_model_json['payment_instrument'] = {}
+        billing_option_model_json['payment_instrument'] = {'foo': 'bar'}
         billing_option_model_json['duration_in_months'] = 11
         billing_option_model_json['line_item_id'] = 10
-        billing_option_model_json['billing_system'] = {}
+        billing_option_model_json['billing_system'] = {'foo': 'bar'}
         billing_option_model_json['renewal_mode_code'] = 'testString'
-        billing_option_model_json['updated_at'] = '2020-01-28T18:40:40.123456Z'
+        billing_option_model_json['updated_at'] = '2019-06-01T00:00:00Z'
 
         # Construct a model instance of BillingOption by calling from_dict on the json representation
         billing_option_model = BillingOption.from_dict(billing_option_model_json)
@@ -382,8 +841,7 @@ class TestBillingOption:
         billing_option_model_json2 = billing_option_model.to_dict()
         assert billing_option_model_json2 == billing_option_model_json
 
-
-class TestBillingOptionsList:
+class TestModel_BillingOptionsList():
     """
     Test Class for BillingOptionsList
     """
@@ -395,20 +853,20 @@ class TestBillingOptionsList:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        billing_option_model = {}  # BillingOption
+        billing_option_model = {} # BillingOption
         billing_option_model['id'] = 'CFL_JJKLVZ2I0JE-_MGU'
         billing_option_model['billing_unit_id'] = 'e19fa97c9bb34963a31a2008044d8b59'
-        billing_option_model['start_date'] = '2020-01-28T18:40:40.123456Z'
-        billing_option_model['end_date'] = '2020-01-28T18:40:40.123456Z'
+        billing_option_model['start_date'] = '2019-05-02T07:00:00Z'
+        billing_option_model['end_date'] = '2019-11-30T08:00:00Z'
         billing_option_model['state'] = 'ACTIVE'
         billing_option_model['type'] = 'SUBSCRIPTION'
         billing_option_model['category'] = 'PLATFORM'
-        billing_option_model['payment_instrument'] = {}
+        billing_option_model['payment_instrument'] = {'foo': 'bar'}
         billing_option_model['duration_in_months'] = 6
         billing_option_model['line_item_id'] = 10
-        billing_option_model['billing_system'] = {}
+        billing_option_model['billing_system'] = {'foo': 'bar'}
         billing_option_model['renewal_mode_code'] = 'T'
-        billing_option_model['updated_at'] = '2020-01-28T18:40:40.123456Z'
+        billing_option_model['updated_at'] = '2019-05-02T07:00:00Z'
 
         # Construct a json representation of a BillingOptionsList model
         billing_options_list_model_json = {}
@@ -431,8 +889,7 @@ class TestBillingOptionsList:
         billing_options_list_model_json2 = billing_options_list_model.to_dict()
         assert billing_options_list_model_json2 == billing_options_list_model_json
 
-
-class TestBillingUnit:
+class TestModel_BillingUnit():
     """
     Test Class for BillingUnit
     """
@@ -445,15 +902,13 @@ class TestBillingUnit:
         # Construct a json representation of a BillingUnit model
         billing_unit_model_json = {}
         billing_unit_model_json['id'] = 'testString'
-        billing_unit_model_json[
-            'crn'
-        ] = 'crn:v1:bluemix:public:billing::a/<<enterprise_account_id>>::billing-unit:<<billing_unit_id>>'
+        billing_unit_model_json['crn'] = 'crn:v1:bluemix:public:billing::a/<<enterprise_account_id>>::billing-unit:<<billing_unit_id>>'
         billing_unit_model_json['name'] = 'testString'
         billing_unit_model_json['enterprise_id'] = 'testString'
         billing_unit_model_json['currency_code'] = 'USD'
         billing_unit_model_json['country_code'] = 'USA'
         billing_unit_model_json['master'] = True
-        billing_unit_model_json['created_at'] = '2020-01-28T18:40:40.123456Z'
+        billing_unit_model_json['created_at'] = '2019-05-01T00:00:00Z'
 
         # Construct a model instance of BillingUnit by calling from_dict on the json representation
         billing_unit_model = BillingUnit.from_dict(billing_unit_model_json)
@@ -470,8 +925,7 @@ class TestBillingUnit:
         billing_unit_model_json2 = billing_unit_model.to_dict()
         assert billing_unit_model_json2 == billing_unit_model_json
 
-
-class TestBillingUnitsList:
+class TestModel_BillingUnitsList():
     """
     Test Class for BillingUnitsList
     """
@@ -483,17 +937,15 @@ class TestBillingUnitsList:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        billing_unit_model = {}  # BillingUnit
+        billing_unit_model = {} # BillingUnit
         billing_unit_model['id'] = '$BILLING_UNIT_ID'
-        billing_unit_model[
-            'crn'
-        ] = 'crn:v1:bluemix:public:billing::a/$ENTERPRISE_ACCOUNT_ID::billing-unit:$BILLING_UNIT_ID'
+        billing_unit_model['crn'] = 'crn:v1:bluemix:public:billing::a/$ENTERPRISE_ACCOUNT_ID::billing-unit:$BILLING_UNIT_ID'
         billing_unit_model['name'] = 'Sample Billing Unit'
         billing_unit_model['enterprise_id'] = '$ENTERPRISE_ID'
         billing_unit_model['currency_code'] = 'USD'
         billing_unit_model['country_code'] = 'USA'
         billing_unit_model['master'] = True
-        billing_unit_model['created_at'] = '2020-01-28T18:40:40.123456Z'
+        billing_unit_model['created_at'] = '2019-07-01T00:00:00Z'
 
         # Construct a json representation of a BillingUnitsList model
         billing_units_list_model_json = {}
@@ -516,8 +968,7 @@ class TestBillingUnitsList:
         billing_units_list_model_json2 = billing_units_list_model.to_dict()
         assert billing_units_list_model_json2 == billing_units_list_model_json
 
-
-class TestCreditPool:
+class TestModel_CreditPool():
     """
     Test Class for CreditPool
     """
@@ -529,20 +980,20 @@ class TestCreditPool:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        term_credits_model = {}  # TermCredits
+        term_credits_model = {} # TermCredits
         term_credits_model['billing_option_id'] = '$BILLING_OPTION_ID'
         term_credits_model['category'] = 'PLATFORM'
-        term_credits_model['start_date'] = '2020-01-28T18:40:40.123456Z'
-        term_credits_model['end_date'] = '2020-01-28T18:40:40.123456Z'
+        term_credits_model['start_date'] = '2019-07-01T01:00:00Z'
+        term_credits_model['end_date'] = '2020-06-30T23:59:59.999000Z'
         term_credits_model['total_credits'] = 7000
         term_credits_model['starting_balance'] = 6000
         term_credits_model['used_credits'] = 1000
         term_credits_model['current_balance'] = 5000
-        term_credits_model['resources'] = [{}]
+        term_credits_model['resources'] = []
 
-        credit_pool_overage_model = {}  # CreditPoolOverage
+        credit_pool_overage_model = {} # CreditPoolOverage
         credit_pool_overage_model['cost'] = 0
-        credit_pool_overage_model['resources'] = [{}]
+        credit_pool_overage_model['resources'] = []
 
         # Construct a json representation of a CreditPool model
         credit_pool_model_json = {}
@@ -567,8 +1018,7 @@ class TestCreditPool:
         credit_pool_model_json2 = credit_pool_model.to_dict()
         assert credit_pool_model_json2 == credit_pool_model_json
 
-
-class TestCreditPoolOverage:
+class TestModel_CreditPoolOverage():
     """
     Test Class for CreditPoolOverage
     """
@@ -581,7 +1031,7 @@ class TestCreditPoolOverage:
         # Construct a json representation of a CreditPoolOverage model
         credit_pool_overage_model_json = {}
         credit_pool_overage_model_json['cost'] = 500
-        credit_pool_overage_model_json['resources'] = [{}]
+        credit_pool_overage_model_json['resources'] = [{'foo': 'bar'}]
 
         # Construct a model instance of CreditPoolOverage by calling from_dict on the json representation
         credit_pool_overage_model = CreditPoolOverage.from_dict(credit_pool_overage_model_json)
@@ -598,8 +1048,7 @@ class TestCreditPoolOverage:
         credit_pool_overage_model_json2 = credit_pool_overage_model.to_dict()
         assert credit_pool_overage_model_json2 == credit_pool_overage_model_json
 
-
-class TestCreditPoolsList:
+class TestModel_CreditPoolsList():
     """
     Test Class for CreditPoolsList
     """
@@ -611,22 +1060,22 @@ class TestCreditPoolsList:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        term_credits_model = {}  # TermCredits
+        term_credits_model = {} # TermCredits
         term_credits_model['billing_option_id'] = '$BILLING_OPTION_ID'
         term_credits_model['category'] = 'PLATFORM'
-        term_credits_model['start_date'] = '2020-01-28T18:40:40.123456Z'
-        term_credits_model['end_date'] = '2020-01-28T18:40:40.123456Z'
+        term_credits_model['start_date'] = '2019-07-01T01:00:00Z'
+        term_credits_model['end_date'] = '2020-06-30T23:59:59.999000Z'
         term_credits_model['total_credits'] = 7000
         term_credits_model['starting_balance'] = 6000
         term_credits_model['used_credits'] = 1000
         term_credits_model['current_balance'] = 5000
-        term_credits_model['resources'] = [{}]
+        term_credits_model['resources'] = []
 
-        credit_pool_overage_model = {}  # CreditPoolOverage
+        credit_pool_overage_model = {} # CreditPoolOverage
         credit_pool_overage_model['cost'] = 0
-        credit_pool_overage_model['resources'] = [{}]
+        credit_pool_overage_model['resources'] = []
 
-        credit_pool_model = {}  # CreditPool
+        credit_pool_model = {} # CreditPool
         credit_pool_model['type'] = 'PLATFORM'
         credit_pool_model['currency_code'] = 'USD'
         credit_pool_model['billing_unit_id'] = '$BILLING_UNIT_ID'
@@ -654,8 +1103,7 @@ class TestCreditPoolsList:
         credit_pools_list_model_json2 = credit_pools_list_model.to_dict()
         assert credit_pools_list_model_json2 == credit_pools_list_model_json
 
-
-class TestTermCredits:
+class TestModel_TermCredits():
     """
     Test Class for TermCredits
     """
@@ -669,13 +1117,13 @@ class TestTermCredits:
         term_credits_model_json = {}
         term_credits_model_json['billing_option_id'] = 'JWX986YRGFSHACQUEFOI'
         term_credits_model_json['category'] = 'PLATFORM'
-        term_credits_model_json['start_date'] = '2020-01-28T18:40:40.123456Z'
-        term_credits_model_json['end_date'] = '2020-01-28T18:40:40.123456Z'
+        term_credits_model_json['start_date'] = '2019-05-01T00:00:00Z'
+        term_credits_model_json['end_date'] = '2020-04-30T23:59:29.999000Z'
         term_credits_model_json['total_credits'] = 10000
         term_credits_model_json['starting_balance'] = 9000
         term_credits_model_json['used_credits'] = 9500
         term_credits_model_json['current_balance'] = 0
-        term_credits_model_json['resources'] = [{}]
+        term_credits_model_json['resources'] = [{'foo': 'bar'}]
 
         # Construct a model instance of TermCredits by calling from_dict on the json representation
         term_credits_model = TermCredits.from_dict(term_credits_model_json)


### PR DESCRIPTION
## PR summary
Adds start and limit parameters to support pagination for certain Enterprise Billing Units APIs 


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
## Current vs new behavior  
Results can now be optionally paginated using the start and limit parameters.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

## Test results
```
$python3 -m pytest test/unit/test_enterprise_billing_units_v1.py                                           
============================================================== test session starts ==============================================================
platform darwin -- Python 3.10.8, pytest-7.2.0, pluggy-1.0.0
plugins: cov-2.12.1
collected 36 items                                                                                                                              

test/unit/test_enterprise_billing_units_v1.py ....................................                                                        [100%]

============================================================== 36 passed in 0.36s ===============================================================
```