### PR TITLE
feat(IAM Policy Management): Add support for policy templates

### DIFF
--- a/examples/test_iam_policy_management_v1_examples.py
+++ b/examples/test_iam_policy_management_v1_examples.py
@@ -49,6 +49,10 @@ example_policy_id = None
 example_policy_etag = None
 example_custom_role_id = None
 example_custom_role_etag = None
+example_template_id = None
+example_template_etag = None
+example_template_version = None
+example_assignment_id = None
 example_user_id = "IBMid-user1"
 example_service_name = "iam-groups"
 
@@ -539,6 +543,341 @@ class TestIamPolicyManagementV1Examples:
             print(json.dumps(response, indent=2))
 
             # end-delete_role
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_create_policy_template_example(self):
+        """
+        create_policy_template request example
+        """
+        try:
+            print('\ncreate_policy_template() result:')
+
+            global example_template_id
+            global example_template_version
+            # begin-create_policy_template
+
+            v2_policy_resource_attribute_model = {
+                'key': 'serviceType',
+                'operator': 'stringEquals',
+                'value': 'service',
+            }
+
+            v2_policy_resource_model = {
+                'attributes': [v2_policy_resource_attribute_model],
+            }
+
+            roles_model = {
+                'role_id': 'crn:v1:bluemix:public:iam::::role:Viewer',
+            }
+
+            grant_model = {
+                'roles': [roles_model],
+            }
+
+            control_model = {
+                'grant': grant_model,
+            }
+
+            template_policy_model = {
+                'type': 'access',
+                'resource': v2_policy_resource_model,
+                'control': control_model,
+            }
+
+            response = iam_policy_management_service.create_policy_template(
+                name='SDKExamplesTest',
+                account_id=example_account_id,
+                policy=template_policy_model,
+            )
+            policy_template = response.get_result()
+
+            print(json.dumps(policy_template, indent=2))
+
+            # end-create_policy_template
+
+            example_template_id = policy_template['id']
+            example_template_version = policy_template['version']
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_get_policy_template_example(self):
+        """
+        get_policy_template request example
+        """
+        try:
+            print('\nget_policy_template() result:')
+
+            global example_template_etag
+            # begin-get_policy_template
+
+            print('example_template_id: ', example_template_id)
+            response = iam_policy_management_service.get_policy_template(
+                policy_template_id=example_template_id,
+            )
+            policy_template = response.get_result()
+
+            print(json.dumps(policy_template, indent=2))
+
+            # end-get_policy_template
+
+            example_template_etag = response.get_headers().get("Etag")
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_replace_policy_template_example(self):
+        """
+        replace_policy_template request example
+        """
+        try:
+            print('\nreplace_policy_template() result:')
+            # begin-replace_policy_template
+
+            v2_policy_resource_attribute_model = {
+                'key': 'serviceType',
+                'operator': 'stringEquals',
+                'value': 'service',
+            }
+
+            v2_policy_resource_model = {
+                'attributes': [v2_policy_resource_attribute_model],
+            }
+
+            roles_model = {
+                'role_id': 'crn:v1:bluemix:public:iam::::role:Editor',
+            }
+
+            grant_model = {
+                'roles': [roles_model],
+            }
+
+            control_model = {
+                'grant': grant_model,
+            }
+
+            template_policy_model = {
+                'type': 'access',
+                'resource': v2_policy_resource_model,
+                'control': control_model,
+            }
+
+            response = iam_policy_management_service.replace_policy_template(
+                policy_template_id=example_template_id,
+                version=example_template_version,
+                if_match=example_template_etag,
+                policy=template_policy_model,
+            )
+            policy_template = response.get_result()
+
+            print(json.dumps(policy_template, indent=2))
+
+            # end-replace_policy_template
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_list_policy_templates_example(self):
+        """
+        list_policy_templates request example
+        """
+        try:
+            print('\nlist_policy_templates() result:')
+            # begin-list_policy_templates
+
+            response = iam_policy_management_service.list_policy_templates(
+                account_id=example_account_id,
+            )
+            policy_template_collection = response.get_result()
+
+            print(json.dumps(policy_template_collection, indent=2))
+
+            # end-list_policy_templates
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_create_policy_template_version_example(self):
+        """
+        create_policy_template_version request example
+        """
+        try:
+            print('\ncreate_policy_template_version() result:')
+            # begin-create_policy_template_version
+
+            v2_policy_resource_attribute_model = {
+                'key': 'serviceType',
+                'operator': 'stringEquals',
+                'value': 'service',
+            }
+
+            v2_policy_resource_model = {
+                'attributes': [v2_policy_resource_attribute_model],
+            }
+
+            roles_model = {
+                'role_id': 'crn:v1:bluemix:public:iam::::role:Viewer',
+            }
+
+            grant_model = {
+                'roles': [roles_model],
+            }
+
+            control_model = {
+                'grant': grant_model,
+            }
+
+            template_policy_model = {
+                'type': 'access',
+                'resource': v2_policy_resource_model,
+                'control': control_model,
+            }
+
+            response = iam_policy_management_service.create_policy_template_version(
+                policy_template_id=example_template_id,
+                policy=template_policy_model,
+            )
+            policy_template = response.get_result()
+
+            print(json.dumps(policy_template, indent=2))
+
+            # end-create_policy_template_version
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_list_policy_template_versions_example(self):
+        """
+        list_policy_template_versions request example
+        """
+        try:
+            print('\nlist_policy_template_versions() result:')
+            # begin-list_policy_template_versions
+
+            response = iam_policy_management_service.list_policy_template_versions(
+                policy_template_id=example_template_id,
+            )
+            policy_template_versions_collection = response.get_result()
+
+            print(json.dumps(policy_template_versions_collection, indent=2))
+
+            # end-list_policy_template_versions
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_get_policy_template_version_example(self):
+        """
+        get_policy_template_version request example
+        """
+        try:
+            print('\nget_policy_template_version() result:')
+            # begin-get_policy_template_version
+
+            response = iam_policy_management_service.get_policy_template_version(
+                policy_template_id=example_template_id,
+                version=example_template_version,
+            )
+            policy_template = response.get_result()
+
+            print(json.dumps(policy_template, indent=2))
+
+            # end-get_policy_template_version
+
+            example_template_etag = response.get_headers().get("Etag")
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_commit_policy_template_example(self):
+        """
+        commit_policy_template request example
+        """
+        try:
+            # begin-commit_policy_template
+
+            response = iam_policy_management_service.commit_policy_template(
+                policy_template_id=example_template_id,
+                version=example_template_version,
+                if_match=example_template_etag,
+            )
+
+            # end-commit_policy_template
+            print('\ncommit_policy_template() response status code: ', response.get_status_code())
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_list_policy_assignments_example(self):
+        """
+        list_policy_assignments request example
+        """
+        try:
+            print('\nlist_policy_assignments() result:')
+
+            global example_assignment_id
+            # begin-list_Policy Assignments
+
+            response = iam_policy_management_service.list_policy_assignments(
+                account_id=example_account_id,
+            )
+            polcy_template_assignment_collection = response.get_result()
+
+            print(json.dumps(polcy_template_assignment_collection, indent=2))
+
+            # end-list_Policy Assignments
+
+            example_assignment_id = polcy_template_assignment_collection['policy_assignments'][0]['id']
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_get_policy_assignment_example(self):
+        """
+        get_policy_assignment request example
+        """
+        try:
+            print('\nget_policy_assignment() result:')
+            # begin-get_policy_assignment
+
+            response = iam_policy_management_service.get_policy_assignment(
+                assignment_id=example_assignment_id,
+            )
+            policy_assignment_record = response.get_result()
+
+            print(json.dumps(policy_assignment_record, indent=2))
+
+            # end-get_policy_assignment
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_delete_policy_template_example(self):
+        """
+        delete_policy_template request example
+        """
+        try:
+            # begin-delete_policy_template
+
+            response = iam_policy_management_service.delete_policy_template(
+                policy_template_id=example_template_id,
+            )
+
+            # end-delete_policy_template
+            print('\ndelete_policy_template() response status code: ', response.get_status_code())
 
         except ApiException as e:
             pytest.fail(str(e))

--- a/ibm_platform_services/iam_policy_management_v1.py
+++ b/ibm_platform_services/iam_policy_management_v1.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# IBM OpenAPI SDK Code Generator Version: 3.68.2-ac7def68-20230310-195410
+# IBM OpenAPI SDK Code Generator Version: 3.65.0-79fc0b8f-20230209-215651
 
 """
 IAM Policy Management API
@@ -1340,6 +1340,588 @@ class IamPolicyManagementV1(BaseService):
         response = self.send(request, **kwargs)
         return response
 
+    #########################
+    # Policy Templates
+    #########################
+
+    def list_policy_templates(self, account_id: str, *, accept_language: str = None, **kwargs) -> DetailedResponse:
+        """
+        Get policy templates by attributes.
+
+        Get policy templates and filter by attributes through query parameters. The
+        following attributes are supported: account_id account_id is a required query
+        parameter. Only policy templates that have the specified attributes and that the
+        caller has read access to are returned. If the caller does not have read access to
+        any policy templates an empty array is returned.
+
+        :param str account_id: The account GUID that the policy templates belong
+               to.
+        :param str accept_language: (optional) Language code for translations
+               * `default` - English
+               * `de` -  German (Standard)
+               * `en` - English
+               * `es` - Spanish (Spain)
+               * `fr` - French (Standard)
+               * `it` - Italian (Standard)
+               * `ja` - Japanese
+               * `ko` - Korean
+               * `pt-br` - Portuguese (Brazil)
+               * `zh-cn` - Chinese (Simplified, PRC)
+               * `zh-tw` - (Chinese, Taiwan).
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `PolicyTemplateCollection` object
+        """
+
+        if not account_id:
+            raise ValueError('account_id must be provided')
+        headers = {
+            'Accept-Language': accept_language,
+        }
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='list_policy_templates'
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'account_id': account_id,
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v1/policy_templates'
+        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def create_policy_template(
+        self,
+        name: str,
+        account_id: str,
+        policy: 'TemplatePolicy',
+        *,
+        description: str = None,
+        committed: bool = None,
+        accept_language: str = None,
+        **kwargs
+    ) -> DetailedResponse:
+        """
+        Create a policy template.
+
+        Creates a policy template.
+
+        :param str name: name of template.
+        :param str account_id: account id where this template will be created.
+        :param TemplatePolicy policy: The core set of properties associated with
+               the template's policy objet.
+        :param str description: (optional) description of template purpose.
+        :param bool committed: (optional) committed status for the template.
+        :param str accept_language: (optional) Language code for translations
+               * `default` - English
+               * `de` -  German (Standard)
+               * `en` - English
+               * `es` - Spanish (Spain)
+               * `fr` - French (Standard)
+               * `it` - Italian (Standard)
+               * `ja` - Japanese
+               * `ko` - Korean
+               * `pt-br` - Portuguese (Brazil)
+               * `zh-cn` - Chinese (Simplified, PRC)
+               * `zh-tw` - (Chinese, Taiwan).
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `PolicyTemplate` object
+        """
+
+        if name is None:
+            raise ValueError('name must be provided')
+        if account_id is None:
+            raise ValueError('account_id must be provided')
+        if policy is None:
+            raise ValueError('policy must be provided')
+        policy = convert_model(policy)
+        headers = {
+            'Accept-Language': accept_language,
+        }
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='create_policy_template'
+        )
+        headers.update(sdk_headers)
+
+        data = {
+            'name': name,
+            'account_id': account_id,
+            'policy': policy,
+            'description': description,
+            'committed': committed,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v1/policy_templates'
+        request = self.prepare_request(method='POST', url=url, headers=headers, data=data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def get_policy_template(self, policy_template_id: str, **kwargs) -> DetailedResponse:
+        """
+        Retrieve latest policy template version by template ID.
+
+        Retrieve the latest version of a policy template by providing a policy template
+        ID.
+
+        :param str policy_template_id: The policy template ID.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `PolicyTemplate` object
+        """
+
+        if not policy_template_id:
+            raise ValueError('policy_template_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='get_policy_template'
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['policy_template_id']
+        path_param_values = self.encode_path_vars(policy_template_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/policy_templates/{policy_template_id}'.format(**path_param_dict)
+        request = self.prepare_request(method='GET', url=url, headers=headers)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def delete_policy_template(self, policy_template_id: str, **kwargs) -> DetailedResponse:
+        """
+        Delete a policy template by ID.
+
+        Delete a policy template by providing a policy template ID. This deletes all
+        versions of this template. A policy template cannot be deleted if the template
+        version is assigned to an account.
+
+        :param str policy_template_id: The policy template ID.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse
+        """
+
+        if not policy_template_id:
+            raise ValueError('policy_template_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='delete_policy_template'
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+
+        path_param_keys = ['policy_template_id']
+        path_param_values = self.encode_path_vars(policy_template_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/policy_templates/{policy_template_id}'.format(**path_param_dict)
+        request = self.prepare_request(method='DELETE', url=url, headers=headers)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def create_policy_template_version(
+        self, policy_template_id: str, policy: 'TemplatePolicy', *, description: str = None, **kwargs
+    ) -> DetailedResponse:
+        """
+        Create a new policy template version.
+
+        Creates a new policy template version Details TBD.
+
+        :param str policy_template_id: The policy template ID.
+        :param TemplatePolicy policy: The core set of properties associated with
+               the template's policy objet.
+        :param str description: (optional) description of template purpose.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `PolicyTemplate` object
+        """
+
+        if not policy_template_id:
+            raise ValueError('policy_template_id must be provided')
+        if policy is None:
+            raise ValueError('policy must be provided')
+        policy = convert_model(policy)
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='create_policy_template_version'
+        )
+        headers.update(sdk_headers)
+
+        data = {
+            'policy': policy,
+            'description': description,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['policy_template_id']
+        path_param_values = self.encode_path_vars(policy_template_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/policy_templates/{policy_template_id}/versions'.format(**path_param_dict)
+        request = self.prepare_request(method='POST', url=url, headers=headers, data=data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def list_policy_template_versions(self, policy_template_id: str, **kwargs) -> DetailedResponse:
+        """
+        Retrieve policy template versions.
+
+        Retrieve the versions of a policy template by providing a policy template ID.
+
+        :param str policy_template_id: The policy template ID.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `PolicyTemplateVersionsCollection` object
+        """
+
+        if not policy_template_id:
+            raise ValueError('policy_template_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='list_policy_template_versions'
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['policy_template_id']
+        path_param_values = self.encode_path_vars(policy_template_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/policy_templates/{policy_template_id}/versions'.format(**path_param_dict)
+        request = self.prepare_request(method='GET', url=url, headers=headers)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def replace_policy_template(
+        self,
+        policy_template_id: str,
+        version: str,
+        if_match: str,
+        policy: 'TemplatePolicy',
+        *,
+        description: str = None,
+        **kwargs
+    ) -> DetailedResponse:
+        """
+        Update a policy template version.
+
+        Update a policy template version  Details TBD.
+
+        :param str policy_template_id: The policy template ID.
+        :param str version: The policy template version.
+        :param str if_match: The revision number for updating a policy template
+               version and must match the ETag value of the existing policy template
+               version. The Etag can be retrieved using the GET
+               /v1/policy_templates/{policy_template_id}/versions/{version} API and
+               looking at the ETag response header.
+        :param TemplatePolicy policy: The core set of properties associated with
+               the template's policy objet.
+        :param str description: (optional) description of template purpose.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `PolicyTemplate` object
+        """
+
+        if not policy_template_id:
+            raise ValueError('policy_template_id must be provided')
+        if not version:
+            raise ValueError('version must be provided')
+        if not if_match:
+            raise ValueError('if_match must be provided')
+        if policy is None:
+            raise ValueError('policy must be provided')
+        policy = convert_model(policy)
+        headers = {
+            'If-Match': if_match,
+        }
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='replace_policy_template'
+        )
+        headers.update(sdk_headers)
+
+        data = {
+            'policy': policy,
+            'description': description,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['policy_template_id', 'version']
+        path_param_values = self.encode_path_vars(policy_template_id, version)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/policy_templates/{policy_template_id}/versions/{version}'.format(**path_param_dict)
+        request = self.prepare_request(method='PUT', url=url, headers=headers, data=data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def delete_policy_template_version(self, policy_template_id: str, version: str, **kwargs) -> DetailedResponse:
+        """
+        Delete a policy template version by ID and version.
+
+        Delete a policy template by providing a policy template ID and version. You can't
+        delete a policy template if the template version is assigned to an account.
+
+        :param str policy_template_id: The policy template ID.
+        :param str version: The policy template version.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse
+        """
+
+        if not policy_template_id:
+            raise ValueError('policy_template_id must be provided')
+        if not version:
+            raise ValueError('version must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='delete_policy_template_version'
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+
+        path_param_keys = ['policy_template_id', 'version']
+        path_param_values = self.encode_path_vars(policy_template_id, version)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/policy_templates/{policy_template_id}/versions/{version}'.format(**path_param_dict)
+        request = self.prepare_request(method='DELETE', url=url, headers=headers)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def get_policy_template_version(self, policy_template_id: str, version: str, **kwargs) -> DetailedResponse:
+        """
+        Retrieve a policy template version by ID.
+
+        Retrieve a policy template by providing a policy template ID and version.
+
+        :param str policy_template_id: The policy template ID.
+        :param str version: The policy template version.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `PolicyTemplate` object
+        """
+
+        if not policy_template_id:
+            raise ValueError('policy_template_id must be provided')
+        if not version:
+            raise ValueError('version must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='get_policy_template_version'
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['policy_template_id', 'version']
+        path_param_values = self.encode_path_vars(policy_template_id, version)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/policy_templates/{policy_template_id}/versions/{version}'.format(**path_param_dict)
+        request = self.prepare_request(method='GET', url=url, headers=headers)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def commit_policy_template(
+        self, policy_template_id: str, version: str, if_match: str, **kwargs
+    ) -> DetailedResponse:
+        """
+        Commit a policy template version.
+
+        Commit a policy template version  Details TBD.
+
+        :param str policy_template_id: The policy template ID.
+        :param str version: The policy template version.
+        :param str if_match: The revision number for updating a policy template
+               version and must match the ETag value of the existing policy template
+               version. The Etag can be retrieved using the GET
+               /v1/policy_templates/{policy_template_id}/versions/{version} API and
+               looking at the ETag response header.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse
+        """
+
+        if not policy_template_id:
+            raise ValueError('policy_template_id must be provided')
+        if not version:
+            raise ValueError('version must be provided')
+        if not if_match:
+            raise ValueError('if_match must be provided')
+        headers = {
+            'If-Match': if_match,
+        }
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='commit_policy_template'
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+
+        path_param_keys = ['policy_template_id', 'version']
+        path_param_values = self.encode_path_vars(policy_template_id, version)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/policy_templates/{policy_template_id}/versions/{version}/commit'.format(**path_param_dict)
+        request = self.prepare_request(method='POST', url=url, headers=headers)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    #########################
+    # Policy Assignments
+    #########################
+
+    def list_policy_assignments(
+        self,
+        account_id: str,
+        *,
+        accept_language: str = None,
+        template_id: str = None,
+        template_version: str = None,
+        **kwargs
+    ) -> DetailedResponse:
+        """
+        Get policies template assignments by attributes.
+
+        Get policy template assignments by attributes. The following attributes are
+        supported: account_id, template_id, template_version, sort account_id is a
+        required query parameter. Only policy template assignments that have the specified
+        attributes and that the caller has read access to are returned. If the caller does
+        not have read access to any policy template assignments an empty array is
+        returned.
+
+        :param str account_id: The account GUID in which the policies belong to.
+        :param str accept_language: (optional) Language code for translations
+               * `default` - English
+               * `de` -  German (Standard)
+               * `en` - English
+               * `es` - Spanish (Spain)
+               * `fr` - French (Standard)
+               * `it` - Italian (Standard)
+               * `ja` - Japanese
+               * `ko` - Korean
+               * `pt-br` - Portuguese (Brazil)
+               * `zh-cn` - Chinese (Simplified, PRC)
+               * `zh-tw` - (Chinese, Taiwan).
+        :param str template_id: (optional) Optional template id.
+        :param str template_version: (optional) Optional policy template version.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `PolcyTemplateAssignmentCollection` object
+        """
+
+        if not account_id:
+            raise ValueError('account_id must be provided')
+        headers = {
+            'Accept-Language': accept_language,
+        }
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='list_policy_assignments'
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'account_id': account_id,
+            'template_id': template_id,
+            'template_version': template_version,
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v1/policy_assignments'
+        request = self.prepare_request(method='GET', url=url, headers=headers, params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def get_policy_assignment(self, assignment_id: str, **kwargs) -> DetailedResponse:
+        """
+        Retrieve a policy assignment by ID.
+
+        Retrieve a policy template assignment by providing a policy assignment ID.
+
+        :param str assignment_id: The policy template assignment ID.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `PolicyAssignmentRecord` object
+        """
+
+        if not assignment_id:
+            raise ValueError('assignment_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME, service_version='V1', operation_id='get_policy_assignment'
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['assignment_id']
+        path_param_values = self.encode_path_vars(assignment_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/policy_assignments/{assignment_id}'.format(**path_param_dict)
+        request = self.prepare_request(method='GET', url=url, headers=headers)
+
+        response = self.send(request, **kwargs)
+        return response
+
 
 class ListPoliciesEnums:
     """
@@ -1465,6 +2047,60 @@ class GetV2PolicyEnums:
 ##############################################################################
 # Models
 ##############################################################################
+
+
+class AssignmentResourceCreated:
+    """
+    On success, includes the  policy assigned.
+
+    :attr str id: (optional) policy id.
+    """
+
+    def __init__(self, *, id: str = None) -> None:
+        """
+        Initialize a AssignmentResourceCreated object.
+
+        :param str id: (optional) policy id.
+        """
+        self.id = id
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'AssignmentResourceCreated':
+        """Initialize a AssignmentResourceCreated object from a json dictionary."""
+        args = {}
+        if 'id' in _dict:
+            args['id'] = _dict.get('id')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a AssignmentResourceCreated object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this AssignmentResourceCreated object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'AssignmentResourceCreated') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'AssignmentResourceCreated') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
 
 
 class Control:
@@ -1764,6 +2400,398 @@ class GrantWithEnrichedRoles:
         return not self == other
 
 
+class PolcyTemplateAssignmentCollection:
+    """
+    A collection of policies assignments.
+
+    :attr List[PolicyAssignmentRecord] policy_assignments: (optional) List of policy
+          assignments.
+    """
+
+    def __init__(self, *, policy_assignments: List['PolicyAssignmentRecord'] = None) -> None:
+        """
+        Initialize a PolcyTemplateAssignmentCollection object.
+
+        :param List[PolicyAssignmentRecord] policy_assignments: (optional) List of
+               policy assignments.
+        """
+        self.policy_assignments = policy_assignments
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolcyTemplateAssignmentCollection':
+        """Initialize a PolcyTemplateAssignmentCollection object from a json dictionary."""
+        args = {}
+        if 'policy_assignments' in _dict:
+            args['policy_assignments'] = [PolicyAssignmentRecord.from_dict(v) for v in _dict.get('policy_assignments')]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolcyTemplateAssignmentCollection object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'policy_assignments') and self.policy_assignments is not None:
+            policy_assignments_list = []
+            for v in self.policy_assignments:
+                if isinstance(v, dict):
+                    policy_assignments_list.append(v)
+                else:
+                    policy_assignments_list.append(v.to_dict())
+            _dict['policy_assignments'] = policy_assignments_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolcyTemplateAssignmentCollection object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolcyTemplateAssignmentCollection') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolcyTemplateAssignmentCollection') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class PolicyAssignmentRecord:
+    """
+    The set of properties associated with the policy template assignment.
+
+    :attr str template_id: policy template id.
+    :attr str template_version: policy template version.
+    :attr str assignment_id: Passed in value to correlate with other assignments.
+    :attr str target_type: Assignment target type.
+    :attr str target: assignment target id.
+    :attr str id: (optional) Policy assignment ID.
+    :attr str href: (optional) The href URL that links to the policies assignments
+          API by policy assignment ID.
+    :attr datetime created_at: (optional) The UTC timestamp when the policy
+          assignment was created.
+    :attr str created_by_id: (optional) The iam ID of the entity that created the
+          policy assignment.
+    :attr datetime last_modified_at: (optional) The UTC timestamp when the policy
+          assignment was last modified.
+    :attr str last_modified_by_id: (optional) The iam ID of the entity that last
+          modified the policy assignment.
+    :attr List[PolicyAssignmentResources] resources: (optional) Object for each
+          account assigned.
+    :attr str status: The policy assignment status.
+    """
+
+    def __init__(
+        self,
+        template_id: str,
+        template_version: str,
+        assignment_id: str,
+        target_type: str,
+        target: str,
+        status: str,
+        *,
+        id: str = None,
+        href: str = None,
+        created_at: datetime = None,
+        created_by_id: str = None,
+        last_modified_at: datetime = None,
+        last_modified_by_id: str = None,
+        resources: List['PolicyAssignmentResources'] = None
+    ) -> None:
+        """
+        Initialize a PolicyAssignmentRecord object.
+
+        :param str template_id: policy template id.
+        :param str template_version: policy template version.
+        :param str assignment_id: Passed in value to correlate with other
+               assignments.
+        :param str target_type: Assignment target type.
+        :param str target: assignment target id.
+        :param str status: The policy assignment status.
+        :param List[PolicyAssignmentResources] resources: (optional) Object for
+               each account assigned.
+        """
+        self.template_id = template_id
+        self.template_version = template_version
+        self.assignment_id = assignment_id
+        self.target_type = target_type
+        self.target = target
+        self.id = id
+        self.href = href
+        self.created_at = created_at
+        self.created_by_id = created_by_id
+        self.last_modified_at = last_modified_at
+        self.last_modified_by_id = last_modified_by_id
+        self.resources = resources
+        self.status = status
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolicyAssignmentRecord':
+        """Initialize a PolicyAssignmentRecord object from a json dictionary."""
+        args = {}
+        if 'template_id' in _dict:
+            args['template_id'] = _dict.get('template_id')
+        else:
+            raise ValueError('Required property \'template_id\' not present in PolicyAssignmentRecord JSON')
+        if 'template_version' in _dict:
+            args['template_version'] = _dict.get('template_version')
+        else:
+            raise ValueError('Required property \'template_version\' not present in PolicyAssignmentRecord JSON')
+        if 'assignment_id' in _dict:
+            args['assignment_id'] = _dict.get('assignment_id')
+        else:
+            raise ValueError('Required property \'assignment_id\' not present in PolicyAssignmentRecord JSON')
+        if 'target_type' in _dict:
+            args['target_type'] = _dict.get('target_type')
+        else:
+            raise ValueError('Required property \'target_type\' not present in PolicyAssignmentRecord JSON')
+        if 'target' in _dict:
+            args['target'] = _dict.get('target')
+        else:
+            raise ValueError('Required property \'target\' not present in PolicyAssignmentRecord JSON')
+        if 'id' in _dict:
+            args['id'] = _dict.get('id')
+        if 'href' in _dict:
+            args['href'] = _dict.get('href')
+        if 'created_at' in _dict:
+            args['created_at'] = string_to_datetime(_dict.get('created_at'))
+        if 'created_by_id' in _dict:
+            args['created_by_id'] = _dict.get('created_by_id')
+        if 'last_modified_at' in _dict:
+            args['last_modified_at'] = string_to_datetime(_dict.get('last_modified_at'))
+        if 'last_modified_by_id' in _dict:
+            args['last_modified_by_id'] = _dict.get('last_modified_by_id')
+        if 'resources' in _dict:
+            args['resources'] = [PolicyAssignmentResources.from_dict(v) for v in _dict.get('resources')]
+        if 'status' in _dict:
+            args['status'] = _dict.get('status')
+        else:
+            raise ValueError('Required property \'status\' not present in PolicyAssignmentRecord JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolicyAssignmentRecord object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'template_id') and self.template_id is not None:
+            _dict['template_id'] = self.template_id
+        if hasattr(self, 'template_version') and self.template_version is not None:
+            _dict['template_version'] = self.template_version
+        if hasattr(self, 'assignment_id') and self.assignment_id is not None:
+            _dict['assignment_id'] = self.assignment_id
+        if hasattr(self, 'target_type') and self.target_type is not None:
+            _dict['target_type'] = self.target_type
+        if hasattr(self, 'target') and self.target is not None:
+            _dict['target'] = self.target
+        if hasattr(self, 'id') and getattr(self, 'id') is not None:
+            _dict['id'] = getattr(self, 'id')
+        if hasattr(self, 'href') and getattr(self, 'href') is not None:
+            _dict['href'] = getattr(self, 'href')
+        if hasattr(self, 'created_at') and getattr(self, 'created_at') is not None:
+            _dict['created_at'] = datetime_to_string(getattr(self, 'created_at'))
+        if hasattr(self, 'created_by_id') and getattr(self, 'created_by_id') is not None:
+            _dict['created_by_id'] = getattr(self, 'created_by_id')
+        if hasattr(self, 'last_modified_at') and getattr(self, 'last_modified_at') is not None:
+            _dict['last_modified_at'] = datetime_to_string(getattr(self, 'last_modified_at'))
+        if hasattr(self, 'last_modified_by_id') and getattr(self, 'last_modified_by_id') is not None:
+            _dict['last_modified_by_id'] = getattr(self, 'last_modified_by_id')
+        if hasattr(self, 'resources') and self.resources is not None:
+            resources_list = []
+            for v in self.resources:
+                if isinstance(v, dict):
+                    resources_list.append(v)
+                else:
+                    resources_list.append(v.to_dict())
+            _dict['resources'] = resources_list
+        if hasattr(self, 'status') and self.status is not None:
+            _dict['status'] = self.status
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyAssignmentRecord object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyAssignmentRecord') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyAssignmentRecord') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class TargetTypeEnum(str, Enum):
+        """
+        Assignment target type.
+        """
+
+        ACCOUNT = 'Account'
+
+    class StatusEnum(str, Enum):
+        """
+        The policy assignment status.
+        """
+
+        IN_PROGRESS = 'in_progress'
+        SUCCEEDED = 'succeeded'
+        SUCCEED_WITH_ERRORS = 'succeed_with_errors'
+        FAILED = 'failed'
+
+
+class PolicyAssignmentResources:
+    """
+    The policy assignment resources.
+
+    :attr str target: (optional) Account ID where resources are assigned.
+    :attr PolicyAssignmentResourcesPolicy policy: (optional) Set of properties for
+          the assigned resource.
+    """
+
+    def __init__(self, *, target: str = None, policy: 'PolicyAssignmentResourcesPolicy' = None) -> None:
+        """
+        Initialize a PolicyAssignmentResources object.
+
+        :param str target: (optional) Account ID where resources are assigned.
+        :param PolicyAssignmentResourcesPolicy policy: (optional) Set of properties
+               for the assigned resource.
+        """
+        self.target = target
+        self.policy = policy
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolicyAssignmentResources':
+        """Initialize a PolicyAssignmentResources object from a json dictionary."""
+        args = {}
+        if 'target' in _dict:
+            args['target'] = _dict.get('target')
+        if 'policy' in _dict:
+            args['policy'] = PolicyAssignmentResourcesPolicy.from_dict(_dict.get('policy'))
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolicyAssignmentResources object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'target') and self.target is not None:
+            _dict['target'] = self.target
+        if hasattr(self, 'policy') and self.policy is not None:
+            if isinstance(self.policy, dict):
+                _dict['policy'] = self.policy
+            else:
+                _dict['policy'] = self.policy.to_dict()
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyAssignmentResources object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyAssignmentResources') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyAssignmentResources') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class PolicyAssignmentResourcesPolicy:
+    """
+    Set of properties for the assigned resource.
+
+    :attr AssignmentResourceCreated resource_created: On success, includes the
+          policy assigned.
+    :attr ErrorResponse error_message: (optional) The error response from API.
+    """
+
+    def __init__(self, resource_created: 'AssignmentResourceCreated', *, error_message: 'ErrorResponse' = None) -> None:
+        """
+        Initialize a PolicyAssignmentResourcesPolicy object.
+
+        :param AssignmentResourceCreated resource_created: On success, includes the
+                policy assigned.
+        :param ErrorResponse error_message: (optional) The error response from API.
+        """
+        self.resource_created = resource_created
+        self.error_message = error_message
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolicyAssignmentResourcesPolicy':
+        """Initialize a PolicyAssignmentResourcesPolicy object from a json dictionary."""
+        args = {}
+        if 'resource_created' in _dict:
+            args['resource_created'] = AssignmentResourceCreated.from_dict(_dict.get('resource_created'))
+        else:
+            raise ValueError(
+                'Required property \'resource_created\' not present in PolicyAssignmentResourcesPolicy JSON'
+            )
+        if 'error_message' in _dict:
+            args['error_message'] = ErrorResponse.from_dict(_dict.get('error_message'))
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolicyAssignmentResourcesPolicy object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'resource_created') and self.resource_created is not None:
+            if isinstance(self.resource_created, dict):
+                _dict['resource_created'] = self.resource_created
+            else:
+                _dict['resource_created'] = self.resource_created.to_dict()
+        if hasattr(self, 'error_message') and self.error_message is not None:
+            if isinstance(self.error_message, dict):
+                _dict['error_message'] = self.error_message
+            else:
+                _dict['error_message'] = self.error_message.to_dict()
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyAssignmentResourcesPolicy object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyAssignmentResourcesPolicy') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyAssignmentResourcesPolicy') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class PolicyRole:
     """
     A role associated with a policy.
@@ -1830,6 +2858,288 @@ class PolicyRole:
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other: 'PolicyRole') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class PolicyTemplate:
+    """
+    The core set of properties associated with the policy template.
+
+    :attr str name: name of template.
+    :attr str description: (optional) description of template purpose.
+    :attr str account_id: account id where this template will be created.
+    :attr str version: Template vesrsion.
+    :attr bool committed: (optional) Template vesrsion committed status.
+    :attr TemplatePolicy policy: The core set of properties associated with the
+          template's policy objet.
+    :attr str id: (optional) The policy template ID.
+    :attr str href: (optional) The href URL that links to the policy templates API
+          by policy tempalte ID.
+    :attr datetime created_at: (optional) The UTC timestamp when the policy template
+          was created.
+    :attr str created_by_id: (optional) The iam ID of the entity that created the
+          policy template.
+    :attr datetime last_modified_at: (optional) The UTC timestamp when the policy
+          template was last modified.
+    :attr str last_modified_by_id: (optional) The iam ID of the entity that last
+          modified the policy template.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        account_id: str,
+        version: str,
+        policy: 'TemplatePolicy',
+        *,
+        description: str = None,
+        committed: bool = None,
+        id: str = None,
+        href: str = None,
+        created_at: datetime = None,
+        created_by_id: str = None,
+        last_modified_at: datetime = None,
+        last_modified_by_id: str = None
+    ) -> None:
+        """
+        Initialize a PolicyTemplate object.
+
+        :param str name: name of template.
+        :param str account_id: account id where this template will be created.
+        :param str version: Template vesrsion.
+        :param TemplatePolicy policy: The core set of properties associated with
+               the template's policy objet.
+        :param str description: (optional) description of template purpose.
+        :param bool committed: (optional) Template vesrsion committed status.
+        """
+        self.name = name
+        self.description = description
+        self.account_id = account_id
+        self.version = version
+        self.committed = committed
+        self.policy = policy
+        self.id = id
+        self.href = href
+        self.created_at = created_at
+        self.created_by_id = created_by_id
+        self.last_modified_at = last_modified_at
+        self.last_modified_by_id = last_modified_by_id
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolicyTemplate':
+        """Initialize a PolicyTemplate object from a json dictionary."""
+        args = {}
+        if 'name' in _dict:
+            args['name'] = _dict.get('name')
+        else:
+            raise ValueError('Required property \'name\' not present in PolicyTemplate JSON')
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
+        if 'account_id' in _dict:
+            args['account_id'] = _dict.get('account_id')
+        else:
+            raise ValueError('Required property \'account_id\' not present in PolicyTemplate JSON')
+        if 'version' in _dict:
+            args['version'] = _dict.get('version')
+        else:
+            raise ValueError('Required property \'version\' not present in PolicyTemplate JSON')
+        if 'committed' in _dict:
+            args['committed'] = _dict.get('committed')
+        if 'policy' in _dict:
+            args['policy'] = TemplatePolicy.from_dict(_dict.get('policy'))
+        else:
+            raise ValueError('Required property \'policy\' not present in PolicyTemplate JSON')
+        if 'id' in _dict:
+            args['id'] = _dict.get('id')
+        if 'href' in _dict:
+            args['href'] = _dict.get('href')
+        if 'created_at' in _dict:
+            args['created_at'] = string_to_datetime(_dict.get('created_at'))
+        if 'created_by_id' in _dict:
+            args['created_by_id'] = _dict.get('created_by_id')
+        if 'last_modified_at' in _dict:
+            args['last_modified_at'] = string_to_datetime(_dict.get('last_modified_at'))
+        if 'last_modified_by_id' in _dict:
+            args['last_modified_by_id'] = _dict.get('last_modified_by_id')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolicyTemplate object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'account_id') and self.account_id is not None:
+            _dict['account_id'] = self.account_id
+        if hasattr(self, 'version') and self.version is not None:
+            _dict['version'] = self.version
+        if hasattr(self, 'committed') and self.committed is not None:
+            _dict['committed'] = self.committed
+        if hasattr(self, 'policy') and self.policy is not None:
+            if isinstance(self.policy, dict):
+                _dict['policy'] = self.policy
+            else:
+                _dict['policy'] = self.policy.to_dict()
+        if hasattr(self, 'id') and getattr(self, 'id') is not None:
+            _dict['id'] = getattr(self, 'id')
+        if hasattr(self, 'href') and getattr(self, 'href') is not None:
+            _dict['href'] = getattr(self, 'href')
+        if hasattr(self, 'created_at') and getattr(self, 'created_at') is not None:
+            _dict['created_at'] = datetime_to_string(getattr(self, 'created_at'))
+        if hasattr(self, 'created_by_id') and getattr(self, 'created_by_id') is not None:
+            _dict['created_by_id'] = getattr(self, 'created_by_id')
+        if hasattr(self, 'last_modified_at') and getattr(self, 'last_modified_at') is not None:
+            _dict['last_modified_at'] = datetime_to_string(getattr(self, 'last_modified_at'))
+        if hasattr(self, 'last_modified_by_id') and getattr(self, 'last_modified_by_id') is not None:
+            _dict['last_modified_by_id'] = getattr(self, 'last_modified_by_id')
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyTemplate object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyTemplate') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyTemplate') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class PolicyTemplateCollection:
+    """
+    A collection of policy Templates.
+
+    :attr List[PolicyTemplate] policy_templates: (optional) List of policy
+          templates.
+    """
+
+    def __init__(self, *, policy_templates: List['PolicyTemplate'] = None) -> None:
+        """
+        Initialize a PolicyTemplateCollection object.
+
+        :param List[PolicyTemplate] policy_templates: (optional) List of policy
+               templates.
+        """
+        self.policy_templates = policy_templates
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolicyTemplateCollection':
+        """Initialize a PolicyTemplateCollection object from a json dictionary."""
+        args = {}
+        if 'policy_templates' in _dict:
+            args['policy_templates'] = [PolicyTemplate.from_dict(v) for v in _dict.get('policy_templates')]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolicyTemplateCollection object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'policy_templates') and self.policy_templates is not None:
+            policy_templates_list = []
+            for v in self.policy_templates:
+                if isinstance(v, dict):
+                    policy_templates_list.append(v)
+                else:
+                    policy_templates_list.append(v.to_dict())
+            _dict['policy_templates'] = policy_templates_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyTemplateCollection object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyTemplateCollection') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyTemplateCollection') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class PolicyTemplateVersionsCollection:
+    """
+    A collection of policy Template versions.
+
+    :attr List[PolicyTemplate] versions: (optional) List of policy templates
+          versions.
+    """
+
+    def __init__(self, *, versions: List['PolicyTemplate'] = None) -> None:
+        """
+        Initialize a PolicyTemplateVersionsCollection object.
+
+        :param List[PolicyTemplate] versions: (optional) List of policy templates
+               versions.
+        """
+        self.versions = versions
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolicyTemplateVersionsCollection':
+        """Initialize a PolicyTemplateVersionsCollection object from a json dictionary."""
+        args = {}
+        if 'versions' in _dict:
+            args['versions'] = [PolicyTemplate.from_dict(v) for v in _dict.get('versions')]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolicyTemplateVersionsCollection object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'versions') and self.versions is not None:
+            versions_list = []
+            for v in self.versions:
+                if isinstance(v, dict):
+                    versions_list.append(v)
+                else:
+                    versions_list.append(v.to_dict())
+            _dict['versions'] = versions_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyTemplateVersionsCollection object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyTemplateVersionsCollection') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyTemplateVersionsCollection') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -2062,6 +3372,198 @@ class RuleAttribute:
         DAYOFWEEKANYOF = 'dayOfWeekAnyOf'
 
 
+class TemplateMetada:
+    """
+    Origin Template information.
+
+    :attr str crn: (optional) Origin Template CRN.
+    :attr str version: (optional) Template version.
+    """
+
+    def __init__(self, *, crn: str = None, version: str = None) -> None:
+        """
+        Initialize a TemplateMetada object.
+
+        :param str crn: (optional) Origin Template CRN.
+        :param str version: (optional) Template version.
+        """
+        self.crn = crn
+        self.version = version
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TemplateMetada':
+        """Initialize a TemplateMetada object from a json dictionary."""
+        args = {}
+        if 'crn' in _dict:
+            args['crn'] = _dict.get('crn')
+        if 'version' in _dict:
+            args['version'] = _dict.get('version')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TemplateMetada object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'crn') and self.crn is not None:
+            _dict['crn'] = self.crn
+        if hasattr(self, 'version') and self.version is not None:
+            _dict['version'] = self.version
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TemplateMetada object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TemplateMetada') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TemplateMetada') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class TemplatePolicy:
+    """
+    The core set of properties associated with the template's policy objet.
+
+    :attr str type: The policy type; either 'access' or 'authorization'.
+    :attr str description: (optional) Allows the customer to use their own words to
+          record the purpose/context related to a policy.
+    :attr V2PolicyResource resource: The resource attributes to which the policy
+          grants access.
+    :attr str pattern: (optional) Indicates pattern of rule, either
+          'time-based-conditions:once', 'time-based-conditions:weekly:all-day', or
+          'time-based-conditions:weekly:custom-hours'.
+    :attr V2PolicyRule rule: (optional) Additional access conditions associated with
+          the policy.
+    :attr Control control: Specifies the type of access granted by the policy.
+    """
+
+    def __init__(
+        self,
+        type: str,
+        resource: 'V2PolicyResource',
+        control: 'Control',
+        *,
+        description: str = None,
+        pattern: str = None,
+        rule: 'V2PolicyRule' = None
+    ) -> None:
+        """
+        Initialize a TemplatePolicy object.
+
+        :param str type: The policy type; either 'access' or 'authorization'.
+        :param V2PolicyResource resource: The resource attributes to which the
+               policy grants access.
+        :param Control control: Specifies the type of access granted by the policy.
+        :param str description: (optional) Allows the customer to use their own
+               words to record the purpose/context related to a policy.
+        :param str pattern: (optional) Indicates pattern of rule, either
+               'time-based-conditions:once', 'time-based-conditions:weekly:all-day', or
+               'time-based-conditions:weekly:custom-hours'.
+        :param V2PolicyRule rule: (optional) Additional access conditions
+               associated with the policy.
+        """
+        self.type = type
+        self.description = description
+        self.resource = resource
+        self.pattern = pattern
+        self.rule = rule
+        self.control = control
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TemplatePolicy':
+        """Initialize a TemplatePolicy object from a json dictionary."""
+        args = {}
+        if 'type' in _dict:
+            args['type'] = _dict.get('type')
+        else:
+            raise ValueError('Required property \'type\' not present in TemplatePolicy JSON')
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
+        if 'resource' in _dict:
+            args['resource'] = V2PolicyResource.from_dict(_dict.get('resource'))
+        else:
+            raise ValueError('Required property \'resource\' not present in TemplatePolicy JSON')
+        if 'pattern' in _dict:
+            args['pattern'] = _dict.get('pattern')
+        if 'rule' in _dict:
+            args['rule'] = _dict.get('rule')
+        if 'control' in _dict:
+            args['control'] = Control.from_dict(_dict.get('control'))
+        else:
+            raise ValueError('Required property \'control\' not present in TemplatePolicy JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TemplatePolicy object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'type') and self.type is not None:
+            _dict['type'] = self.type
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'resource') and self.resource is not None:
+            if isinstance(self.resource, dict):
+                _dict['resource'] = self.resource
+            else:
+                _dict['resource'] = self.resource.to_dict()
+        if hasattr(self, 'pattern') and self.pattern is not None:
+            _dict['pattern'] = self.pattern
+        if hasattr(self, 'rule') and self.rule is not None:
+            if isinstance(self.rule, dict):
+                _dict['rule'] = self.rule
+            else:
+                _dict['rule'] = self.rule.to_dict()
+        if hasattr(self, 'control') and self.control is not None:
+            if isinstance(self.control, dict):
+                _dict['control'] = self.control
+            else:
+                _dict['control'] = self.control.to_dict()
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TemplatePolicy object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TemplatePolicy') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TemplatePolicy') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class TypeEnum(str, Enum):
+        """
+        The policy type; either 'access' or 'authorization'.
+        """
+
+        ACCESS = 'access'
+        AUTHORIZATION = 'authorization'
+
+
 class V2Policy:
     """
     The core set of properties associated with the policy.
@@ -2096,6 +3598,7 @@ class V2Policy:
     :attr int last_permit_frequency: (optional) The optional count of times that
           policy has provided a permit, when passing query parameter
           format=include_last_permit.
+    :attr TemplateMetada template: (optional) Origin Template information.
     """
 
     def __init__(
@@ -2116,7 +3619,8 @@ class V2Policy:
         last_modified_at: datetime = None,
         last_modified_by_id: str = None,
         last_permit_at: str = None,
-        last_permit_frequency: int = None
+        last_permit_frequency: int = None,
+        template: 'TemplateMetada' = None
     ) -> None:
         """
         Initialize a V2Policy object.
@@ -2140,6 +3644,7 @@ class V2Policy:
         :param int last_permit_frequency: (optional) The optional count of times
                that policy has provided a permit, when passing query parameter
                format=include_last_permit.
+        :param TemplateMetada template: (optional) Origin Template information.
         """
         self.type = type
         self.description = description
@@ -2157,6 +3662,7 @@ class V2Policy:
         self.state = state
         self.last_permit_at = last_permit_at
         self.last_permit_frequency = last_permit_frequency
+        self.template = template
 
     @classmethod
     def from_dict(cls, _dict: Dict) -> 'V2Policy':
@@ -2200,6 +3706,8 @@ class V2Policy:
             args['last_permit_at'] = _dict.get('last_permit_at')
         if 'last_permit_frequency' in _dict:
             args['last_permit_frequency'] = _dict.get('last_permit_frequency')
+        if 'template' in _dict:
+            args['template'] = TemplateMetada.from_dict(_dict.get('template'))
         return cls(**args)
 
     @classmethod
@@ -2254,6 +3762,11 @@ class V2Policy:
             _dict['last_permit_at'] = self.last_permit_at
         if hasattr(self, 'last_permit_frequency') and self.last_permit_frequency is not None:
             _dict['last_permit_frequency'] = self.last_permit_frequency
+        if hasattr(self, 'template') and self.template is not None:
+            if isinstance(self.template, dict):
+                _dict['template'] = self.template
+            else:
+                _dict['template'] = self.template.to_dict()
         return _dict
 
     def _to_dict(self):
@@ -2766,6 +4279,74 @@ class V2PolicySubjectAttribute:
         STRINGEQUALS = 'stringEquals'
 
 
+class ConflictsWith:
+    """
+    Details of conflicting resource.
+
+    :attr str etag: (optional) The revision number of the resource.
+    :attr str role: (optional) The conflicting role id.
+    :attr str policy: (optional) The conflicting policy id.
+    """
+
+    def __init__(self, *, etag: str = None, role: str = None, policy: str = None) -> None:
+        """
+        Initialize a ConflictsWith object.
+
+        :param str etag: (optional) The revision number of the resource.
+        :param str role: (optional) The conflicting role id.
+        :param str policy: (optional) The conflicting policy id.
+        """
+        self.etag = etag
+        self.role = role
+        self.policy = policy
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'ConflictsWith':
+        """Initialize a ConflictsWith object from a json dictionary."""
+        args = {}
+        if 'etag' in _dict:
+            args['etag'] = _dict.get('etag')
+        if 'role' in _dict:
+            args['role'] = _dict.get('role')
+        if 'policy' in _dict:
+            args['policy'] = _dict.get('policy')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a ConflictsWith object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'etag') and self.etag is not None:
+            _dict['etag'] = self.etag
+        if hasattr(self, 'role') and self.role is not None:
+            _dict['role'] = self.role
+        if hasattr(self, 'policy') and self.policy is not None:
+            _dict['policy'] = self.policy
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this ConflictsWith object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'ConflictsWith') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'ConflictsWith') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class CustomRole:
     """
     An additional set of properties associated with a role.
@@ -2936,6 +4517,245 @@ class CustomRole:
         return not self == other
 
 
+class ErrorDetails:
+    """
+    Additional error details.
+
+    :attr ConflictsWith conflicts_with: (optional) Details of conflicting resource.
+    """
+
+    def __init__(self, *, conflicts_with: 'ConflictsWith' = None) -> None:
+        """
+        Initialize a ErrorDetails object.
+
+        :param ConflictsWith conflicts_with: (optional) Details of conflicting
+               resource.
+        """
+        self.conflicts_with = conflicts_with
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'ErrorDetails':
+        """Initialize a ErrorDetails object from a json dictionary."""
+        args = {}
+        if 'conflicts_with' in _dict:
+            args['conflicts_with'] = ConflictsWith.from_dict(_dict.get('conflicts_with'))
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a ErrorDetails object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'conflicts_with') and self.conflicts_with is not None:
+            if isinstance(self.conflicts_with, dict):
+                _dict['conflicts_with'] = self.conflicts_with
+            else:
+                _dict['conflicts_with'] = self.conflicts_with.to_dict()
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this ErrorDetails object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'ErrorDetails') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'ErrorDetails') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class ErrorObject:
+    """
+    ErrorObject.
+
+    :attr str code: The API error code for the error.
+    :attr str message: The error message returned by the API.
+    :attr ErrorDetails details: (optional) Additional error details.
+    :attr str more_info: (optional) Additional info for error.
+    """
+
+    def __init__(self, code: str, message: str, *, details: 'ErrorDetails' = None, more_info: str = None) -> None:
+        """
+        Initialize a ErrorObject object.
+
+        :param str code: The API error code for the error.
+        :param str message: The error message returned by the API.
+        :param ErrorDetails details: (optional) Additional error details.
+        :param str more_info: (optional) Additional info for error.
+        """
+        self.code = code
+        self.message = message
+        self.details = details
+        self.more_info = more_info
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'ErrorObject':
+        """Initialize a ErrorObject object from a json dictionary."""
+        args = {}
+        if 'code' in _dict:
+            args['code'] = _dict.get('code')
+        else:
+            raise ValueError('Required property \'code\' not present in ErrorObject JSON')
+        if 'message' in _dict:
+            args['message'] = _dict.get('message')
+        else:
+            raise ValueError('Required property \'message\' not present in ErrorObject JSON')
+        if 'details' in _dict:
+            args['details'] = ErrorDetails.from_dict(_dict.get('details'))
+        if 'more_info' in _dict:
+            args['more_info'] = _dict.get('more_info')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a ErrorObject object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'code') and self.code is not None:
+            _dict['code'] = self.code
+        if hasattr(self, 'message') and self.message is not None:
+            _dict['message'] = self.message
+        if hasattr(self, 'details') and self.details is not None:
+            if isinstance(self.details, dict):
+                _dict['details'] = self.details
+            else:
+                _dict['details'] = self.details.to_dict()
+        if hasattr(self, 'more_info') and self.more_info is not None:
+            _dict['more_info'] = self.more_info
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this ErrorObject object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'ErrorObject') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'ErrorObject') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class CodeEnum(str, Enum):
+        """
+        The API error code for the error.
+        """
+
+        INSUFFICENT_PERMISSIONS = 'insufficent_permissions'
+        INVALID_BODY = 'invalid_body'
+        INVALID_TOKEN = 'invalid_token'
+        MISSING_REQUIRED_QUERY_PARAMETER = 'missing_required_query_parameter'
+        NOT_FOUND = 'not_found'
+        POLICY_CONFLICT_ERROR = 'policy_conflict_error'
+        POLICY_NOT_FOUND = 'policy_not_found'
+        REQUEST_NOT_PROCESSED = 'request_not_processed'
+        ROLE_CONFLICT_ERROR = 'role_conflict_error'
+        ROLE_NOT_FOUND = 'role_not_found'
+        TOO_MANY_REQUESTS = 'too_many_requests'
+        UNABLE_TO_PROCESS = 'unable_to_process'
+        UNSUPPORTED_CONTENT_TYPE = 'unsupported_content_type'
+        POLICY_TEMPLATE_CONFLICT_ERROR = 'policy_template_conflict_error'
+        POLICY_TEMPLATE_NOT_FOUND = 'policy_template_not_found'
+        POLICY_ASSIGNMENT_NOT_FOUND = 'policy_assignment_not_found'
+        POLICY_ASSIGNMENT_CONFLICT_ERROR = 'policy_assignment_conflict_error'
+
+
+class ErrorResponse:
+    """
+    The error response from API.
+
+    :attr str trace: (optional) The unique transaction id for the request.
+    :attr List[ErrorObject] errors: (optional) The errors encountered during the
+          response.
+    :attr int status_code: (optional) The http error code of the response.
+    """
+
+    def __init__(self, *, trace: str = None, errors: List['ErrorObject'] = None, status_code: int = None) -> None:
+        """
+        Initialize a ErrorResponse object.
+
+        :param str trace: (optional) The unique transaction id for the request.
+        :param List[ErrorObject] errors: (optional) The errors encountered during
+               the response.
+        :param int status_code: (optional) The http error code of the response.
+        """
+        self.trace = trace
+        self.errors = errors
+        self.status_code = status_code
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'ErrorResponse':
+        """Initialize a ErrorResponse object from a json dictionary."""
+        args = {}
+        if 'trace' in _dict:
+            args['trace'] = _dict.get('trace')
+        if 'errors' in _dict:
+            args['errors'] = [ErrorObject.from_dict(v) for v in _dict.get('errors')]
+        if 'status_code' in _dict:
+            args['status_code'] = _dict.get('status_code')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a ErrorResponse object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'trace') and self.trace is not None:
+            _dict['trace'] = self.trace
+        if hasattr(self, 'errors') and self.errors is not None:
+            errors_list = []
+            for v in self.errors:
+                if isinstance(v, dict):
+                    errors_list.append(v)
+                else:
+                    errors_list.append(v.to_dict())
+            _dict['errors'] = errors_list
+        if hasattr(self, 'status_code') and self.status_code is not None:
+            _dict['status_code'] = self.status_code
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this ErrorResponse object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'ErrorResponse') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'ErrorResponse') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class Policy:
     """
     The core set of properties associated with a policy.
@@ -2957,6 +4777,7 @@ class Policy:
     :attr str last_modified_by_id: (optional) The iam ID of the entity that last
           modified the policy.
     :attr str state: (optional) The policy state.
+    :attr TemplateMetada template: (optional) Origin Template information.
     """
 
     def __init__(
@@ -2973,7 +4794,8 @@ class Policy:
         created_by_id: str = None,
         last_modified_at: datetime = None,
         last_modified_by_id: str = None,
-        state: str = None
+        state: str = None,
+        template: 'TemplateMetada' = None
     ) -> None:
         """
         Initialize a Policy object.
@@ -2986,6 +4808,7 @@ class Policy:
                policy.
         :param str description: (optional) Customer-defined description.
         :param str state: (optional) The policy state.
+        :param TemplateMetada template: (optional) Origin Template information.
         """
         self.id = id
         self.type = type
@@ -2999,6 +4822,7 @@ class Policy:
         self.last_modified_at = last_modified_at
         self.last_modified_by_id = last_modified_by_id
         self.state = state
+        self.template = template
 
     @classmethod
     def from_dict(cls, _dict: Dict) -> 'Policy':
@@ -3036,6 +4860,8 @@ class Policy:
             args['last_modified_by_id'] = _dict.get('last_modified_by_id')
         if 'state' in _dict:
             args['state'] = _dict.get('state')
+        if 'template' in _dict:
+            args['template'] = TemplateMetada.from_dict(_dict.get('template'))
         return cls(**args)
 
     @classmethod
@@ -3088,6 +4914,11 @@ class Policy:
             _dict['last_modified_by_id'] = getattr(self, 'last_modified_by_id')
         if hasattr(self, 'state') and self.state is not None:
             _dict['state'] = self.state
+        if hasattr(self, 'template') and self.template is not None:
+            if isinstance(self.template, dict):
+                _dict['template'] = self.template
+            else:
+                _dict['template'] = self.template.to_dict()
         return _dict
 
     def _to_dict(self):

--- a/test/integration/test_iam_policy_management_v1.py
+++ b/test/integration/test_iam_policy_management_v1.py
@@ -116,6 +116,24 @@ class TestIamPolicyManagementV1(unittest.TestCase):
             actions=['iam-groups.groups.read'],
         )
 
+        cls.testTemplateId = ""
+        cls.testTemplateETag = ""
+        cls.testTemplateVersion = ""
+        cls.testNewTemplateVersion = ""
+        cls.testAssignmentId = ""
+        cls.testV2PolicyTemplateResource = V2PolicyResource(
+            attributes=[
+                V2PolicyResourceAttribute(key='serviceType', value='service', operator='stringEquals'),
+            ],
+        )
+        cls.testTemplatePolicy = TemplatePolicy(
+            type='access',
+            control=cls.testV2PolicyControl,
+            resource=cls.testV2PolicyTemplateResource,
+            description='SDK Test Policy',
+        )
+        cls.testTemplateName = 'SDKPython' + str(random.randint(0, 99999))
+
         print('\nSetup complete.')
 
     @classmethod
@@ -154,6 +172,27 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         response = cls.service.delete_role(role_id=cls.testCustomRoleId)
         assert response is not None
         assert response.get_status_code() == 204
+
+        # Delete all the policy templates that we created during the test.
+        #
+        # List all policy templates in the account
+        response = cls.service.list_policy_templates(account_id=cls.testAccountId)
+        assert response is not None
+        assert response.get_status_code() == 200
+
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        result = PolicyTemplateCollection.from_dict(result_dict)
+        assert result is not None
+
+        for template in result.policy_templates:
+            now = datetime.now(timezone.utc)
+            minutesDifference = (now - policy.created_at).seconds / 60
+            if template.id == cls.testTemplateId or minutesDifference < 5:
+                response = cls.service.delete_policy_template(policy_template_id=template.id)
+                assert response is not None
+                assert response.get_status_code() == 204
 
         print('\nClean up complete.')
 
@@ -461,6 +500,9 @@ class TestIamPolicyManagementV1(unittest.TestCase):
 
         self.__class__.testPolicyETag = response.get_headers().get(self.etagHeader)
 
+        # Set role_id back to default
+        self.testV2PolicyControl.grant.roles[0].role_id = self.testViewerRoleCrn
+
     def test_13_list_v2_access_policies(self):
         print("Policy ID: ", self.testPolicyId)
 
@@ -511,3 +553,214 @@ class TestIamPolicyManagementV1(unittest.TestCase):
                 testServiceRolePresent = True
                 break
         assert testServiceRolePresent
+
+    def test_15_create_policy_template(self):
+
+        response = self.service.create_policy_template(
+            name=self.testTemplateName,
+            account_id=self.testAccountId,
+            policy=self.testTemplatePolicy,
+            description='SDK Test Policy Template',
+        )
+        assert response is not None
+
+        assert response.get_status_code() == 201
+
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        result = PolicyTemplate.from_dict(result_dict)
+        assert result is not None
+
+        self.__class__.testTemplateId = result.id
+        self.__class__.testTemplateVersion = result.version
+
+    def test_16_get_policy_template(self):
+        assert self.testTemplateId
+        print("Policy Tempate ID: ", self.testTemplateId)
+
+        response = self.service.get_policy_template(
+            policy_template_id=self.testTemplateId,
+        )
+        assert response is not None
+        assert response.get_status_code() == 200
+
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        result = PolicyTemplate.from_dict(result_dict)
+        assert result is not None
+
+        self.__class__.testTemplateETag = response.get_headers().get(self.etagHeader)
+
+    def test_17_replace_policy_template(self):
+        assert self.testTemplateId
+        assert self.testTemplateETag
+        assert self.testTemplateVersion
+
+        print("Policy Tempate ID: ", self.testTemplateId)
+        self.testV2PolicyControl.grant.roles[0].role_id = self.testEditorRoleCrn
+
+        updated_template_description = 'SDK Updated Test Policy Template'
+        response = self.service.replace_policy_template(
+            policy_template_id=self.testTemplateId,
+            version=self.testTemplateVersion,
+            if_match=self.testTemplateETag,
+            policy=self.testTemplatePolicy,
+            description=updated_template_description,
+        )
+
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        result = PolicyTemplate.from_dict(result_dict)
+        assert result is not None
+        assert result.description == updated_template_description
+
+    def test_18_list_policy_templates(self):
+        response = self.service.list_policy_templates(
+            account_id=self.testAccountId,
+            accept_language='default',
+        )
+
+        assert response.get_status_code() == 200
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        result = PolicyTemplateCollection.from_dict(result_dict)
+
+        print("Policy Template list: ", result)
+
+        # Confirm the test policy template is present
+        foundTestTemplate = False
+        for policy_template in result.policy_templates:
+            if policy_template.id == self.testTemplateId:
+                foundTestTemplate = True
+                break
+        assert foundTestTemplate
+
+    def test_19_create_policy_template_version(self):
+
+        self.testV2PolicyControl.grant.roles[0].role_id = self.testViewerRoleCrn
+        response = self.service.create_policy_template_version(
+            policy_template_id=self.testTemplateId,
+            policy=self.testTemplatePolicy,
+            description='SDK New Test Policy Template',
+        )
+
+        assert response.get_status_code() == 201
+        result_dict = response.get_result()
+        assert result_dict is not None
+        result = PolicyTemplate.from_dict(result_dict)
+        assert result is not None
+
+        assert result.version > self.testTemplateVersion
+        self.__class__.testNewTemplateVersion = result.version
+
+    def test_20_get_policy_template_version(self):
+        response = self.service.get_policy_template_version(
+            policy_template_id=self.testTemplateId,
+            version=self.testNewTemplateVersion,
+        )
+
+        assert response.get_status_code() == 200
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        self.__class__.testTemplateETag = response.get_headers().get(self.etagHeader)
+
+    def test_21_commit_policy_template(self):
+        response = self.service.commit_policy_template(
+            policy_template_id=self.testTemplateId,
+            version=self.testTemplateVersion,
+            if_match=self.testTemplateETag,
+        )
+
+        assert response.get_status_code() == 204
+
+        response = self.service.get_policy_template_version(
+            policy_template_id=self.testTemplateId,
+            version=self.testTemplateVersion,
+        )
+
+        assert response.get_status_code() == 200
+        self.__class__.testTemplateETag = response.get_headers().get(self.etagHeader)
+        assert self.testTemplateETag is not None
+
+        # Now that policy template is committed, should fail to update version
+        try:
+            response = self.service.replace_policy_template(
+                policy_template_id=self.testTemplateId,
+                version=self.testTemplateVersion,
+                if_match=self.testTemplateETag,
+                policy=self.testTemplatePolicy,
+                description='SDK Fail to Update Committed Version',
+            )
+        except ApiException as e:
+            assert (
+                e.message
+                == "Policy template id '"
+                + self.testTemplateId
+                + "' and version '"
+                + self.testTemplateVersion
+                + "' is committed and cannot be updated"
+            )
+
+    def test_22_delete_policy_template_version(self):
+
+        response = self.service.delete_policy_template_version(
+            policy_template_id=self.testTemplateId,
+            version=self.testTemplateVersion,
+        )
+
+        assert response.get_status_code() == 204
+
+    def test_23_list_policy_template_versions(self):
+
+        response = self.service.list_policy_template_versions(
+            policy_template_id=self.testTemplateId,
+        )
+
+        assert response.get_status_code() == 200
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        result = PolicyTemplateVersionsCollection.from_dict(result_dict)
+        assert result is not None
+        assert len(result.versions) == 1
+
+        # Confirm the test policy template with new version is present
+        foundTestTemplateVersion = False
+        for version in result.versions:
+            if version.version == self.testNewTemplateVersion:
+                foundTestTemplateVersion = True
+                break
+        assert foundTestTemplateVersion
+
+    def test_24_list_policy_assignments(self):
+        response = self.service.list_policy_assignments(
+            account_id=self.testAccountId,
+            accept_language='default',
+        )
+
+        assert response.get_status_code() == 200
+        result_dict = response.get_result()
+        assert result_dict is not None
+        result = PolcyTemplateAssignmentCollection.from_dict(result_dict)
+        assert result is not None
+
+        self.__class__.testAssignmentId = result.policy_assignments[0].id
+
+    def test_25_get_policy_assignment(self):
+
+        response = self.service.get_policy_assignment(
+            assignment_id=self.testAssignmentId,
+        )
+
+        assert response.get_status_code() == 200
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        result = PolicyAssignmentRecord.from_dict(result_dict)
+        assert result is not None
+        assert result.id == self.testAssignmentId

--- a/test/unit/test_iam_policy_management_v1.py
+++ b/test/unit/test_iam_policy_management_v1.py
@@ -59,7 +59,8 @@ def preprocess_url(operation_path: str):
     # Otherwise, return a regular expression that matches one or more trailing /.
     if re.fullmatch('.*/+', request_url) is None:
         return request_url
-    return re.compile(request_url.rstrip('/') + '/+')
+    else:
+        return re.compile(request_url.rstrip('/') + '/+')
 
 
 ##############################################################################
@@ -108,7 +109,7 @@ class TestListPolicies:
         """
         # Set up mock
         url = preprocess_url('/v1/policies')
-        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
+        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"crn": "crn", "version": "version"}}]}'
         responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
@@ -173,7 +174,7 @@ class TestListPolicies:
         """
         # Set up mock
         url = preprocess_url('/v1/policies')
-        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
+        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"crn": "crn", "version": "version"}}]}'
         responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
@@ -206,7 +207,7 @@ class TestListPolicies:
         """
         # Set up mock
         url = preprocess_url('/v1/policies')
-        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}]}'
+        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"crn": "crn", "version": "version"}}]}'
         responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
@@ -243,7 +244,7 @@ class TestCreatePolicy:
         """
         # Set up mock
         url = preprocess_url('/v1/policies')
-        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Construct a dict representation of a SubjectAttribute model
@@ -316,7 +317,7 @@ class TestCreatePolicy:
         """
         # Set up mock
         url = preprocess_url('/v1/policies')
-        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Construct a dict representation of a SubjectAttribute model
@@ -386,7 +387,7 @@ class TestCreatePolicy:
         """
         # Set up mock
         url = preprocess_url('/v1/policies')
-        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Construct a dict representation of a SubjectAttribute model
@@ -460,7 +461,7 @@ class TestReplacePolicy:
         """
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
-        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
 
         # Construct a dict representation of a SubjectAttribute model
@@ -534,7 +535,7 @@ class TestReplacePolicy:
         """
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
-        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
 
         # Construct a dict representation of a SubjectAttribute model
@@ -612,7 +613,7 @@ class TestGetPolicy:
         """
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
-        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
@@ -641,7 +642,7 @@ class TestGetPolicy:
         """
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
-        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
@@ -742,7 +743,7 @@ class TestUpdatePolicyState:
         """
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
-        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.PATCH, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
@@ -776,7 +777,7 @@ class TestUpdatePolicyState:
         """
         # Set up mock
         url = preprocess_url('/v1/policies/testString')
-        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active"}'
+        mock_response = '{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.PATCH, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
@@ -1330,7 +1331,7 @@ class TestListV2Policies:
         """
         # Set up mock
         url = preprocess_url('/v2/policies')
-        mock_response = '{"policies": [{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}]}'
+        mock_response = '{"policies": [{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"crn": "crn", "version": "version"}}]}'
         responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
@@ -1395,7 +1396,7 @@ class TestListV2Policies:
         """
         # Set up mock
         url = preprocess_url('/v2/policies')
-        mock_response = '{"policies": [{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}]}'
+        mock_response = '{"policies": [{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"crn": "crn", "version": "version"}}]}'
         responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
@@ -1428,7 +1429,7 @@ class TestListV2Policies:
         """
         # Set up mock
         url = preprocess_url('/v2/policies')
-        mock_response = '{"policies": [{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}]}'
+        mock_response = '{"policies": [{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"crn": "crn", "version": "version"}}]}'
         responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
@@ -1465,7 +1466,7 @@ class TestCreateV2Policy:
         """
         # Set up mock
         url = preprocess_url('/v2/policies')
-        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}'
+        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Construct a dict representation of a Roles model
@@ -1565,7 +1566,7 @@ class TestCreateV2Policy:
         """
         # Set up mock
         url = preprocess_url('/v2/policies')
-        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}'
+        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Construct a dict representation of a Roles model
@@ -1663,7 +1664,7 @@ class TestCreateV2Policy:
         """
         # Set up mock
         url = preprocess_url('/v2/policies')
-        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}'
+        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
 
         # Construct a dict representation of a Roles model
@@ -1752,7 +1753,7 @@ class TestReplaceV2Policy:
         """
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
-        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}'
+        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
 
         # Construct a dict representation of a Roles model
@@ -1854,7 +1855,7 @@ class TestReplaceV2Policy:
         """
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
-        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}'
+        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
 
         # Construct a dict representation of a Roles model
@@ -1947,7 +1948,7 @@ class TestGetV2Policy:
         """
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
-        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}'
+        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
@@ -1981,7 +1982,7 @@ class TestGetV2Policy:
         """
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
-        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}'
+        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
@@ -2010,7 +2011,7 @@ class TestGetV2Policy:
         """
         # Set up mock
         url = preprocess_url('/v2/policies/testString')
-        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21}'
+        mock_response = '{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "value"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"crn": "crn", "version": "version"}}'
         responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
 
         # Set up parameter values
@@ -2104,11 +2105,1409 @@ class TestDeleteV2Policy:
 # End of Service: V2Policies
 ##############################################################################
 
+##############################################################################
+# Start of Service: PolicyTemplates
+##############################################################################
+# region
+
+
+class TestNewInstance:
+    """
+    Test Class for new_instance
+    """
+
+    def test_new_instance(self):
+        """
+        new_instance()
+        """
+        os.environ['TEST_SERVICE_AUTH_TYPE'] = 'noAuth'
+
+        service = IamPolicyManagementV1.new_instance(
+            service_name='TEST_SERVICE',
+        )
+
+        assert service is not None
+        assert isinstance(service, IamPolicyManagementV1)
+
+    def test_new_instance_without_authenticator(self):
+        """
+        new_instance_without_authenticator()
+        """
+        with pytest.raises(ValueError, match='authenticator must be provided'):
+            service = IamPolicyManagementV1.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
+
+
+class TestListPolicyTemplates:
+    """
+    Test Class for list_policy_templates
+    """
+
+    @responses.activate
+    def test_list_policy_templates_all_params(self):
+        """
+        list_policy_templates()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates')
+        mock_response = '{"policy_templates": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        account_id = 'testString'
+        accept_language = 'default'
+
+        # Invoke method
+        response = _service.list_policy_templates(account_id, accept_language=accept_language, headers={})
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'account_id={}'.format(account_id) in query_string
+
+    def test_list_policy_templates_all_params_with_retries(self):
+        # Enable retries and run test_list_policy_templates_all_params.
+        _service.enable_retries()
+        self.test_list_policy_templates_all_params()
+
+        # Disable retries and run test_list_policy_templates_all_params.
+        _service.disable_retries()
+        self.test_list_policy_templates_all_params()
+
+    @responses.activate
+    def test_list_policy_templates_required_params(self):
+        """
+        test_list_policy_templates_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates')
+        mock_response = '{"policy_templates": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        account_id = 'testString'
+
+        # Invoke method
+        response = _service.list_policy_templates(account_id, headers={})
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'account_id={}'.format(account_id) in query_string
+
+    def test_list_policy_templates_required_params_with_retries(self):
+        # Enable retries and run test_list_policy_templates_required_params.
+        _service.enable_retries()
+        self.test_list_policy_templates_required_params()
+
+        # Disable retries and run test_list_policy_templates_required_params.
+        _service.disable_retries()
+        self.test_list_policy_templates_required_params()
+
+    @responses.activate
+    def test_list_policy_templates_value_error(self):
+        """
+        test_list_policy_templates_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates')
+        mock_response = '{"policy_templates": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        account_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "account_id": account_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.list_policy_templates(**req_copy)
+
+    def test_list_policy_templates_value_error_with_retries(self):
+        # Enable retries and run test_list_policy_templates_value_error.
+        _service.enable_retries()
+        self.test_list_policy_templates_value_error()
+
+        # Disable retries and run test_list_policy_templates_value_error.
+        _service.disable_retries()
+        self.test_list_policy_templates_value_error()
+
+
+class TestCreatePolicyTemplate:
+    """
+    Test Class for create_policy_template
+    """
+
+    @responses.activate
+    def test_create_policy_template_all_params(self):
+        """
+        create_policy_template()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates')
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
+
+        # Construct a dict representation of a V2PolicyResourceAttribute model
+        v2_policy_resource_attribute_model = {}
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyResourceTag model
+        v2_policy_resource_tag_model = {}
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        # Construct a dict representation of a V2PolicyResource model
+        v2_policy_resource_model = {}
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        # Construct a dict representation of a V2PolicyRuleRuleAttribute model
+        v2_policy_rule_model = {}
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
+
+        # Construct a dict representation of a Roles model
+        roles_model = {}
+        roles_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a Grant model
+        grant_model = {}
+        grant_model['roles'] = [roles_model]
+
+        # Construct a dict representation of a Control model
+        control_model = {}
+        control_model['grant'] = grant_model
+
+        # Construct a dict representation of a TemplatePolicy model
+        template_policy_model = {}
+        template_policy_model['type'] = 'access'
+        template_policy_model['description'] = 'testString'
+        template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['pattern'] = 'testString'
+        template_policy_model['rule'] = v2_policy_rule_model
+        template_policy_model['control'] = control_model
+
+        # Set up parameter values
+        name = 'testString'
+        account_id = 'testString'
+        policy = template_policy_model
+        description = 'testString'
+        committed = True
+        accept_language = 'default'
+
+        # Invoke method
+        response = _service.create_policy_template(
+            name,
+            account_id,
+            policy,
+            description=description,
+            committed=committed,
+            accept_language=accept_language,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['name'] == 'testString'
+        assert req_body['account_id'] == 'testString'
+        assert req_body['policy'] == template_policy_model
+        assert req_body['description'] == 'testString'
+        assert req_body['committed'] == True
+
+    def test_create_policy_template_all_params_with_retries(self):
+        # Enable retries and run test_create_policy_template_all_params.
+        _service.enable_retries()
+        self.test_create_policy_template_all_params()
+
+        # Disable retries and run test_create_policy_template_all_params.
+        _service.disable_retries()
+        self.test_create_policy_template_all_params()
+
+    @responses.activate
+    def test_create_policy_template_required_params(self):
+        """
+        test_create_policy_template_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates')
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
+
+        # Construct a dict representation of a V2PolicyResourceAttribute model
+        v2_policy_resource_attribute_model = {}
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyResourceTag model
+        v2_policy_resource_tag_model = {}
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        # Construct a dict representation of a V2PolicyResource model
+        v2_policy_resource_model = {}
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        # Construct a dict representation of a V2PolicyRuleRuleAttribute model
+        v2_policy_rule_model = {}
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
+
+        # Construct a dict representation of a Roles model
+        roles_model = {}
+        roles_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a Grant model
+        grant_model = {}
+        grant_model['roles'] = [roles_model]
+
+        # Construct a dict representation of a Control model
+        control_model = {}
+        control_model['grant'] = grant_model
+
+        # Construct a dict representation of a TemplatePolicy model
+        template_policy_model = {}
+        template_policy_model['type'] = 'access'
+        template_policy_model['description'] = 'testString'
+        template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['pattern'] = 'testString'
+        template_policy_model['rule'] = v2_policy_rule_model
+        template_policy_model['control'] = control_model
+
+        # Set up parameter values
+        name = 'testString'
+        account_id = 'testString'
+        policy = template_policy_model
+        description = 'testString'
+        committed = True
+
+        # Invoke method
+        response = _service.create_policy_template(
+            name, account_id, policy, description=description, committed=committed, headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['name'] == 'testString'
+        assert req_body['account_id'] == 'testString'
+        assert req_body['policy'] == template_policy_model
+        assert req_body['description'] == 'testString'
+        assert req_body['committed'] == True
+
+    def test_create_policy_template_required_params_with_retries(self):
+        # Enable retries and run test_create_policy_template_required_params.
+        _service.enable_retries()
+        self.test_create_policy_template_required_params()
+
+        # Disable retries and run test_create_policy_template_required_params.
+        _service.disable_retries()
+        self.test_create_policy_template_required_params()
+
+    @responses.activate
+    def test_create_policy_template_value_error(self):
+        """
+        test_create_policy_template_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates')
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
+
+        # Construct a dict representation of a V2PolicyResourceAttribute model
+        v2_policy_resource_attribute_model = {}
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyResourceTag model
+        v2_policy_resource_tag_model = {}
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        # Construct a dict representation of a V2PolicyResource model
+        v2_policy_resource_model = {}
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        # Construct a dict representation of a V2PolicyRuleRuleAttribute model
+        v2_policy_rule_model = {}
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
+
+        # Construct a dict representation of a Roles model
+        roles_model = {}
+        roles_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a Grant model
+        grant_model = {}
+        grant_model['roles'] = [roles_model]
+
+        # Construct a dict representation of a Control model
+        control_model = {}
+        control_model['grant'] = grant_model
+
+        # Construct a dict representation of a TemplatePolicy model
+        template_policy_model = {}
+        template_policy_model['type'] = 'access'
+        template_policy_model['description'] = 'testString'
+        template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['pattern'] = 'testString'
+        template_policy_model['rule'] = v2_policy_rule_model
+        template_policy_model['control'] = control_model
+
+        # Set up parameter values
+        name = 'testString'
+        account_id = 'testString'
+        policy = template_policy_model
+        description = 'testString'
+        committed = True
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "name": name,
+            "account_id": account_id,
+            "policy": policy,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.create_policy_template(**req_copy)
+
+    def test_create_policy_template_value_error_with_retries(self):
+        # Enable retries and run test_create_policy_template_value_error.
+        _service.enable_retries()
+        self.test_create_policy_template_value_error()
+
+        # Disable retries and run test_create_policy_template_value_error.
+        _service.disable_retries()
+        self.test_create_policy_template_value_error()
+
+
+class TestGetPolicyTemplate:
+    """
+    Test Class for get_policy_template
+    """
+
+    @responses.activate
+    def test_get_policy_template_all_params(self):
+        """
+        get_policy_template()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates/testString')
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        policy_template_id = 'testString'
+
+        # Invoke method
+        response = _service.get_policy_template(policy_template_id, headers={})
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_policy_template_all_params_with_retries(self):
+        # Enable retries and run test_get_policy_template_all_params.
+        _service.enable_retries()
+        self.test_get_policy_template_all_params()
+
+        # Disable retries and run test_get_policy_template_all_params.
+        _service.disable_retries()
+        self.test_get_policy_template_all_params()
+
+    @responses.activate
+    def test_get_policy_template_value_error(self):
+        """
+        test_get_policy_template_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates/testString')
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        policy_template_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "policy_template_id": policy_template_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_policy_template(**req_copy)
+
+    def test_get_policy_template_value_error_with_retries(self):
+        # Enable retries and run test_get_policy_template_value_error.
+        _service.enable_retries()
+        self.test_get_policy_template_value_error()
+
+        # Disable retries and run test_get_policy_template_value_error.
+        _service.disable_retries()
+        self.test_get_policy_template_value_error()
+
+
+class TestDeletePolicyTemplate:
+    """
+    Test Class for delete_policy_template
+    """
+
+    @responses.activate
+    def test_delete_policy_template_all_params(self):
+        """
+        delete_policy_template()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates/testString')
+        responses.add(responses.DELETE, url, status=204)
+
+        # Set up parameter values
+        policy_template_id = 'testString'
+
+        # Invoke method
+        response = _service.delete_policy_template(policy_template_id, headers={})
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_delete_policy_template_all_params_with_retries(self):
+        # Enable retries and run test_delete_policy_template_all_params.
+        _service.enable_retries()
+        self.test_delete_policy_template_all_params()
+
+        # Disable retries and run test_delete_policy_template_all_params.
+        _service.disable_retries()
+        self.test_delete_policy_template_all_params()
+
+    @responses.activate
+    def test_delete_policy_template_value_error(self):
+        """
+        test_delete_policy_template_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates/testString')
+        responses.add(responses.DELETE, url, status=204)
+
+        # Set up parameter values
+        policy_template_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "policy_template_id": policy_template_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_policy_template(**req_copy)
+
+    def test_delete_policy_template_value_error_with_retries(self):
+        # Enable retries and run test_delete_policy_template_value_error.
+        _service.enable_retries()
+        self.test_delete_policy_template_value_error()
+
+        # Disable retries and run test_delete_policy_template_value_error.
+        _service.disable_retries()
+        self.test_delete_policy_template_value_error()
+
+
+class TestCreatePolicyTemplateVersion:
+    """
+    Test Class for create_policy_template_version
+    """
+
+    @responses.activate
+    def test_create_policy_template_version_all_params(self):
+        """
+        create_policy_template_version()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates/testString/versions')
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
+
+        # Construct a dict representation of a V2PolicyResourceAttribute model
+        v2_policy_resource_attribute_model = {}
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyResourceTag model
+        v2_policy_resource_tag_model = {}
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        # Construct a dict representation of a V2PolicyResource model
+        v2_policy_resource_model = {}
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        # Construct a dict representation of a V2PolicyRuleRuleAttribute model
+        v2_policy_rule_model = {}
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
+
+        # Construct a dict representation of a Roles model
+        roles_model = {}
+        roles_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a Grant model
+        grant_model = {}
+        grant_model['roles'] = [roles_model]
+
+        # Construct a dict representation of a Control model
+        control_model = {}
+        control_model['grant'] = grant_model
+
+        # Construct a dict representation of a TemplatePolicy model
+        template_policy_model = {}
+        template_policy_model['type'] = 'access'
+        template_policy_model['description'] = 'testString'
+        template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['pattern'] = 'testString'
+        template_policy_model['rule'] = v2_policy_rule_model
+        template_policy_model['control'] = control_model
+
+        # Set up parameter values
+        policy_template_id = 'testString'
+        policy = template_policy_model
+        description = 'testString'
+
+        # Invoke method
+        response = _service.create_policy_template_version(
+            policy_template_id, policy, description=description, headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['policy'] == template_policy_model
+        assert req_body['description'] == 'testString'
+
+    def test_create_policy_template_version_all_params_with_retries(self):
+        # Enable retries and run test_create_policy_template_version_all_params.
+        _service.enable_retries()
+        self.test_create_policy_template_version_all_params()
+
+        # Disable retries and run test_create_policy_template_version_all_params.
+        _service.disable_retries()
+        self.test_create_policy_template_version_all_params()
+
+    @responses.activate
+    def test_create_policy_template_version_value_error(self):
+        """
+        test_create_policy_template_version_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates/testString/versions')
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(responses.POST, url, body=mock_response, content_type='application/json', status=201)
+
+        # Construct a dict representation of a V2PolicyResourceAttribute model
+        v2_policy_resource_attribute_model = {}
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyResourceTag model
+        v2_policy_resource_tag_model = {}
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        # Construct a dict representation of a V2PolicyResource model
+        v2_policy_resource_model = {}
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        # Construct a dict representation of a V2PolicyRuleRuleAttribute model
+        v2_policy_rule_model = {}
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
+
+        # Construct a dict representation of a Roles model
+        roles_model = {}
+        roles_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a Grant model
+        grant_model = {}
+        grant_model['roles'] = [roles_model]
+
+        # Construct a dict representation of a Control model
+        control_model = {}
+        control_model['grant'] = grant_model
+
+        # Construct a dict representation of a TemplatePolicy model
+        template_policy_model = {}
+        template_policy_model['type'] = 'access'
+        template_policy_model['description'] = 'testString'
+        template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['pattern'] = 'testString'
+        template_policy_model['rule'] = v2_policy_rule_model
+        template_policy_model['control'] = control_model
+
+        # Set up parameter values
+        policy_template_id = 'testString'
+        policy = template_policy_model
+        description = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "policy_template_id": policy_template_id,
+            "policy": policy,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.create_policy_template_version(**req_copy)
+
+    def test_create_policy_template_version_value_error_with_retries(self):
+        # Enable retries and run test_create_policy_template_version_value_error.
+        _service.enable_retries()
+        self.test_create_policy_template_version_value_error()
+
+        # Disable retries and run test_create_policy_template_version_value_error.
+        _service.disable_retries()
+        self.test_create_policy_template_version_value_error()
+
+
+class TestListPolicyTemplateVersions:
+    """
+    Test Class for list_policy_template_versions
+    """
+
+    @responses.activate
+    def test_list_policy_template_versions_all_params(self):
+        """
+        list_policy_template_versions()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates/testString/versions')
+        mock_response = '{"versions": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        policy_template_id = 'testString'
+
+        # Invoke method
+        response = _service.list_policy_template_versions(policy_template_id, headers={})
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_list_policy_template_versions_all_params_with_retries(self):
+        # Enable retries and run test_list_policy_template_versions_all_params.
+        _service.enable_retries()
+        self.test_list_policy_template_versions_all_params()
+
+        # Disable retries and run test_list_policy_template_versions_all_params.
+        _service.disable_retries()
+        self.test_list_policy_template_versions_all_params()
+
+    @responses.activate
+    def test_list_policy_template_versions_value_error(self):
+        """
+        test_list_policy_template_versions_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates/testString/versions')
+        mock_response = '{"versions": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        policy_template_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "policy_template_id": policy_template_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.list_policy_template_versions(**req_copy)
+
+    def test_list_policy_template_versions_value_error_with_retries(self):
+        # Enable retries and run test_list_policy_template_versions_value_error.
+        _service.enable_retries()
+        self.test_list_policy_template_versions_value_error()
+
+        # Disable retries and run test_list_policy_template_versions_value_error.
+        _service.disable_retries()
+        self.test_list_policy_template_versions_value_error()
+
+
+class TestReplacePolicyTemplate:
+    """
+    Test Class for replace_policy_template
+    """
+
+    @responses.activate
+    def test_replace_policy_template_all_params(self):
+        """
+        replace_policy_template()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates/testString/versions/testString')
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
+
+        # Construct a dict representation of a V2PolicyResourceAttribute model
+        v2_policy_resource_attribute_model = {}
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyResourceTag model
+        v2_policy_resource_tag_model = {}
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        # Construct a dict representation of a V2PolicyResource model
+        v2_policy_resource_model = {}
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        # Construct a dict representation of a V2PolicyRuleRuleAttribute model
+        v2_policy_rule_model = {}
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
+
+        # Construct a dict representation of a Roles model
+        roles_model = {}
+        roles_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a Grant model
+        grant_model = {}
+        grant_model['roles'] = [roles_model]
+
+        # Construct a dict representation of a Control model
+        control_model = {}
+        control_model['grant'] = grant_model
+
+        # Construct a dict representation of a TemplatePolicy model
+        template_policy_model = {}
+        template_policy_model['type'] = 'access'
+        template_policy_model['description'] = 'testString'
+        template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['pattern'] = 'testString'
+        template_policy_model['rule'] = v2_policy_rule_model
+        template_policy_model['control'] = control_model
+
+        # Set up parameter values
+        policy_template_id = 'testString'
+        version = 'testString'
+        if_match = 'testString'
+        policy = template_policy_model
+        description = 'testString'
+
+        # Invoke method
+        response = _service.replace_policy_template(
+            policy_template_id, version, if_match, policy, description=description, headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['policy'] == template_policy_model
+        assert req_body['description'] == 'testString'
+
+    def test_replace_policy_template_all_params_with_retries(self):
+        # Enable retries and run test_replace_policy_template_all_params.
+        _service.enable_retries()
+        self.test_replace_policy_template_all_params()
+
+        # Disable retries and run test_replace_policy_template_all_params.
+        _service.disable_retries()
+        self.test_replace_policy_template_all_params()
+
+    @responses.activate
+    def test_replace_policy_template_value_error(self):
+        """
+        test_replace_policy_template_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates/testString/versions/testString')
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(responses.PUT, url, body=mock_response, content_type='application/json', status=200)
+
+        # Construct a dict representation of a V2PolicyResourceAttribute model
+        v2_policy_resource_attribute_model = {}
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicyResourceTag model
+        v2_policy_resource_tag_model = {}
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        # Construct a dict representation of a V2PolicyResource model
+        v2_policy_resource_model = {}
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        # Construct a dict representation of a V2PolicyRuleRuleAttribute model
+        v2_policy_rule_model = {}
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
+
+        # Construct a dict representation of a Roles model
+        roles_model = {}
+        roles_model['role_id'] = 'testString'
+
+        # Construct a dict representation of a Grant model
+        grant_model = {}
+        grant_model['roles'] = [roles_model]
+
+        # Construct a dict representation of a Control model
+        control_model = {}
+        control_model['grant'] = grant_model
+
+        # Construct a dict representation of a TemplatePolicy model
+        template_policy_model = {}
+        template_policy_model['type'] = 'access'
+        template_policy_model['description'] = 'testString'
+        template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['pattern'] = 'testString'
+        template_policy_model['rule'] = v2_policy_rule_model
+        template_policy_model['control'] = control_model
+
+        # Set up parameter values
+        policy_template_id = 'testString'
+        version = 'testString'
+        if_match = 'testString'
+        policy = template_policy_model
+        description = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "policy_template_id": policy_template_id,
+            "version": version,
+            "if_match": if_match,
+            "policy": policy,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.replace_policy_template(**req_copy)
+
+    def test_replace_policy_template_value_error_with_retries(self):
+        # Enable retries and run test_replace_policy_template_value_error.
+        _service.enable_retries()
+        self.test_replace_policy_template_value_error()
+
+        # Disable retries and run test_replace_policy_template_value_error.
+        _service.disable_retries()
+        self.test_replace_policy_template_value_error()
+
+
+class TestDeletePolicyTemplateVersion:
+    """
+    Test Class for delete_policy_template_version
+    """
+
+    @responses.activate
+    def test_delete_policy_template_version_all_params(self):
+        """
+        delete_policy_template_version()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates/testString/versions/testString')
+        responses.add(responses.DELETE, url, status=204)
+
+        # Set up parameter values
+        policy_template_id = 'testString'
+        version = 'testString'
+
+        # Invoke method
+        response = _service.delete_policy_template_version(policy_template_id, version, headers={})
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_delete_policy_template_version_all_params_with_retries(self):
+        # Enable retries and run test_delete_policy_template_version_all_params.
+        _service.enable_retries()
+        self.test_delete_policy_template_version_all_params()
+
+        # Disable retries and run test_delete_policy_template_version_all_params.
+        _service.disable_retries()
+        self.test_delete_policy_template_version_all_params()
+
+    @responses.activate
+    def test_delete_policy_template_version_value_error(self):
+        """
+        test_delete_policy_template_version_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates/testString/versions/testString')
+        responses.add(responses.DELETE, url, status=204)
+
+        # Set up parameter values
+        policy_template_id = 'testString'
+        version = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "policy_template_id": policy_template_id,
+            "version": version,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_policy_template_version(**req_copy)
+
+    def test_delete_policy_template_version_value_error_with_retries(self):
+        # Enable retries and run test_delete_policy_template_version_value_error.
+        _service.enable_retries()
+        self.test_delete_policy_template_version_value_error()
+
+        # Disable retries and run test_delete_policy_template_version_value_error.
+        _service.disable_retries()
+        self.test_delete_policy_template_version_value_error()
+
+
+class TestGetPolicyTemplateVersion:
+    """
+    Test Class for get_policy_template_version
+    """
+
+    @responses.activate
+    def test_get_policy_template_version_all_params(self):
+        """
+        get_policy_template_version()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates/testString/versions/testString')
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        policy_template_id = 'testString'
+        version = 'testString'
+
+        # Invoke method
+        response = _service.get_policy_template_version(policy_template_id, version, headers={})
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_policy_template_version_all_params_with_retries(self):
+        # Enable retries and run test_get_policy_template_version_all_params.
+        _service.enable_retries()
+        self.test_get_policy_template_version_all_params()
+
+        # Disable retries and run test_get_policy_template_version_all_params.
+        _service.disable_retries()
+        self.test_get_policy_template_version_all_params()
+
+    @responses.activate
+    def test_get_policy_template_version_value_error(self):
+        """
+        test_get_policy_template_version_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates/testString/versions/testString')
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        policy_template_id = 'testString'
+        version = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "policy_template_id": policy_template_id,
+            "version": version,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_policy_template_version(**req_copy)
+
+    def test_get_policy_template_version_value_error_with_retries(self):
+        # Enable retries and run test_get_policy_template_version_value_error.
+        _service.enable_retries()
+        self.test_get_policy_template_version_value_error()
+
+        # Disable retries and run test_get_policy_template_version_value_error.
+        _service.disable_retries()
+        self.test_get_policy_template_version_value_error()
+
+
+class TestCommitPolicyTemplate:
+    """
+    Test Class for commit_policy_template
+    """
+
+    @responses.activate
+    def test_commit_policy_template_all_params(self):
+        """
+        commit_policy_template()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates/testString/versions/testString/commit')
+        responses.add(responses.POST, url, status=204)
+
+        # Set up parameter values
+        policy_template_id = 'testString'
+        version = 'testString'
+        if_match = 'testString'
+
+        # Invoke method
+        response = _service.commit_policy_template(policy_template_id, version, if_match, headers={})
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_commit_policy_template_all_params_with_retries(self):
+        # Enable retries and run test_commit_policy_template_all_params.
+        _service.enable_retries()
+        self.test_commit_policy_template_all_params()
+
+        # Disable retries and run test_commit_policy_template_all_params.
+        _service.disable_retries()
+        self.test_commit_policy_template_all_params()
+
+    @responses.activate
+    def test_commit_policy_template_value_error(self):
+        """
+        test_commit_policy_template_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_templates/testString/versions/testString/commit')
+        responses.add(responses.POST, url, status=204)
+
+        # Set up parameter values
+        policy_template_id = 'testString'
+        version = 'testString'
+        if_match = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "policy_template_id": policy_template_id,
+            "version": version,
+            "if_match": if_match,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.commit_policy_template(**req_copy)
+
+    def test_commit_policy_template_value_error_with_retries(self):
+        # Enable retries and run test_commit_policy_template_value_error.
+        _service.enable_retries()
+        self.test_commit_policy_template_value_error()
+
+        # Disable retries and run test_commit_policy_template_value_error.
+        _service.disable_retries()
+        self.test_commit_policy_template_value_error()
+
+
+# endregion
+##############################################################################
+# End of Service: PolicyTemplates
+##############################################################################
+
+##############################################################################
+# Start of Service: PolicyAssignments
+##############################################################################
+# region
+
+
+class TestNewInstance:
+    """
+    Test Class for new_instance
+    """
+
+    def test_new_instance(self):
+        """
+        new_instance()
+        """
+        os.environ['TEST_SERVICE_AUTH_TYPE'] = 'noAuth'
+
+        service = IamPolicyManagementV1.new_instance(
+            service_name='TEST_SERVICE',
+        )
+
+        assert service is not None
+        assert isinstance(service, IamPolicyManagementV1)
+
+    def test_new_instance_without_authenticator(self):
+        """
+        new_instance_without_authenticator()
+        """
+        with pytest.raises(ValueError, match='authenticator must be provided'):
+            service = IamPolicyManagementV1.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
+
+
+class TestListPolicyAssignments:
+    """
+    Test Class for list_policy_assignments
+    """
+
+    @responses.activate
+    def test_list_policy_assignments_all_params(self):
+        """
+        list_policy_assignments()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_assignments')
+        mock_response = '{"policy_assignments": [{"template_id": "template_id", "template_version": "template_version", "assignment_id": "assignment_id", "target_type": "Account", "target": "target", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": "target", "policy": {"resource_created": {"id": "id"}, "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "status": "in_progress"}]}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        account_id = 'testString'
+        accept_language = 'default'
+        template_id = 'testString'
+        template_version = 'testString'
+
+        # Invoke method
+        response = _service.list_policy_assignments(
+            account_id,
+            accept_language=accept_language,
+            template_id=template_id,
+            template_version=template_version,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'account_id={}'.format(account_id) in query_string
+        assert 'template_id={}'.format(template_id) in query_string
+        assert 'template_version={}'.format(template_version) in query_string
+
+    def test_list_policy_assignments_all_params_with_retries(self):
+        # Enable retries and run test_list_policy_assignments_all_params.
+        _service.enable_retries()
+        self.test_list_policy_assignments_all_params()
+
+        # Disable retries and run test_list_policy_assignments_all_params.
+        _service.disable_retries()
+        self.test_list_policy_assignments_all_params()
+
+    @responses.activate
+    def test_list_policy_assignments_required_params(self):
+        """
+        test_list_policy_assignments_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_assignments')
+        mock_response = '{"policy_assignments": [{"template_id": "template_id", "template_version": "template_version", "assignment_id": "assignment_id", "target_type": "Account", "target": "target", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": "target", "policy": {"resource_created": {"id": "id"}, "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "status": "in_progress"}]}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        account_id = 'testString'
+
+        # Invoke method
+        response = _service.list_policy_assignments(account_id, headers={})
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'account_id={}'.format(account_id) in query_string
+
+    def test_list_policy_assignments_required_params_with_retries(self):
+        # Enable retries and run test_list_policy_assignments_required_params.
+        _service.enable_retries()
+        self.test_list_policy_assignments_required_params()
+
+        # Disable retries and run test_list_policy_assignments_required_params.
+        _service.disable_retries()
+        self.test_list_policy_assignments_required_params()
+
+    @responses.activate
+    def test_list_policy_assignments_value_error(self):
+        """
+        test_list_policy_assignments_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_assignments')
+        mock_response = '{"policy_assignments": [{"template_id": "template_id", "template_version": "template_version", "assignment_id": "assignment_id", "target_type": "Account", "target": "target", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": "target", "policy": {"resource_created": {"id": "id"}, "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "status": "in_progress"}]}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        account_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "account_id": account_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.list_policy_assignments(**req_copy)
+
+    def test_list_policy_assignments_value_error_with_retries(self):
+        # Enable retries and run test_list_policy_assignments_value_error.
+        _service.enable_retries()
+        self.test_list_policy_assignments_value_error()
+
+        # Disable retries and run test_list_policy_assignments_value_error.
+        _service.disable_retries()
+        self.test_list_policy_assignments_value_error()
+
+
+class TestGetPolicyAssignment:
+    """
+    Test Class for get_policy_assignment
+    """
+
+    @responses.activate
+    def test_get_policy_assignment_all_params(self):
+        """
+        get_policy_assignment()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_assignments/testString')
+        mock_response = '{"template_id": "template_id", "template_version": "template_version", "assignment_id": "assignment_id", "target_type": "Account", "target": "target", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": "target", "policy": {"resource_created": {"id": "id"}, "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "status": "in_progress"}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        assignment_id = 'testString'
+
+        # Invoke method
+        response = _service.get_policy_assignment(assignment_id, headers={})
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_policy_assignment_all_params_with_retries(self):
+        # Enable retries and run test_get_policy_assignment_all_params.
+        _service.enable_retries()
+        self.test_get_policy_assignment_all_params()
+
+        # Disable retries and run test_get_policy_assignment_all_params.
+        _service.disable_retries()
+        self.test_get_policy_assignment_all_params()
+
+    @responses.activate
+    def test_get_policy_assignment_value_error(self):
+        """
+        test_get_policy_assignment_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_assignments/testString')
+        mock_response = '{"template_id": "template_id", "template_version": "template_version", "assignment_id": "assignment_id", "target_type": "Account", "target": "target", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": "target", "policy": {"resource_created": {"id": "id"}, "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "status": "in_progress"}'
+        responses.add(responses.GET, url, body=mock_response, content_type='application/json', status=200)
+
+        # Set up parameter values
+        assignment_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "assignment_id": assignment_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_policy_assignment(**req_copy)
+
+    def test_get_policy_assignment_value_error_with_retries(self):
+        # Enable retries and run test_get_policy_assignment_value_error.
+        _service.enable_retries()
+        self.test_get_policy_assignment_value_error()
+
+        # Disable retries and run test_get_policy_assignment_value_error.
+        _service.disable_retries()
+        self.test_get_policy_assignment_value_error()
+
+
+# endregion
+##############################################################################
+# End of Service: PolicyAssignments
+##############################################################################
+
 
 ##############################################################################
 # Start of Model Tests
 ##############################################################################
 # region
+class TestModel_AssignmentResourceCreated:
+    """
+    Test Class for AssignmentResourceCreated
+    """
+
+    def test_assignment_resource_created_serialization(self):
+        """
+        Test serialization/deserialization for AssignmentResourceCreated
+        """
+
+        # Construct a json representation of a AssignmentResourceCreated model
+        assignment_resource_created_model_json = {}
+        assignment_resource_created_model_json['id'] = 'testString'
+
+        # Construct a model instance of AssignmentResourceCreated by calling from_dict on the json representation
+        assignment_resource_created_model = AssignmentResourceCreated.from_dict(assignment_resource_created_model_json)
+        assert assignment_resource_created_model != False
+
+        # Construct a model instance of AssignmentResourceCreated by calling from_dict on the json representation
+        assignment_resource_created_model_dict = AssignmentResourceCreated.from_dict(
+            assignment_resource_created_model_json
+        ).__dict__
+        assignment_resource_created_model2 = AssignmentResourceCreated(**assignment_resource_created_model_dict)
+
+        # Verify the model instances are equivalent
+        assert assignment_resource_created_model == assignment_resource_created_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        assignment_resource_created_model_json2 = assignment_resource_created_model.to_dict()
+        assert assignment_resource_created_model_json2 == assignment_resource_created_model_json
+
+
 class TestModel_Control:
     """
     Test Class for Control
@@ -2263,6 +3662,275 @@ class TestModel_GrantWithEnrichedRoles:
         assert grant_with_enriched_roles_model_json2 == grant_with_enriched_roles_model_json
 
 
+class TestModel_PolcyTemplateAssignmentCollection:
+    """
+    Test Class for PolcyTemplateAssignmentCollection
+    """
+
+    def test_polcy_template_assignment_collection_serialization(self):
+        """
+        Test serialization/deserialization for PolcyTemplateAssignmentCollection
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        assignment_resource_created_model = {}  # AssignmentResourceCreated
+        assignment_resource_created_model['id'] = 'testString'
+
+        conflicts_with_model = {}  # ConflictsWith
+        conflicts_with_model['etag'] = 'testString'
+        conflicts_with_model['role'] = 'testString'
+        conflicts_with_model['policy'] = 'testString'
+
+        error_details_model = {}  # ErrorDetails
+        error_details_model['conflicts_with'] = conflicts_with_model
+
+        error_object_model = {}  # ErrorObject
+        error_object_model['code'] = 'insufficent_permissions'
+        error_object_model['message'] = 'testString'
+        error_object_model['details'] = error_details_model
+        error_object_model['more_info'] = 'testString'
+
+        error_response_model = {}  # ErrorResponse
+        error_response_model['trace'] = 'testString'
+        error_response_model['errors'] = [error_object_model]
+        error_response_model['status_code'] = 38
+
+        policy_assignment_resources_policy_model = {}  # PolicyAssignmentResourcesPolicy
+        policy_assignment_resources_policy_model['resource_created'] = assignment_resource_created_model
+        policy_assignment_resources_policy_model['error_message'] = error_response_model
+
+        policy_assignment_resources_model = {}  # PolicyAssignmentResources
+        policy_assignment_resources_model['target'] = 'testString'
+        policy_assignment_resources_model['policy'] = policy_assignment_resources_policy_model
+
+        policy_assignment_record_model = {}  # PolicyAssignmentRecord
+        policy_assignment_record_model['template_id'] = 'testString'
+        policy_assignment_record_model['template_version'] = 'testString'
+        policy_assignment_record_model['assignment_id'] = 'testString'
+        policy_assignment_record_model['target_type'] = 'Account'
+        policy_assignment_record_model['target'] = 'testString'
+        policy_assignment_record_model['resources'] = [policy_assignment_resources_model]
+        policy_assignment_record_model['status'] = 'in_progress'
+
+        # Construct a json representation of a PolcyTemplateAssignmentCollection model
+        polcy_template_assignment_collection_model_json = {}
+        polcy_template_assignment_collection_model_json['policy_assignments'] = [policy_assignment_record_model]
+
+        # Construct a model instance of PolcyTemplateAssignmentCollection by calling from_dict on the json representation
+        polcy_template_assignment_collection_model = PolcyTemplateAssignmentCollection.from_dict(
+            polcy_template_assignment_collection_model_json
+        )
+        assert polcy_template_assignment_collection_model != False
+
+        # Construct a model instance of PolcyTemplateAssignmentCollection by calling from_dict on the json representation
+        polcy_template_assignment_collection_model_dict = PolcyTemplateAssignmentCollection.from_dict(
+            polcy_template_assignment_collection_model_json
+        ).__dict__
+        polcy_template_assignment_collection_model2 = PolcyTemplateAssignmentCollection(
+            **polcy_template_assignment_collection_model_dict
+        )
+
+        # Verify the model instances are equivalent
+        assert polcy_template_assignment_collection_model == polcy_template_assignment_collection_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        polcy_template_assignment_collection_model_json2 = polcy_template_assignment_collection_model.to_dict()
+        assert polcy_template_assignment_collection_model_json2 == polcy_template_assignment_collection_model_json
+
+
+class TestModel_PolicyAssignmentRecord:
+    """
+    Test Class for PolicyAssignmentRecord
+    """
+
+    def test_policy_assignment_record_serialization(self):
+        """
+        Test serialization/deserialization for PolicyAssignmentRecord
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        assignment_resource_created_model = {}  # AssignmentResourceCreated
+        assignment_resource_created_model['id'] = 'testString'
+
+        conflicts_with_model = {}  # ConflictsWith
+        conflicts_with_model['etag'] = 'testString'
+        conflicts_with_model['role'] = 'testString'
+        conflicts_with_model['policy'] = 'testString'
+
+        error_details_model = {}  # ErrorDetails
+        error_details_model['conflicts_with'] = conflicts_with_model
+
+        error_object_model = {}  # ErrorObject
+        error_object_model['code'] = 'insufficent_permissions'
+        error_object_model['message'] = 'testString'
+        error_object_model['details'] = error_details_model
+        error_object_model['more_info'] = 'testString'
+
+        error_response_model = {}  # ErrorResponse
+        error_response_model['trace'] = 'testString'
+        error_response_model['errors'] = [error_object_model]
+        error_response_model['status_code'] = 38
+
+        policy_assignment_resources_policy_model = {}  # PolicyAssignmentResourcesPolicy
+        policy_assignment_resources_policy_model['resource_created'] = assignment_resource_created_model
+        policy_assignment_resources_policy_model['error_message'] = error_response_model
+
+        policy_assignment_resources_model = {}  # PolicyAssignmentResources
+        policy_assignment_resources_model['target'] = 'testString'
+        policy_assignment_resources_model['policy'] = policy_assignment_resources_policy_model
+
+        # Construct a json representation of a PolicyAssignmentRecord model
+        policy_assignment_record_model_json = {}
+        policy_assignment_record_model_json['template_id'] = 'testString'
+        policy_assignment_record_model_json['template_version'] = 'testString'
+        policy_assignment_record_model_json['assignment_id'] = 'testString'
+        policy_assignment_record_model_json['target_type'] = 'Account'
+        policy_assignment_record_model_json['target'] = 'testString'
+        policy_assignment_record_model_json['resources'] = [policy_assignment_resources_model]
+        policy_assignment_record_model_json['status'] = 'in_progress'
+
+        # Construct a model instance of PolicyAssignmentRecord by calling from_dict on the json representation
+        policy_assignment_record_model = PolicyAssignmentRecord.from_dict(policy_assignment_record_model_json)
+        assert policy_assignment_record_model != False
+
+        # Construct a model instance of PolicyAssignmentRecord by calling from_dict on the json representation
+        policy_assignment_record_model_dict = PolicyAssignmentRecord.from_dict(
+            policy_assignment_record_model_json
+        ).__dict__
+        policy_assignment_record_model2 = PolicyAssignmentRecord(**policy_assignment_record_model_dict)
+
+        # Verify the model instances are equivalent
+        assert policy_assignment_record_model == policy_assignment_record_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_assignment_record_model_json2 = policy_assignment_record_model.to_dict()
+        assert policy_assignment_record_model_json2 == policy_assignment_record_model_json
+
+
+class TestModel_PolicyAssignmentResources:
+    """
+    Test Class for PolicyAssignmentResources
+    """
+
+    def test_policy_assignment_resources_serialization(self):
+        """
+        Test serialization/deserialization for PolicyAssignmentResources
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        assignment_resource_created_model = {}  # AssignmentResourceCreated
+        assignment_resource_created_model['id'] = 'testString'
+
+        conflicts_with_model = {}  # ConflictsWith
+        conflicts_with_model['etag'] = 'testString'
+        conflicts_with_model['role'] = 'testString'
+        conflicts_with_model['policy'] = 'testString'
+
+        error_details_model = {}  # ErrorDetails
+        error_details_model['conflicts_with'] = conflicts_with_model
+
+        error_object_model = {}  # ErrorObject
+        error_object_model['code'] = 'insufficent_permissions'
+        error_object_model['message'] = 'testString'
+        error_object_model['details'] = error_details_model
+        error_object_model['more_info'] = 'testString'
+
+        error_response_model = {}  # ErrorResponse
+        error_response_model['trace'] = 'testString'
+        error_response_model['errors'] = [error_object_model]
+        error_response_model['status_code'] = 38
+
+        policy_assignment_resources_policy_model = {}  # PolicyAssignmentResourcesPolicy
+        policy_assignment_resources_policy_model['resource_created'] = assignment_resource_created_model
+        policy_assignment_resources_policy_model['error_message'] = error_response_model
+
+        # Construct a json representation of a PolicyAssignmentResources model
+        policy_assignment_resources_model_json = {}
+        policy_assignment_resources_model_json['target'] = 'testString'
+        policy_assignment_resources_model_json['policy'] = policy_assignment_resources_policy_model
+
+        # Construct a model instance of PolicyAssignmentResources by calling from_dict on the json representation
+        policy_assignment_resources_model = PolicyAssignmentResources.from_dict(policy_assignment_resources_model_json)
+        assert policy_assignment_resources_model != False
+
+        # Construct a model instance of PolicyAssignmentResources by calling from_dict on the json representation
+        policy_assignment_resources_model_dict = PolicyAssignmentResources.from_dict(
+            policy_assignment_resources_model_json
+        ).__dict__
+        policy_assignment_resources_model2 = PolicyAssignmentResources(**policy_assignment_resources_model_dict)
+
+        # Verify the model instances are equivalent
+        assert policy_assignment_resources_model == policy_assignment_resources_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_assignment_resources_model_json2 = policy_assignment_resources_model.to_dict()
+        assert policy_assignment_resources_model_json2 == policy_assignment_resources_model_json
+
+
+class TestModel_PolicyAssignmentResourcesPolicy:
+    """
+    Test Class for PolicyAssignmentResourcesPolicy
+    """
+
+    def test_policy_assignment_resources_policy_serialization(self):
+        """
+        Test serialization/deserialization for PolicyAssignmentResourcesPolicy
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        assignment_resource_created_model = {}  # AssignmentResourceCreated
+        assignment_resource_created_model['id'] = 'testString'
+
+        conflicts_with_model = {}  # ConflictsWith
+        conflicts_with_model['etag'] = 'testString'
+        conflicts_with_model['role'] = 'testString'
+        conflicts_with_model['policy'] = 'testString'
+
+        error_details_model = {}  # ErrorDetails
+        error_details_model['conflicts_with'] = conflicts_with_model
+
+        error_object_model = {}  # ErrorObject
+        error_object_model['code'] = 'insufficent_permissions'
+        error_object_model['message'] = 'testString'
+        error_object_model['details'] = error_details_model
+        error_object_model['more_info'] = 'testString'
+
+        error_response_model = {}  # ErrorResponse
+        error_response_model['trace'] = 'testString'
+        error_response_model['errors'] = [error_object_model]
+        error_response_model['status_code'] = 38
+
+        # Construct a json representation of a PolicyAssignmentResourcesPolicy model
+        policy_assignment_resources_policy_model_json = {}
+        policy_assignment_resources_policy_model_json['resource_created'] = assignment_resource_created_model
+        policy_assignment_resources_policy_model_json['error_message'] = error_response_model
+
+        # Construct a model instance of PolicyAssignmentResourcesPolicy by calling from_dict on the json representation
+        policy_assignment_resources_policy_model = PolicyAssignmentResourcesPolicy.from_dict(
+            policy_assignment_resources_policy_model_json
+        )
+        assert policy_assignment_resources_policy_model != False
+
+        # Construct a model instance of PolicyAssignmentResourcesPolicy by calling from_dict on the json representation
+        policy_assignment_resources_policy_model_dict = PolicyAssignmentResourcesPolicy.from_dict(
+            policy_assignment_resources_policy_model_json
+        ).__dict__
+        policy_assignment_resources_policy_model2 = PolicyAssignmentResourcesPolicy(
+            **policy_assignment_resources_policy_model_dict
+        )
+
+        # Verify the model instances are equivalent
+        assert policy_assignment_resources_policy_model == policy_assignment_resources_policy_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_assignment_resources_policy_model_json2 = policy_assignment_resources_policy_model.to_dict()
+        assert policy_assignment_resources_policy_model_json2 == policy_assignment_resources_policy_model_json
+
+
 class TestModel_PolicyRole:
     """
     Test Class for PolicyRole
@@ -2291,6 +3959,239 @@ class TestModel_PolicyRole:
         # Convert model instance back to dict and verify no loss of data
         policy_role_model_json2 = policy_role_model.to_dict()
         assert policy_role_model_json2 == policy_role_model_json
+
+
+class TestModel_PolicyTemplate:
+    """
+    Test Class for PolicyTemplate
+    """
+
+    def test_policy_template_serialization(self):
+        """
+        Test serialization/deserialization for PolicyTemplate
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_resource_attribute_model = {}  # V2PolicyResourceAttribute
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
+
+        v2_policy_resource_tag_model = {}  # V2PolicyResourceTag
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        v2_policy_resource_model = {}  # V2PolicyResource
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        v2_policy_rule_model = {}  # V2PolicyRuleRuleAttribute
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
+
+        roles_model = {}  # Roles
+        roles_model['role_id'] = 'testString'
+
+        grant_model = {}  # Grant
+        grant_model['roles'] = [roles_model]
+
+        control_model = {}  # Control
+        control_model['grant'] = grant_model
+
+        template_policy_model = {}  # TemplatePolicy
+        template_policy_model['type'] = 'access'
+        template_policy_model['description'] = 'testString'
+        template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['pattern'] = 'testString'
+        template_policy_model['rule'] = v2_policy_rule_model
+        template_policy_model['control'] = control_model
+
+        # Construct a json representation of a PolicyTemplate model
+        policy_template_model_json = {}
+        policy_template_model_json['name'] = 'testString'
+        policy_template_model_json['description'] = 'testString'
+        policy_template_model_json['account_id'] = 'testString'
+        policy_template_model_json['version'] = 'testString'
+        policy_template_model_json['committed'] = True
+        policy_template_model_json['policy'] = template_policy_model
+
+        # Construct a model instance of PolicyTemplate by calling from_dict on the json representation
+        policy_template_model = PolicyTemplate.from_dict(policy_template_model_json)
+        assert policy_template_model != False
+
+        # Construct a model instance of PolicyTemplate by calling from_dict on the json representation
+        policy_template_model_dict = PolicyTemplate.from_dict(policy_template_model_json).__dict__
+        policy_template_model2 = PolicyTemplate(**policy_template_model_dict)
+
+        # Verify the model instances are equivalent
+        assert policy_template_model == policy_template_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_template_model_json2 = policy_template_model.to_dict()
+        assert policy_template_model_json2 == policy_template_model_json
+
+
+class TestModel_PolicyTemplateCollection:
+    """
+    Test Class for PolicyTemplateCollection
+    """
+
+    def test_policy_template_collection_serialization(self):
+        """
+        Test serialization/deserialization for PolicyTemplateCollection
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_resource_attribute_model = {}  # V2PolicyResourceAttribute
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
+
+        v2_policy_resource_tag_model = {}  # V2PolicyResourceTag
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        v2_policy_resource_model = {}  # V2PolicyResource
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        v2_policy_rule_model = {}  # V2PolicyRuleRuleAttribute
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
+
+        roles_model = {}  # Roles
+        roles_model['role_id'] = 'testString'
+
+        grant_model = {}  # Grant
+        grant_model['roles'] = [roles_model]
+
+        control_model = {}  # Control
+        control_model['grant'] = grant_model
+
+        template_policy_model = {}  # TemplatePolicy
+        template_policy_model['type'] = 'access'
+        template_policy_model['description'] = 'testString'
+        template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['pattern'] = 'testString'
+        template_policy_model['rule'] = v2_policy_rule_model
+        template_policy_model['control'] = control_model
+
+        policy_template_model = {}  # PolicyTemplate
+        policy_template_model['name'] = 'testString'
+        policy_template_model['description'] = 'testString'
+        policy_template_model['account_id'] = 'testString'
+        policy_template_model['version'] = 'testString'
+        policy_template_model['committed'] = True
+        policy_template_model['policy'] = template_policy_model
+
+        # Construct a json representation of a PolicyTemplateCollection model
+        policy_template_collection_model_json = {}
+        policy_template_collection_model_json['policy_templates'] = [policy_template_model]
+
+        # Construct a model instance of PolicyTemplateCollection by calling from_dict on the json representation
+        policy_template_collection_model = PolicyTemplateCollection.from_dict(policy_template_collection_model_json)
+        assert policy_template_collection_model != False
+
+        # Construct a model instance of PolicyTemplateCollection by calling from_dict on the json representation
+        policy_template_collection_model_dict = PolicyTemplateCollection.from_dict(
+            policy_template_collection_model_json
+        ).__dict__
+        policy_template_collection_model2 = PolicyTemplateCollection(**policy_template_collection_model_dict)
+
+        # Verify the model instances are equivalent
+        assert policy_template_collection_model == policy_template_collection_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_template_collection_model_json2 = policy_template_collection_model.to_dict()
+        assert policy_template_collection_model_json2 == policy_template_collection_model_json
+
+
+class TestModel_PolicyTemplateVersionsCollection:
+    """
+    Test Class for PolicyTemplateVersionsCollection
+    """
+
+    def test_policy_template_versions_collection_serialization(self):
+        """
+        Test serialization/deserialization for PolicyTemplateVersionsCollection
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_resource_attribute_model = {}  # V2PolicyResourceAttribute
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
+
+        v2_policy_resource_tag_model = {}  # V2PolicyResourceTag
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        v2_policy_resource_model = {}  # V2PolicyResource
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        v2_policy_rule_model = {}  # V2PolicyRuleRuleAttribute
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
+
+        roles_model = {}  # Roles
+        roles_model['role_id'] = 'testString'
+
+        grant_model = {}  # Grant
+        grant_model['roles'] = [roles_model]
+
+        control_model = {}  # Control
+        control_model['grant'] = grant_model
+
+        template_policy_model = {}  # TemplatePolicy
+        template_policy_model['type'] = 'access'
+        template_policy_model['description'] = 'testString'
+        template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['pattern'] = 'testString'
+        template_policy_model['rule'] = v2_policy_rule_model
+        template_policy_model['control'] = control_model
+
+        policy_template_model = {}  # PolicyTemplate
+        policy_template_model['name'] = 'testString'
+        policy_template_model['description'] = 'testString'
+        policy_template_model['account_id'] = 'testString'
+        policy_template_model['version'] = 'testString'
+        policy_template_model['committed'] = True
+        policy_template_model['policy'] = template_policy_model
+
+        # Construct a json representation of a PolicyTemplateVersionsCollection model
+        policy_template_versions_collection_model_json = {}
+        policy_template_versions_collection_model_json['versions'] = [policy_template_model]
+
+        # Construct a model instance of PolicyTemplateVersionsCollection by calling from_dict on the json representation
+        policy_template_versions_collection_model = PolicyTemplateVersionsCollection.from_dict(
+            policy_template_versions_collection_model_json
+        )
+        assert policy_template_versions_collection_model != False
+
+        # Construct a model instance of PolicyTemplateVersionsCollection by calling from_dict on the json representation
+        policy_template_versions_collection_model_dict = PolicyTemplateVersionsCollection.from_dict(
+            policy_template_versions_collection_model_json
+        ).__dict__
+        policy_template_versions_collection_model2 = PolicyTemplateVersionsCollection(
+            **policy_template_versions_collection_model_dict
+        )
+
+        # Verify the model instances are equivalent
+        assert policy_template_versions_collection_model == policy_template_versions_collection_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_template_versions_collection_model_json2 = policy_template_versions_collection_model.to_dict()
+        assert policy_template_versions_collection_model_json2 == policy_template_versions_collection_model_json
 
 
 class TestModel_RoleAction:
@@ -2387,6 +4288,102 @@ class TestModel_RuleAttribute:
         assert rule_attribute_model_json2 == rule_attribute_model_json
 
 
+class TestModel_TemplateMetada:
+    """
+    Test Class for TemplateMetada
+    """
+
+    def test_template_metada_serialization(self):
+        """
+        Test serialization/deserialization for TemplateMetada
+        """
+
+        # Construct a json representation of a TemplateMetada model
+        template_metada_model_json = {}
+        template_metada_model_json['crn'] = 'testString'
+        template_metada_model_json['version'] = 'testString'
+
+        # Construct a model instance of TemplateMetada by calling from_dict on the json representation
+        template_metada_model = TemplateMetada.from_dict(template_metada_model_json)
+        assert template_metada_model != False
+
+        # Construct a model instance of TemplateMetada by calling from_dict on the json representation
+        template_metada_model_dict = TemplateMetada.from_dict(template_metada_model_json).__dict__
+        template_metada_model2 = TemplateMetada(**template_metada_model_dict)
+
+        # Verify the model instances are equivalent
+        assert template_metada_model == template_metada_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        template_metada_model_json2 = template_metada_model.to_dict()
+        assert template_metada_model_json2 == template_metada_model_json
+
+
+class TestModel_TemplatePolicy:
+    """
+    Test Class for TemplatePolicy
+    """
+
+    def test_template_policy_serialization(self):
+        """
+        Test serialization/deserialization for TemplatePolicy
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        v2_policy_resource_attribute_model = {}  # V2PolicyResourceAttribute
+        v2_policy_resource_attribute_model['key'] = 'testString'
+        v2_policy_resource_attribute_model['operator'] = 'stringEquals'
+        v2_policy_resource_attribute_model['value'] = 'testString'
+
+        v2_policy_resource_tag_model = {}  # V2PolicyResourceTag
+        v2_policy_resource_tag_model['key'] = 'testString'
+        v2_policy_resource_tag_model['value'] = 'testString'
+        v2_policy_resource_tag_model['operator'] = 'stringEquals'
+
+        v2_policy_resource_model = {}  # V2PolicyResource
+        v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
+        v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
+
+        v2_policy_rule_model = {}  # V2PolicyRuleRuleAttribute
+        v2_policy_rule_model['key'] = 'testString'
+        v2_policy_rule_model['operator'] = 'timeLessThan'
+        v2_policy_rule_model['value'] = 'testString'
+
+        roles_model = {}  # Roles
+        roles_model['role_id'] = 'testString'
+
+        grant_model = {}  # Grant
+        grant_model['roles'] = [roles_model]
+
+        control_model = {}  # Control
+        control_model['grant'] = grant_model
+
+        # Construct a json representation of a TemplatePolicy model
+        template_policy_model_json = {}
+        template_policy_model_json['type'] = 'access'
+        template_policy_model_json['description'] = 'testString'
+        template_policy_model_json['resource'] = v2_policy_resource_model
+        template_policy_model_json['pattern'] = 'testString'
+        template_policy_model_json['rule'] = v2_policy_rule_model
+        template_policy_model_json['control'] = control_model
+
+        # Construct a model instance of TemplatePolicy by calling from_dict on the json representation
+        template_policy_model = TemplatePolicy.from_dict(template_policy_model_json)
+        assert template_policy_model != False
+
+        # Construct a model instance of TemplatePolicy by calling from_dict on the json representation
+        template_policy_model_dict = TemplatePolicy.from_dict(template_policy_model_json).__dict__
+        template_policy_model2 = TemplatePolicy(**template_policy_model_dict)
+
+        # Verify the model instances are equivalent
+        assert template_policy_model == template_policy_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        template_policy_model_json2 = template_policy_model.to_dict()
+        assert template_policy_model_json2 == template_policy_model_json
+
+
 class TestModel_V2Policy:
     """
     Test Class for V2Policy
@@ -2435,6 +4432,10 @@ class TestModel_V2Policy:
         control_response_model = {}  # ControlResponseControl
         control_response_model['grant'] = grant_model
 
+        template_metada_model = {}  # TemplateMetada
+        template_metada_model['crn'] = 'testString'
+        template_metada_model['version'] = 'testString'
+
         # Construct a json representation of a V2Policy model
         v2_policy_model_json = {}
         v2_policy_model_json['type'] = 'access'
@@ -2447,6 +4448,7 @@ class TestModel_V2Policy:
         v2_policy_model_json['state'] = 'active'
         v2_policy_model_json['last_permit_at'] = 'testString'
         v2_policy_model_json['last_permit_frequency'] = 38
+        v2_policy_model_json['template'] = template_metada_model
 
         # Construct a model instance of V2Policy by calling from_dict on the json representation
         v2_policy_model = V2Policy.from_dict(v2_policy_model_json)
@@ -2512,6 +4514,10 @@ class TestModel_V2PolicyCollection:
         control_response_model = {}  # ControlResponseControl
         control_response_model['grant'] = grant_model
 
+        template_metada_model = {}  # TemplateMetada
+        template_metada_model['crn'] = 'testString'
+        template_metada_model['version'] = 'testString'
+
         v2_policy_model = {}  # V2Policy
         v2_policy_model['type'] = 'access'
         v2_policy_model['description'] = 'testString'
@@ -2523,6 +4529,7 @@ class TestModel_V2PolicyCollection:
         v2_policy_model['state'] = 'active'
         v2_policy_model['last_permit_at'] = 'testString'
         v2_policy_model['last_permit_frequency'] = 38
+        v2_policy_model['template'] = template_metada_model
 
         # Construct a json representation of a V2PolicyCollection model
         v2_policy_collection_model_json = {}
@@ -2726,6 +4733,38 @@ class TestModel_V2PolicySubjectAttribute:
         assert v2_policy_subject_attribute_model_json2 == v2_policy_subject_attribute_model_json
 
 
+class TestModel_ConflictsWith:
+    """
+    Test Class for ConflictsWith
+    """
+
+    def test_conflicts_with_serialization(self):
+        """
+        Test serialization/deserialization for ConflictsWith
+        """
+
+        # Construct a json representation of a ConflictsWith model
+        conflicts_with_model_json = {}
+        conflicts_with_model_json['etag'] = 'testString'
+        conflicts_with_model_json['role'] = 'testString'
+        conflicts_with_model_json['policy'] = 'testString'
+
+        # Construct a model instance of ConflictsWith by calling from_dict on the json representation
+        conflicts_with_model = ConflictsWith.from_dict(conflicts_with_model_json)
+        assert conflicts_with_model != False
+
+        # Construct a model instance of ConflictsWith by calling from_dict on the json representation
+        conflicts_with_model_dict = ConflictsWith.from_dict(conflicts_with_model_json).__dict__
+        conflicts_with_model2 = ConflictsWith(**conflicts_with_model_dict)
+
+        # Verify the model instances are equivalent
+        assert conflicts_with_model == conflicts_with_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        conflicts_with_model_json2 = conflicts_with_model.to_dict()
+        assert conflicts_with_model_json2 == conflicts_with_model_json
+
+
 class TestModel_CustomRole:
     """
     Test Class for CustomRole
@@ -2759,6 +4798,134 @@ class TestModel_CustomRole:
         # Convert model instance back to dict and verify no loss of data
         custom_role_model_json2 = custom_role_model.to_dict()
         assert custom_role_model_json2 == custom_role_model_json
+
+
+class TestModel_ErrorDetails:
+    """
+    Test Class for ErrorDetails
+    """
+
+    def test_error_details_serialization(self):
+        """
+        Test serialization/deserialization for ErrorDetails
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        conflicts_with_model = {}  # ConflictsWith
+        conflicts_with_model['etag'] = 'testString'
+        conflicts_with_model['role'] = 'testString'
+        conflicts_with_model['policy'] = 'testString'
+
+        # Construct a json representation of a ErrorDetails model
+        error_details_model_json = {}
+        error_details_model_json['conflicts_with'] = conflicts_with_model
+
+        # Construct a model instance of ErrorDetails by calling from_dict on the json representation
+        error_details_model = ErrorDetails.from_dict(error_details_model_json)
+        assert error_details_model != False
+
+        # Construct a model instance of ErrorDetails by calling from_dict on the json representation
+        error_details_model_dict = ErrorDetails.from_dict(error_details_model_json).__dict__
+        error_details_model2 = ErrorDetails(**error_details_model_dict)
+
+        # Verify the model instances are equivalent
+        assert error_details_model == error_details_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        error_details_model_json2 = error_details_model.to_dict()
+        assert error_details_model_json2 == error_details_model_json
+
+
+class TestModel_ErrorObject:
+    """
+    Test Class for ErrorObject
+    """
+
+    def test_error_object_serialization(self):
+        """
+        Test serialization/deserialization for ErrorObject
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        conflicts_with_model = {}  # ConflictsWith
+        conflicts_with_model['etag'] = 'testString'
+        conflicts_with_model['role'] = 'testString'
+        conflicts_with_model['policy'] = 'testString'
+
+        error_details_model = {}  # ErrorDetails
+        error_details_model['conflicts_with'] = conflicts_with_model
+
+        # Construct a json representation of a ErrorObject model
+        error_object_model_json = {}
+        error_object_model_json['code'] = 'insufficent_permissions'
+        error_object_model_json['message'] = 'testString'
+        error_object_model_json['details'] = error_details_model
+        error_object_model_json['more_info'] = 'testString'
+
+        # Construct a model instance of ErrorObject by calling from_dict on the json representation
+        error_object_model = ErrorObject.from_dict(error_object_model_json)
+        assert error_object_model != False
+
+        # Construct a model instance of ErrorObject by calling from_dict on the json representation
+        error_object_model_dict = ErrorObject.from_dict(error_object_model_json).__dict__
+        error_object_model2 = ErrorObject(**error_object_model_dict)
+
+        # Verify the model instances are equivalent
+        assert error_object_model == error_object_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        error_object_model_json2 = error_object_model.to_dict()
+        assert error_object_model_json2 == error_object_model_json
+
+
+class TestModel_ErrorResponse:
+    """
+    Test Class for ErrorResponse
+    """
+
+    def test_error_response_serialization(self):
+        """
+        Test serialization/deserialization for ErrorResponse
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        conflicts_with_model = {}  # ConflictsWith
+        conflicts_with_model['etag'] = 'testString'
+        conflicts_with_model['role'] = 'testString'
+        conflicts_with_model['policy'] = 'testString'
+
+        error_details_model = {}  # ErrorDetails
+        error_details_model['conflicts_with'] = conflicts_with_model
+
+        error_object_model = {}  # ErrorObject
+        error_object_model['code'] = 'insufficent_permissions'
+        error_object_model['message'] = 'testString'
+        error_object_model['details'] = error_details_model
+        error_object_model['more_info'] = 'testString'
+
+        # Construct a json representation of a ErrorResponse model
+        error_response_model_json = {}
+        error_response_model_json['trace'] = 'testString'
+        error_response_model_json['errors'] = [error_object_model]
+        error_response_model_json['status_code'] = 38
+
+        # Construct a model instance of ErrorResponse by calling from_dict on the json representation
+        error_response_model = ErrorResponse.from_dict(error_response_model_json)
+        assert error_response_model != False
+
+        # Construct a model instance of ErrorResponse by calling from_dict on the json representation
+        error_response_model_dict = ErrorResponse.from_dict(error_response_model_json).__dict__
+        error_response_model2 = ErrorResponse(**error_response_model_dict)
+
+        # Verify the model instances are equivalent
+        assert error_response_model == error_response_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        error_response_model_json2 = error_response_model.to_dict()
+        assert error_response_model_json2 == error_response_model_json
 
 
 class TestModel_Policy:
@@ -2797,6 +4964,10 @@ class TestModel_Policy:
         policy_resource_model['attributes'] = [resource_attribute_model]
         policy_resource_model['tags'] = [resource_tag_model]
 
+        template_metada_model = {}  # TemplateMetada
+        template_metada_model['crn'] = 'testString'
+        template_metada_model['version'] = 'testString'
+
         # Construct a json representation of a Policy model
         policy_model_json = {}
         policy_model_json['type'] = 'testString'
@@ -2805,6 +4976,7 @@ class TestModel_Policy:
         policy_model_json['roles'] = [policy_role_model]
         policy_model_json['resources'] = [policy_resource_model]
         policy_model_json['state'] = 'active'
+        policy_model_json['template'] = template_metada_model
 
         # Construct a model instance of Policy by calling from_dict on the json representation
         policy_model = Policy.from_dict(policy_model_json)
@@ -2858,6 +5030,10 @@ class TestModel_PolicyList:
         policy_resource_model['attributes'] = [resource_attribute_model]
         policy_resource_model['tags'] = [resource_tag_model]
 
+        template_metada_model = {}  # TemplateMetada
+        template_metada_model['crn'] = 'testString'
+        template_metada_model['version'] = 'testString'
+
         policy_model = {}  # Policy
         policy_model['type'] = 'testString'
         policy_model['description'] = 'testString'
@@ -2865,6 +5041,7 @@ class TestModel_PolicyList:
         policy_model['roles'] = [policy_role_model]
         policy_model['resources'] = [policy_resource_model]
         policy_model['state'] = 'active'
+        policy_model['template'] = template_metada_model
 
         # Construct a json representation of a PolicyList model
         policy_list_model_json = {}


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
Added feature support for Enterprise IAM work, policy templates and get template assigments.

Issue: https://github.ibm.com/IAM/AM-issues/issues/1346

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

SDK adopters will be able to call policy template and assignment APIs.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->

API defintion:
[Staging](https://github.ibm.com/cloud-api-docs/iam-access-management/blob/test/iam-policy-management.yaml)
[Prod](https://github.ibm.com/cloud-api-docs/iam-access-management/pull/168)

Test Information
Integration Tests:
```sh
platform-services-python-sdk % pytest test/integration/test_iam_policy_management_v1.py
============================================================================================== test session starts ===============================================================================================
platform darwin -- Python 3.10.8, pytest-7.2.0, pluggy-1.0.0
rootdir: /Users/shaunsmacibm/Desktop/cloud-platform/iam/sdk/platform-services-python-sdk
plugins: cov-2.12.1
collected 26 items                                                                                                                                                                                               

test/integration/test_iam_policy_management_v1.py ..........................                                                                                                                               [100%]

============================================================================================== 26 passed in 10.71s ===============================================================================================

```

examples tests:
```sh
platform-services-python-sdk % pytest examples/test_iam_policy_management_v1_examples.py
============================================================================================== test session starts ===============================================================================================
platform darwin -- Python 3.10.8, pytest-7.2.0, pluggy-1.0.0
rootdir: /Users/shaunsmacibm/Desktop/cloud-platform/iam/sdk/platform-services-python-sdk
plugins: cov-2.12.1
collected 27 items                                                                                                                                                                                               

examples/test_iam_policy_management_v1_examples.py ...........................                                                                                                                             [100%]

=============================================================================================== 27 passed in 6.64s ===============================================================================================

```