### PR TITLE
feat(IAM Identity): Add support for IAM enterprise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
 cache: pip
 
 install:
-- sudo apt-get update
+# - sudo apt-get update
 - sudo apt-get install pandoc
 - pip install pypandoc
 - pip install setuptools=="60.8.2"

--- a/examples/test_iam_identity_v1_examples.py
+++ b/examples/test_iam_identity_v1_examples.py
@@ -1127,7 +1127,7 @@ class TestIamIdentityV1Examples:
                 name='Example-Profile-Template',
                 description='IAM enterprise trusted profile template example',
                 account_id=enterprise_account_id,
-                profile=profile
+                profile=profile,
             )
 
             profile_template = create_response.get_result()
@@ -1153,8 +1153,7 @@ class TestIamIdentityV1Examples:
 
             # begin-get_profile_template_version
             get_response = iam_identity_service.get_profile_template_version(
-                template_id=profile_template_id,
-                version=str(profile_template_version)
+                template_id=profile_template_id, version=str(profile_template_version)
             )
 
             profile_template = get_response.get_result()
@@ -1167,7 +1166,6 @@ class TestIamIdentityV1Examples:
         except ApiException as e:
             pytest.fail(str(e))
 
-
     @needscredentials
     def test_list_profile_templates(self):
         """
@@ -1177,9 +1175,7 @@ class TestIamIdentityV1Examples:
             print('\nlist_profile_templates() result:')
             # begin-list_profile_templates
 
-            list_response = iam_identity_service.list_profile_templates(
-                account_id=enterprise_account_id
-            )
+            list_response = iam_identity_service.list_profile_templates(account_id=enterprise_account_id)
 
             profile_template_list = list_response.get_result()
             print('\nlist_profile_templates response: ', json.dumps(profile_template_list, indent=2))
@@ -1228,8 +1224,7 @@ class TestIamIdentityV1Examples:
 
             # begin-commit_profile_template
             commit_response = iam_identity_service.commit_profile_template(
-                template_id=profile_template_id,
-                version=str(profile_template_version)
+                template_id=profile_template_id, version=str(profile_template_version)
             )
             # end-commit_profile_template
 
@@ -1241,7 +1236,7 @@ class TestIamIdentityV1Examples:
                 template_id=profile_template_id,
                 template_version=profile_template_version,
                 target_type='Account',
-                target=enterprise_subaccount_id
+                target=enterprise_subaccount_id,
             )
             assignment = assign_response.get_result()
             print('\ncreate_trusted_profile_assignment() response: ', json.dumps(assignment, indent=2))
@@ -1281,8 +1276,7 @@ class TestIamIdentityV1Examples:
 
             # begin-list_trusted_profile_assignments
             list_response = iam_identity_service.list_trusted_profile_assignments(
-                account_id=enterprise_account_id,
-                template_id=profile_template_id
+                account_id=enterprise_account_id, template_id=profile_template_id
             )
             assignment_list = list_response.get_result()
             print('\nlist_trusted_profile_assignments() response: ', json.dumps(assignment_list, indent=2))
@@ -1329,7 +1323,7 @@ class TestIamIdentityV1Examples:
                 name='Example-Profile-Template',
                 description='IAM enterprise trusted profile template example - new version',
                 account_id=enterprise_account_id,
-                profile=profile
+                profile=profile,
             )
 
             profile_template = create_response.get_result()
@@ -1351,9 +1345,7 @@ class TestIamIdentityV1Examples:
             global profile_template_id
 
             # begin-get_latest_profile_template_version
-            get_response = iam_identity_service.get_latest_profile_template_version(
-                template_id=profile_template_id
-            )
+            get_response = iam_identity_service.get_latest_profile_template_version(template_id=profile_template_id)
 
             profile_template = get_response.get_result()
             print('\nget_latest_profile_template_version response: ', json.dumps(profile_template, indent=2))
@@ -1371,9 +1363,7 @@ class TestIamIdentityV1Examples:
             global profile_template_id
 
             # begin-list_versions_of_profile_template
-            list_response = iam_identity_service.list_versions_of_profile_template(
-                template_id=profile_template_id
-            )
+            list_response = iam_identity_service.list_versions_of_profile_template(template_id=profile_template_id)
             profile_template_list = list_response.get_result()
             print('\nlist_profile_template_versions response: ', json.dumps(profile_template_list, indent=2))
             # end-list_versions_of_profile_template
@@ -1393,8 +1383,7 @@ class TestIamIdentityV1Examples:
             global profile_template_assignment_etag
 
             commit_response = iam_identity_service.commit_profile_template(
-                template_id=profile_template_id,
-                version=str(profile_template_version)
+                template_id=profile_template_id, version=str(profile_template_version)
             )
 
             self.waitUntilTrustedProfileAssignmentFinished(iam_identity_service, profile_template_assignment_id)
@@ -1403,7 +1392,7 @@ class TestIamIdentityV1Examples:
             assign_response = iam_identity_service.update_trusted_profile_assignment(
                 assignment_id=profile_template_assignment_id,
                 template_version=profile_template_version,
-                if_match=profile_template_assignment_etag
+                if_match=profile_template_assignment_etag,
             )
             assignment = assign_response.get_result()
             print('\nupdate_profile_template_assignment response: ', json.dumps(assignment, indent=2))
@@ -1443,8 +1432,7 @@ class TestIamIdentityV1Examples:
 
             # begin-delete_profile_template_version
             delete_response = iam_identity_service.delete_profile_template_version(
-                template_id=profile_template_id,
-                version='1'
+                template_id=profile_template_id, version='1'
             )
             # end-delete_profile_template_version
         except ApiException as e:
@@ -1485,7 +1473,7 @@ class TestIamIdentityV1Examples:
                 name='Example-Account-Settings-Template',
                 description='IAM enterprise account settings template example',
                 account_id=enterprise_account_id,
-                account_settings=account_settings
+                account_settings=account_settings,
             )
 
             account_settings_template = create_response.get_result()
@@ -1511,8 +1499,7 @@ class TestIamIdentityV1Examples:
 
             # begin-get_account_settings_template_version
             get_response = iam_identity_service.get_account_settings_template_version(
-                template_id=account_settings_template_id,
-                version=str(account_settings_template_version)
+                template_id=account_settings_template_id, version=str(account_settings_template_version)
             )
 
             account_settings_template = get_response.get_result()
@@ -1533,9 +1520,7 @@ class TestIamIdentityV1Examples:
             print('\nlist_account_settings_templates() result:')
 
             # begin-list_account_settings_templates
-            list_response = iam_identity_service.list_account_settings_templates(
-                account_id=enterprise_account_id
-            )
+            list_response = iam_identity_service.list_account_settings_templates(account_id=enterprise_account_id)
 
             account_settings_template_list = list_response.get_result()
             print('\nlist_account_settings_templates response: ', json.dumps(account_settings_template_list, indent=2))
@@ -1567,7 +1552,7 @@ class TestIamIdentityV1Examples:
                 if_match=account_settings_template_etag,
                 name='Example-Account-Settings-Template',
                 description='IAM enterprise account settings template example - updated',
-                account_settings=account_settings
+                account_settings=account_settings,
             )
 
             account_settings_template = update_response.get_result()
@@ -1590,8 +1575,7 @@ class TestIamIdentityV1Examples:
             global account_settings_template_version
             # begin-commit_account_settings_template
             commit_response = iam_identity_service.commit_account_settings_template(
-                template_id=account_settings_template_id,
-                version=str(account_settings_template_version)
+                template_id=account_settings_template_id, version=str(account_settings_template_version)
             )
             # end-commit_account_settings_template
             """
@@ -1603,7 +1587,7 @@ class TestIamIdentityV1Examples:
                 template_id=account_settings_template_id,
                 template_version=account_settings_template_version,
                 target_type='Account',
-                target=enterprise_subaccount_id
+                target=enterprise_subaccount_id,
             )
             assignment = assign_response.get_result()
             print('\ncreate_account_settings_assignment() response: ', json.dumps(assignment, indent=2))
@@ -1627,8 +1611,7 @@ class TestIamIdentityV1Examples:
             # begin-list_account_settings_assignments
 
             list_response = iam_identity_service.list_account_settings_assignments(
-                account_id=enterprise_account_id,
-                template_id=account_settings_template_id
+                account_id=enterprise_account_id, template_id=account_settings_template_id
             )
             assignment_list = list_response.get_result()
             print('\ncreate_account_settings_assignment() response: ', json.dumps(assignment_list, indent=2))
@@ -1675,11 +1658,14 @@ class TestIamIdentityV1Examples:
                 name='Example-Account-Settings-Template',
                 description='IAM enterprise account settings template example - new version',
                 account_id=enterprise_account_id,
-                account_settings=account_settings
+                account_settings=account_settings,
             )
 
             account_settings_template = create_response.get_result()
-            print('\ncreate_account_settings_template_version() response: ', json.dumps(account_settings_template, indent=2))
+            print(
+                '\ncreate_account_settings_template_version() response: ',
+                json.dumps(account_settings_template, indent=2),
+            )
 
             global account_settings_template_version
             account_settings_template_version = account_settings_template['version']
@@ -1701,7 +1687,10 @@ class TestIamIdentityV1Examples:
                 template_id=account_settings_template_id
             )
             account_settings_template = get_response.get_result()
-            print('\nget_latest_account_settings_template_version response: ', json.dumps(account_settings_template, indent=2))
+            print(
+                '\nget_latest_account_settings_template_version response: ',
+                json.dumps(account_settings_template, indent=2),
+            )
             # end-get_latest_account_settings_template_version
         except ApiException as e:
             pytest.fail(str(e))
@@ -1720,7 +1709,10 @@ class TestIamIdentityV1Examples:
                 template_id=account_settings_template_id
             )
             account_settings_template_list = list_response.get_result()
-            print('\nlist_account_settings_template_versions response: ', json.dumps(account_settings_template_list, indent=2))
+            print(
+                '\nlist_account_settings_template_versions response: ',
+                json.dumps(account_settings_template_list, indent=2),
+            )
             # end-list_versions_of_account_settings_template
         except ApiException as e:
             pytest.fail(str(e))
@@ -1738,17 +1730,18 @@ class TestIamIdentityV1Examples:
             global account_settings_template_assignment_id
             global account_settings_template_assignment_etag
             commit_response = iam_identity_service.commit_account_settings_template(
-                template_id=account_settings_template_id,
-                version=str(account_settings_template_version)
+                template_id=account_settings_template_id, version=str(account_settings_template_version)
             )
 
-            self.waitUntilAccountSettingsAssignmentFinished(iam_identity_service, account_settings_template_assignment_id)
+            self.waitUntilAccountSettingsAssignmentFinished(
+                iam_identity_service, account_settings_template_assignment_id
+            )
 
             # begin-update_account_settings_assignment
             assign_response = iam_identity_service.update_account_settings_assignment(
                 assignment_id=account_settings_template_assignment_id,
                 template_version=account_settings_template_version,
-                if_match=account_settings_template_assignment_etag
+                if_match=account_settings_template_assignment_etag,
             )
             assignment = assign_response.get_result()
             print('\nupdate_account_settings_template_assignment response: ', json.dumps(assignment, indent=2))
@@ -1766,7 +1759,9 @@ class TestIamIdentityV1Examples:
             print('\ndelete_account_settings_assignment() result:')
             global account_settings_template_assignment_id
 
-            self.waitUntilAccountSettingsAssignmentFinished(iam_identity_service, account_settings_template_assignment_id)
+            self.waitUntilAccountSettingsAssignmentFinished(
+                iam_identity_service, account_settings_template_assignment_id
+            )
             # begin-delete_account_settings_assignment
             delete_response = iam_identity_service.delete_account_settings_assignment(
                 assignment_id=account_settings_template_assignment_id
@@ -1787,8 +1782,7 @@ class TestIamIdentityV1Examples:
             # begin-delete_account_settings_template_version
 
             delete_response = iam_identity_service.delete_account_settings_template_version(
-                template_id=account_settings_template_id,
-                version='1'
+                template_id=account_settings_template_id, version='1'
             )
             # end-delete_account_settings_template_version
         except ApiException as e:
@@ -1802,7 +1796,9 @@ class TestIamIdentityV1Examples:
         try:
             print('\ndelete_all_versions_of_account_settings_template() result:')
             global account_settings_template_id
-            self.waitUntilAccountSettingsAssignmentFinished(iam_identity_service, account_settings_template_assignment_id)
+            self.waitUntilAccountSettingsAssignmentFinished(
+                iam_identity_service, account_settings_template_assignment_id
+            )
             # begin-delete_all_versions_of_account_settings_template
             delete_response = iam_identity_service.delete_all_versions_of_account_settings_template(
                 template_id=account_settings_template_id
@@ -1810,6 +1806,7 @@ class TestIamIdentityV1Examples:
             # end-delete_all_versions_of_account_settings_template
         except ApiException as e:
             pytest.fail(str(e))
+
 
 # endregion
 ##############################################################################

--- a/examples/test_iam_identity_v1_examples.py
+++ b/examples/test_iam_identity_v1_examples.py
@@ -20,6 +20,7 @@ Examples for IamIdentityV1
 import json
 import os
 import pytest
+import time
 from ibm_cloud_sdk_core import ApiException, read_external_sources
 from ibm_platform_services.iam_identity_v1 import *
 
@@ -34,6 +35,9 @@ from ibm_platform_services.iam_identity_v1 import *
 # IAM_IDENTITY_APIKEY=<IAM APIKEY for the User>
 # IAM_IDENTITY_ACCOUNT_ID=<AccountID which is unique to the User>
 # IAM_IDENTITY_IAM_ID=<IAM ID which is unique to the User account>
+# IAM_IDENTITY_IAM_ID_MEMBER=<IAM ID of a user belonging to the account but different to the one above>
+# IAM_IDENTITY_ENTERPRISE_ACCOUNT_ID=<AccountID of the enterprise account>
+# IAM_IDENTITY_ENTERPRISE_SUBACCOUNT_ID=<AccountID of an account in the enterprise>
 #
 # These configuration properties can be exported as environment variables, or stored
 # in a configuration file and then:
@@ -50,7 +54,10 @@ serviceid_name = 'Example-ServiceId'
 
 account_id = None
 iam_id = None
+iam_id_member = None
 apikey = None
+enterprise_account_id = None
+enterprise_subaccount_id = None
 
 apikey_id = None
 apikey_etag = None
@@ -70,7 +77,17 @@ account_settings_etag = None
 
 report_reference_mfa = None
 
-iam_id_member = None
+profile_template_id = None
+profile_template_version = None
+profile_template_etag = None
+profile_template_assignment_id = None
+profile_template_assignment_etag = None
+
+account_settings_template_id = None
+account_settings_template_version = None
+account_settings_template_etag = None
+account_settings_template_assignment_id = None
+account_settings_template_assignment_etag = None
 
 
 ##############################################################################
@@ -111,11 +128,61 @@ class TestIamIdentityV1Examples:
             global apikey
             apikey = config['APIKEY']
 
+            global enterprise_account_id
+            enterprise_account_id = config['ENTERPRISE_ACCOUNT_ID']
+
+            global enterprise_subaccount_id
+            enterprise_subaccount_id = config['ENTERPRISE_SUBACCOUNT_ID']
+
         print('Setup complete.')
 
     needscredentials = pytest.mark.skipif(
         not os.path.exists(config_file), reason="External configuration not available, skipping..."
     )
+
+    @classmethod
+    def isFinished(cls, status):
+        return "succeeded" == status.lower() or "failed" == status.lower()
+
+    @classmethod
+    def waitUntilTrustedProfileAssignmentFinished(cls, service, assignmentId):
+        finished = False
+        for x in range(20):
+            try:
+                response = service.get_trusted_profile_assignment(assignment_id=assignmentId)
+                assignment = response.get_result()
+                finished = cls.isFinished(assignment['status'])
+                if finished:
+                    global profile_template_assignment_etag
+                    profile_template_assignment_etag = response.get_headers()['Etag']
+                    profile_template_assignment_etag is not None
+                    break
+            except ApiException as e:
+                if e.code == 404:
+                    finished = True
+                    break
+            time.sleep(10)
+        assert finished == True
+
+    @classmethod
+    def waitUntilAccountSettingsAssignmentFinished(cls, service, assignmentId):
+        finished = False
+        for x in range(20):
+            try:
+                response = service.get_account_settings_assignment(assignment_id=assignmentId)
+                assignment = response.get_result()
+                finished = cls.isFinished(assignment['status'])
+                if finished:
+                    global account_settings_template_assignment_etag
+                    account_settings_template_assignment_etag = response.get_headers()['Etag']
+                    account_settings_template_assignment_etag is not None
+                    break
+            except ApiException as e:
+                if e.code == 404:
+                    finished = True
+                    break
+            time.sleep(10)
+        assert finished == True
 
     @needscredentials
     def test_create_api_key_example(self):
@@ -543,7 +610,7 @@ class TestIamIdentityV1Examples:
             claimRule = iam_identity_service.create_claim_rule(
                 profile_id=profile_id,
                 type='Profile-SAML',
-                realm_name='https://w3id.sso.ibm.com/auth/sps/samlidp2/saml20',
+                realm_name='https://sdk.test.realm/1234',
                 expiration=43200,
                 conditions=[profile_claim_rule_conditions_model],
             ).get_result()
@@ -625,7 +692,7 @@ class TestIamIdentityV1Examples:
                 expiration=33200,
                 conditions=[profile_claim_rule_conditions_model],
                 type='Profile-SAML',
-                realm_name='https://w3id.sso.ibm.com/auth/sps/samlidp2/saml20',
+                realm_name='https://sdk.test.realm/1234',
             ).get_result()
 
             print(json.dumps(claimRule, indent=2))
@@ -774,7 +841,7 @@ class TestIamIdentityV1Examples:
 
             # begin-set_profile_identities
             accounts = [account_id]
-            profileIdentity = ProfileIdentity(
+            profileIdentity = ProfileIdentityRequest(
                 identifier=iam_id, accounts=accounts, type="user", description="Identity description"
             )
             profile_identities_input = [profileIdentity]
@@ -1031,6 +1098,718 @@ class TestIamIdentityV1Examples:
         except ApiException as e:
             pytest.fail(str(e))
 
+    @needscredentials
+    def test_create_profile_template(self):
+        """
+        create_profile_template request example
+        """
+        try:
+            print('\ncreate_profile_template() result:')
+            # begin-create_profile_template
+            profile_claim_rule_conditions = {}
+            profile_claim_rule_conditions['claim'] = 'blueGroups'
+            profile_claim_rule_conditions['operator'] = 'EQUALS'
+            profile_claim_rule_conditions['value'] = '\"cloud-docs-dev\"'
+
+            profile_claim_rule = {}
+            profile_claim_rule['name'] = 'My Rule'
+            profile_claim_rule['realm_name'] = 'https://sdk.test.realm/1234'
+            profile_claim_rule['type'] = 'Profile-SAML'
+            profile_claim_rule['expiration'] = 43200
+            profile_claim_rule['conditions'] = [profile_claim_rule_conditions]
+
+            profile = {}
+            profile['name'] = 'Profile-From-Example-Template'
+            profile['description'] = 'Trusted profile created from a template'
+            profile['rules'] = [profile_claim_rule]
+
+            create_response = iam_identity_service.create_profile_template(
+                name='Example-Profile-Template',
+                description='IAM enterprise trusted profile template example',
+                account_id=enterprise_account_id,
+                profile=profile
+            )
+
+            profile_template = create_response.get_result()
+            print('\ncreate_profile_template() response: ', json.dumps(profile_template, indent=2))
+
+            global profile_template_id
+            profile_template_id = profile_template['id']
+            global profile_template_version
+            profile_template_version = profile_template['version']
+            # end-create_profile_template
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_get_profile_template(self):
+        """
+        get_profile_template request example
+        """
+        try:
+            print('\nget_profile_template() result:')
+            global profile_template_id
+            global profile_template_version
+
+            # begin-get_profile_template_version
+            get_response = iam_identity_service.get_profile_template_version(
+                template_id=profile_template_id,
+                version=str(profile_template_version)
+            )
+
+            profile_template = get_response.get_result()
+            print('\nget_profile_template response: ', json.dumps(profile_template, indent=2))
+
+            global profile_template_etag
+            profile_template_etag = get_response.get_headers()['Etag']
+            profile_template_etag is not None
+            # end-get_profile_template_version
+        except ApiException as e:
+            pytest.fail(str(e))
+
+
+    @needscredentials
+    def test_list_profile_templates(self):
+        """
+        list_profile_templates request example
+        """
+        try:
+            print('\nlist_profile_templates() result:')
+            # begin-list_profile_templates
+
+            list_response = iam_identity_service.list_profile_templates(
+                account_id=enterprise_account_id
+            )
+
+            profile_template_list = list_response.get_result()
+            print('\nlist_profile_templates response: ', json.dumps(profile_template_list, indent=2))
+            # end-list_profile_templates
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_update_profile_template(self):
+        """
+        update_profile_template request example
+        """
+        try:
+            print('\nupdate_profile_template() result:')
+            global profile_template_id
+            global profile_template_version
+            global profile_template_etag
+
+            # begin-update_profile_template_version
+            update_response = iam_identity_service.update_profile_template_version(
+                account_id=enterprise_account_id,
+                template_id=profile_template_id,
+                version=str(profile_template_version),
+                if_match=profile_template_etag,
+                name='Example-Profile-Template',
+                description='IAM enterprise trusted profile template example - updated',
+            )
+
+            profile_template = update_response.get_result()
+            print('\nupdate_profile_template() response: ', json.dumps(profile_template, indent=2))
+
+            profile_template_etag = update_response.get_headers()['Etag']
+            # end-update_profile_template_version
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_assign_profile_template(self):
+        """
+        commit_profile_template request example
+        """
+        try:
+            print('\nupdate_profile_template() result:')
+            global profile_template_id
+            global profile_template_version
+
+            # begin-commit_profile_template
+            commit_response = iam_identity_service.commit_profile_template(
+                template_id=profile_template_id,
+                version=str(profile_template_version)
+            )
+            # end-commit_profile_template
+
+            """
+            create_trusted_profile_assignment request example
+            """
+            # begin-create_trusted_profile_assignment
+            assign_response = iam_identity_service.create_trusted_profile_assignment(
+                template_id=profile_template_id,
+                template_version=profile_template_version,
+                target_type='Account',
+                target=enterprise_subaccount_id
+            )
+            assignment = assign_response.get_result()
+            print('\ncreate_trusted_profile_assignment() response: ', json.dumps(assignment, indent=2))
+            global profile_template_assignment_id
+            profile_template_assignment_id = assignment['id']
+            global profile_template_assignment_etag
+            profile_template_assignment_etag = assign_response.get_headers()['Etag']
+            # end-create_trusted_profile_assignment
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_get_trusted_profile_assignment(self):
+        """
+        get_trusted_profile_assignment request example
+        """
+        try:
+            print('\nget_trusted_profile_assignment() result:')
+            global profile_template_assignment_id
+
+            # begin-get_trusted_profile_assignment
+            response = iam_identity_service.get_trusted_profile_assignment(assignment_id=profile_template_assignment_id)
+            assignment = response.get_result()
+            print('\nget_trusted_profile_assignment() response: ', json.dumps(assignment, indent=2))
+            # end-get_trusted_profile_assignment
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_list_profile_template_assignments(self):
+        """
+        list_profile_template_assignments request example
+        """
+        try:
+            print('\nlist_profile_template_assignments() result:')
+            global profile_template_id
+
+            # begin-list_trusted_profile_assignments
+            list_response = iam_identity_service.list_trusted_profile_assignments(
+                account_id=enterprise_account_id,
+                template_id=profile_template_id
+            )
+            assignment_list = list_response.get_result()
+            print('\nlist_trusted_profile_assignments() response: ', json.dumps(assignment_list, indent=2))
+            # end-list_trusted_profile_assignments
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_create_new_profile_template_version(self):
+        """
+        create_profile_template_version request example
+        """
+        try:
+            print('\ncreate_profile_template_version() result:')
+            global profile_template_id
+
+            # begin-create_profile_template_version
+            profile_claim_rule_conditions = {}
+            profile_claim_rule_conditions['claim'] = 'blueGroups'
+            profile_claim_rule_conditions['operator'] = 'EQUALS'
+            profile_claim_rule_conditions['value'] = '\"cloud-docs-dev\"'
+
+            profile_claim_rule = {}
+            profile_claim_rule['name'] = 'My Rule'
+            profile_claim_rule['realm_name'] = 'https://sdk.test.realm/1234'
+            profile_claim_rule['type'] = 'Profile-SAML'
+            profile_claim_rule['expiration'] = 43200
+            profile_claim_rule['conditions'] = [profile_claim_rule_conditions]
+
+            profile_identity = {}
+            profile_identity['identifier'] = iam_id
+            profile_identity['accounts'] = [enterprise_account_id]
+            profile_identity['type'] = 'user'
+            profile_identity['description'] = 'Identity description'
+
+            profile = {}
+            profile['name'] = 'Profile-From-Example-Template'
+            profile['description'] = 'Trusted profile created from a template - new version'
+            profile['rules'] = [profile_claim_rule]
+            profile['identities'] = [profile_identity]
+
+            create_response = iam_identity_service.create_profile_template_version(
+                template_id=profile_template_id,
+                name='Example-Profile-Template',
+                description='IAM enterprise trusted profile template example - new version',
+                account_id=enterprise_account_id,
+                profile=profile
+            )
+
+            profile_template = create_response.get_result()
+            print('\ncreate_profile_template_version() response: ', json.dumps(profile_template, indent=2))
+
+            global profile_template_version
+            profile_template_version = profile_template['version']
+            # end-create_profile_template_version
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_get_latest_profile_template_version(self):
+        """
+        get_latest_profile_template_version request example
+        """
+        try:
+            print('\nget_latest_profile_template_version() result:')
+            global profile_template_id
+
+            # begin-get_latest_profile_template_version
+            get_response = iam_identity_service.get_latest_profile_template_version(
+                template_id=profile_template_id
+            )
+
+            profile_template = get_response.get_result()
+            print('\nget_latest_profile_template_version response: ', json.dumps(profile_template, indent=2))
+            # end-get_latest_profile_template_version
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_list_profile_template_versions(self):
+        """
+        list_profile_template_versions request example
+        """
+        try:
+            print('\nlist_profile_template_versions() result:')
+            global profile_template_id
+
+            # begin-list_versions_of_profile_template
+            list_response = iam_identity_service.list_versions_of_profile_template(
+                template_id=profile_template_id
+            )
+            profile_template_list = list_response.get_result()
+            print('\nlist_profile_template_versions response: ', json.dumps(profile_template_list, indent=2))
+            # end-list_versions_of_profile_template
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_update_profile_template_assignment(self):
+        """
+        update_trusted_profile_assignment request example
+        """
+        try:
+            print('\nupdate_trusted_profile_assignment() result:')
+            global profile_template_id
+            global profile_template_version
+            global profile_template_assignment_id
+            global profile_template_assignment_etag
+
+            commit_response = iam_identity_service.commit_profile_template(
+                template_id=profile_template_id,
+                version=str(profile_template_version)
+            )
+
+            self.waitUntilTrustedProfileAssignmentFinished(iam_identity_service, profile_template_assignment_id)
+
+            # begin-update_trusted_profile_assignment
+            assign_response = iam_identity_service.update_trusted_profile_assignment(
+                assignment_id=profile_template_assignment_id,
+                template_version=profile_template_version,
+                if_match=profile_template_assignment_etag
+            )
+            assignment = assign_response.get_result()
+            print('\nupdate_profile_template_assignment response: ', json.dumps(assignment, indent=2))
+            profile_template_assignment_etag = assign_response.get_headers()['Etag']
+            # end-update_trusted_profile_assignment
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_delete_profile_template_assignment(self):
+        """
+        delete_trusted_profile_assignment request example
+        """
+        try:
+            print('\ndelete_trusted_profile_assignment() result:')
+            global profile_template_assignment_id
+
+            self.waitUntilTrustedProfileAssignmentFinished(iam_identity_service, profile_template_assignment_id)
+
+            # begin-delete_trusted_profile_assignment
+            delete_response = iam_identity_service.delete_trusted_profile_assignment(
+                assignment_id=profile_template_assignment_id
+            )
+            # end-delete_trusted_profile_assignment
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_delete_profile_template_version(self):
+        """
+        delete_profile_template_version request example
+        """
+        try:
+            print('\ndelete_profile_template_version() result:')
+            global profile_template_id
+            global profile_template_assignment_id
+
+            # begin-delete_profile_template_version
+            delete_response = iam_identity_service.delete_profile_template_version(
+                template_id=profile_template_id,
+                version='1'
+            )
+            # end-delete_profile_template_version
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_delete_profile_template(self):
+        """
+        delete_all_versions_of_profile_template request example
+        """
+        try:
+            print('\ndelete_all_versions_of_profile_template() result:')
+            global profile_template_id
+
+            self.waitUntilTrustedProfileAssignmentFinished(iam_identity_service, profile_template_assignment_id)
+
+            # begin-delete_all_versions_of_profile_template
+            delete_response = iam_identity_service.delete_all_versions_of_profile_template(
+                template_id=profile_template_id
+            )
+            # end-delete_all_versions_of_profile_template
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_create_account_settings_template(self):
+        """
+        create_account_settings_template request example
+        """
+        try:
+            print('\ncreate_account_settings_template() result:')
+            # begin-create_account_settings_template
+            account_settings = {}
+            account_settings['mfa'] = 'LEVEL1'
+            account_settings['system_access_token_expiration_in_seconds'] = 3000
+
+            create_response = iam_identity_service.create_account_settings_template(
+                name='Example-Account-Settings-Template',
+                description='IAM enterprise account settings template example',
+                account_id=enterprise_account_id,
+                account_settings=account_settings
+            )
+
+            account_settings_template = create_response.get_result()
+            print('\ncreate_account_settings_template() response: ', json.dumps(account_settings_template, indent=2))
+
+            global account_settings_template_id
+            account_settings_template_id = account_settings_template['id']
+            global account_settings_template_version
+            account_settings_template_version = account_settings_template['version']
+            # end-create_account_settings_template
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_get_account_settings_template(self):
+        """
+        get_account_settings_template_version request example
+        """
+        try:
+            print('\nget_account_settings_template_version() result:')
+            global account_settings_template_id
+            global account_settings_template_version
+
+            # begin-get_account_settings_template_version
+            get_response = iam_identity_service.get_account_settings_template_version(
+                template_id=account_settings_template_id,
+                version=str(account_settings_template_version)
+            )
+
+            account_settings_template = get_response.get_result()
+            print('\nget_account_settings_template response: ', json.dumps(account_settings_template, indent=2))
+
+            global account_settings_template_etag
+            account_settings_template_etag = get_response.get_headers()['Etag']
+            # end-get_account_settings_template_version
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_list_account_settings_templates(self):
+        """
+        list_account_settings_templates request example
+        """
+        try:
+            print('\nlist_account_settings_templates() result:')
+
+            # begin-list_account_settings_templates
+            list_response = iam_identity_service.list_account_settings_templates(
+                account_id=enterprise_account_id
+            )
+
+            account_settings_template_list = list_response.get_result()
+            print('\nlist_account_settings_templates response: ', json.dumps(account_settings_template_list, indent=2))
+            # end-list_account_settings_templates
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_update_account_settings_template(self):
+        """
+        update_account_settings_template_version request example
+        """
+        try:
+            print('\nupdate_account_settings_template_version() result:')
+
+            global account_settings_template_id
+            global account_settings_template_version
+            global account_settings_template_etag
+            # begin-update_account_settings_template_version
+
+            account_settings = {}
+            account_settings['mfa'] = 'LEVEL1'
+            account_settings['system_access_token_expiration_in_seconds'] = 3000
+
+            update_response = iam_identity_service.update_account_settings_template_version(
+                account_id=enterprise_account_id,
+                template_id=account_settings_template_id,
+                version=str(account_settings_template_version),
+                if_match=account_settings_template_etag,
+                name='Example-Account-Settings-Template',
+                description='IAM enterprise account settings template example - updated',
+                account_settings=account_settings
+            )
+
+            account_settings_template = update_response.get_result()
+            print('\nupdate_account_settings_template() response: ', json.dumps(account_settings_template, indent=2))
+
+            account_settings_template_etag = update_response.get_headers()['Etag']
+            # end-update_account_settings_template_version
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_assign_account_settings_template(self):
+        """
+        commit_account_settings_template request example
+        """
+        try:
+            print('\ncommit_account_settings_template() result:')
+
+            global account_settings_template_id
+            global account_settings_template_version
+            # begin-commit_account_settings_template
+            commit_response = iam_identity_service.commit_account_settings_template(
+                template_id=account_settings_template_id,
+                version=str(account_settings_template_version)
+            )
+            # end-commit_account_settings_template
+            """
+            create_account_settings_assignment request example
+            """
+            print('\ncreate_account_settings_assignment() result:')
+            # begin-create_account_settings_assignment
+            assign_response = iam_identity_service.create_account_settings_assignment(
+                template_id=account_settings_template_id,
+                template_version=account_settings_template_version,
+                target_type='Account',
+                target=enterprise_subaccount_id
+            )
+            assignment = assign_response.get_result()
+            print('\ncreate_account_settings_assignment() response: ', json.dumps(assignment, indent=2))
+            global account_settings_template_assignment_id
+            account_settings_template_assignment_id = assignment['id']
+            global account_settings_template_assignment_etag
+            account_settings_template_assignment_etag = assign_response.get_headers()['Etag']
+            # end-create_account_settings_assignment
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_list_account_settings_template_assignments(self):
+        """
+        list_account_settings_assignments request example
+        """
+        try:
+            print('\nlist_account_settings_assignments() result:')
+
+            global account_settings_template_id
+            # begin-list_account_settings_assignments
+
+            list_response = iam_identity_service.list_account_settings_assignments(
+                account_id=enterprise_account_id,
+                template_id=account_settings_template_id
+            )
+            assignment_list = list_response.get_result()
+            print('\ncreate_account_settings_assignment() response: ', json.dumps(assignment_list, indent=2))
+            # end-list_account_settings_assignments
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_get_latest_account_settings_template_version(self):
+        """
+        get_account_settings_assignment request example
+        """
+        try:
+            print('\nget_account_settings_assignment() result:')
+            global account_settings_template_assignment_id
+
+            # begin-get_account_settings_assignment
+            response = service.get_account_settings_assignment(assignment_id=account_settings_template_assignment_id)
+            assignment = response.get_result()
+            print('\nget_latest_account_settings_template_version response: ', json.dumps(assignment, indent=2))
+            # end-get_account_settings_assignment
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_create_new_account_settings_template_version(self):
+        """
+        create_account_settings_template_version request example
+        """
+        try:
+            print('\ncreate_account_settings_template_version() result:')
+
+            global account_settings_template_id
+            # begin-create_account_settings_template_version
+
+            account_settings = {}
+            account_settings['mfa'] = 'LEVEL1'
+            account_settings['system_access_token_expiration_in_seconds'] = 2600
+            account_settings['restrict_create_platform_apikey'] = 'RESTRICTED'
+            account_settings['restrict_create_service_id'] = 'RESTRICTED'
+
+            create_response = iam_identity_service.create_account_settings_template_version(
+                template_id=account_settings_template_id,
+                name='Example-Account-Settings-Template',
+                description='IAM enterprise account settings template example - new version',
+                account_id=enterprise_account_id,
+                account_settings=account_settings
+            )
+
+            account_settings_template = create_response.get_result()
+            print('\ncreate_account_settings_template_version() response: ', json.dumps(account_settings_template, indent=2))
+
+            global account_settings_template_version
+            account_settings_template_version = account_settings_template['version']
+            # end-create_account_settings_template_version
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_get_latest_account_settings_template_version(self):
+        """
+        get_latest_account_settings_template_version request example
+        """
+        try:
+            print('\nget_latest_account_settings_template_version() result:')
+
+            global account_settings_template_id
+            # begin-get_latest_account_settings_template_version
+            get_response = iam_identity_service.get_latest_account_settings_template_version(
+                template_id=account_settings_template_id
+            )
+            account_settings_template = get_response.get_result()
+            print('\nget_latest_account_settings_template_version response: ', json.dumps(account_settings_template, indent=2))
+            # end-get_latest_account_settings_template_version
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_list_account_settings_template_versions(self):
+        """
+        list_versions_of_account_settings_template request example
+        """
+        try:
+            print('\nlist_versions_of_account_settings_template() result:')
+
+            global account_settings_template_id
+            # begin-list_versions_of_account_settings_template
+            list_response = iam_identity_service.list_versions_of_account_settings_template(
+                template_id=account_settings_template_id
+            )
+            account_settings_template_list = list_response.get_result()
+            print('\nlist_account_settings_template_versions response: ', json.dumps(account_settings_template_list, indent=2))
+            # end-list_versions_of_account_settings_template
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_update_account_settings_template_assignment(self):
+        """
+        update_account_settings_assignment request example
+        """
+        try:
+            print('\nupdate_account_settings_assignment() result:')
+
+            global account_settings_template_id
+            global account_settings_template_version
+            global account_settings_template_assignment_id
+            global account_settings_template_assignment_etag
+            commit_response = iam_identity_service.commit_account_settings_template(
+                template_id=account_settings_template_id,
+                version=str(account_settings_template_version)
+            )
+
+            self.waitUntilAccountSettingsAssignmentFinished(iam_identity_service, account_settings_template_assignment_id)
+
+            # begin-update_account_settings_assignment
+            assign_response = iam_identity_service.update_account_settings_assignment(
+                assignment_id=account_settings_template_assignment_id,
+                template_version=account_settings_template_version,
+                if_match=account_settings_template_assignment_etag
+            )
+            assignment = assign_response.get_result()
+            print('\nupdate_account_settings_template_assignment response: ', json.dumps(assignment, indent=2))
+            account_settings_template_assignment_etag = assign_response.get_headers()['Etag']
+            # end-update_account_settings_assignment
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_delete_account_settings_template_assignment(self):
+        """
+        delete_account_settings_assignment request example
+        """
+        try:
+            print('\ndelete_account_settings_assignment() result:')
+            global account_settings_template_assignment_id
+
+            self.waitUntilAccountSettingsAssignmentFinished(iam_identity_service, account_settings_template_assignment_id)
+            # begin-delete_account_settings_assignment
+            delete_response = iam_identity_service.delete_account_settings_assignment(
+                assignment_id=account_settings_template_assignment_id
+            )
+            # end-delete_account_settings_assignment
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_delete_account_settings_template_version(self):
+        """
+        delete_account_settings_template_version request example
+        """
+        try:
+            print('\ndelete_account_settings_template_version() result:')
+            global account_settings_template_assignment_id
+            global account_settings_template_assignment_id
+            # begin-delete_account_settings_template_version
+
+            delete_response = iam_identity_service.delete_account_settings_template_version(
+                template_id=account_settings_template_id,
+                version='1'
+            )
+            # end-delete_account_settings_template_version
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_delete_account_settings_template(self):
+        """
+        delete_all_versions_of_account_settings_template request example
+        """
+        try:
+            print('\ndelete_all_versions_of_account_settings_template() result:')
+            global account_settings_template_id
+            self.waitUntilAccountSettingsAssignmentFinished(iam_identity_service, account_settings_template_assignment_id)
+            # begin-delete_all_versions_of_account_settings_template
+            delete_response = iam_identity_service.delete_all_versions_of_account_settings_template(
+                template_id=account_settings_template_id
+            )
+            # end-delete_all_versions_of_account_settings_template
+        except ApiException as e:
+            pytest.fail(str(e))
 
 # endregion
 ##############################################################################

--- a/ibm_platform_services/iam_identity_v1.py
+++ b/ibm_platform_services/iam_identity_v1.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# IBM OpenAPI SDK Code Generator Version: 3.72.0-5d70f2bb-20230511-203609
+# IBM OpenAPI SDK Code Generator Version: 3.74.0-89f1dbab-20230630-160213
 
 """
 The IAM Identity Service API allows for the management of Account Settings and Identities
@@ -56,7 +56,9 @@ class IamIdentityV1(BaseService):
                parameters and external configuration.
         """
         authenticator = get_authenticator_from_environment(service_name)
-        service = cls(authenticator)
+        service = cls(
+            authenticator
+            )
         service.configure_service(service_name)
         return service
 
@@ -74,7 +76,7 @@ class IamIdentityV1(BaseService):
         BaseService.__init__(self, service_url=self.DEFAULT_SERVICE_URL, authenticator=authenticator)
 
     #########################
-    # API key Operations
+    # API key operations
     #########################
 
     def list_api_keys(
@@ -100,21 +102,21 @@ class IamIdentityV1(BaseService):
         IDs and their API keys, a user must be either an account owner, a IBM Cloud org
         manager or IBM Cloud space developer in order to manage service IDs of the entity.
 
-        :param str account_id: (optional) Account ID of the API keys to query. If a
-               service IAM ID is specified in iam_id then account_id must match the
+        :param str account_id: (optional) Account ID of the API keys(s) to query.
+               If a service IAM ID is specified in iam_id then account_id must match the
                account of the IAM ID. If a user IAM ID is specified in iam_id then then
                account_id must match the account of the Authorization token.
-        :param str iam_id: (optional) IAM ID of the API keys to be queried. The IAM
-               ID may be that of a user or a service. For a user IAM ID iam_id must match
-               the Authorization token.
+        :param str iam_id: (optional) IAM ID of the API key(s) to be queried. The
+               IAM ID may be that of a user or a service. For a user IAM ID iam_id must
+               match the Authorization token.
         :param int pagesize: (optional) Optional size of a single page. Default is
                20 items per page. Valid range is 1 to 100.
         :param str pagetoken: (optional) Optional Prev or Next page token returned
                from a previous query execution. Default is start with first page.
         :param str scope: (optional) Optional parameter to define the scope of the
-               queried API keys. Can be 'entity' (default) or 'account'.
+               queried API Keys. Can be 'entity' (default) or 'account'.
         :param str type: (optional) Optional parameter to filter the type of the
-               queried API keys. Can be 'user' or 'serviceid'.
+               queried API Keys. Can be 'user' or 'serviceid'.
         :param str sort: (optional) Optional sort property, valid values are name,
                description, created_at and created_by. If specified, the items are sorted
                by the value of this property.
@@ -194,8 +196,8 @@ class IamIdentityV1(BaseService):
                value for this API key. If passed, NO validation of that apiKey value is
                done, i.e. the value can be non-URL safe. If omitted, the API key
                management will create an URL safe opaque API key value. The value of the
-               API key is checked for uniqueness. Please ensure enough variations when
-               passing in this value.
+               API key is checked for uniqueness. Ensure enough variations when passing in
+               this value.
         :param bool store_value: (optional) Send true or false to set whether the
                API key value is retrievable in the future by using the Get details of an
                API key request. If you create an API key for a user, you must specify
@@ -323,7 +325,7 @@ class IamIdentityV1(BaseService):
                included in the response.
         :param bool include_activity: (optional) Defines if the entity's activity
                is included in the response. Retrieving activity data is an expensive
-               operation, so please only request this when needed.
+               operation, so only request this when needed.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `ApiKey` object
@@ -579,7 +581,7 @@ class IamIdentityV1(BaseService):
         return response
 
     #########################
-    # Service ID Operations
+    # Service ID operations
     #########################
 
     def list_service_ids(
@@ -600,7 +602,7 @@ class IamIdentityV1(BaseService):
         Returns a list of service IDs. Users can manage user API keys for themself, or
         service ID API keys for service IDs that are bound to an entity they have access
         to. Note: apikey details are only included in the response when creating a Service
-        ID with an api key.
+        ID with an apikey.
 
         :param str account_id: (optional) Account ID of the service ID(s) to query.
                This parameter is required (unless using a pagetoken).
@@ -749,14 +751,14 @@ class IamIdentityV1(BaseService):
         Returns the details of a service ID. Users can manage user API keys for themself,
         or service ID API keys for service IDs that are bound to an entity they have
         access to. Note: apikey details are only included in the response when creating a
-        Service ID with an api key.
+        Service ID with an apikey.
 
         :param str id: Unique ID of the service ID.
         :param bool include_history: (optional) Defines if the entity history is
                included in the response.
         :param bool include_activity: (optional) Defines if the entity's activity
                is included in the response. Retrieving activity data is an expensive
-               operation, so please only request this when needed.
+               operation, so only request this when needed.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `ServiceId` object
@@ -1023,7 +1025,7 @@ class IamIdentityV1(BaseService):
         return response
 
     #########################
-    # Trusted Profiles Operations
+    # Trusted profiles operations
     #########################
 
     def create_profile(
@@ -1177,7 +1179,7 @@ class IamIdentityV1(BaseService):
         :param str profile_id: ID of the trusted profile to get.
         :param bool include_activity: (optional) Defines if the entity's activity
                is included in the response. Retrieving activity data is an expensive
-               operation, so please only request this when needed.
+               operation, so only request this when needed.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `TrustedProfile` object
@@ -1925,7 +1927,7 @@ class IamIdentityV1(BaseService):
         profile_id: str,
         if_match: str,
         *,
-        identities: List['ProfileIdentity'] = None,
+        identities: List['ProfileIdentityRequest'] = None,
         **kwargs,
     ) -> DetailedResponse:
         """
@@ -1938,8 +1940,8 @@ class IamIdentityV1(BaseService):
                the tag that you retrieved when reading the Profile Identities. This value
                helps identify parallel usage of this API. Pass * to indicate updating any
                available version, which may result in stale updates.
-        :param List[ProfileIdentity] identities: (optional) List of identities that
-               can assume the trusted profile.
+        :param List[ProfileIdentityRequest] identities: (optional) List of
+               identities that can assume the trusted profile.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `ProfileIdentitiesResponse` object
@@ -1994,7 +1996,6 @@ class IamIdentityV1(BaseService):
         identifier: str,
         type: str,
         *,
-        iam_id: str = None,
         accounts: List[str] = None,
         description: str = None,
         **kwargs,
@@ -2012,7 +2013,6 @@ class IamIdentityV1(BaseService):
                'serviceid' and for the identifier 'crn' it uses account id contained in
                the CRN.
         :param str type: Type of the identity.
-        :param str iam_id: (optional) IAM ID of the identity.
         :param List[str] accounts: (optional) Only valid for the type user.
                Accounts from which a user can assume the trusted profile.
         :param str description: (optional) Description of the identity that can
@@ -2023,7 +2023,7 @@ class IamIdentityV1(BaseService):
                project'.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
-        :rtype: DetailedResponse with `dict` result representing a `ProfileIdentity` object
+        :rtype: DetailedResponse with `dict` result representing a `ProfileIdentityResponse` object
         """
 
         if not profile_id:
@@ -2045,7 +2045,6 @@ class IamIdentityV1(BaseService):
         data = {
             'identifier': identifier,
             'type': type,
-            'iam_id': iam_id,
             'accounts': accounts,
             'description': description,
         }
@@ -2090,7 +2089,7 @@ class IamIdentityV1(BaseService):
                trusted profiles.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
-        :rtype: DetailedResponse with `dict` result representing a `ProfileIdentity` object
+        :rtype: DetailedResponse with `dict` result representing a `ProfileIdentityResponse` object
         """
 
         if not profile_id:
@@ -2178,7 +2177,7 @@ class IamIdentityV1(BaseService):
         return response
 
     #########################
-    # Account Settings
+    # Account settings
     #########################
 
     def get_account_settings(
@@ -2255,7 +2254,7 @@ class IamIdentityV1(BaseService):
         Update account configurations.
 
         Allows a user to configure settings on their account with regards to MFA, MFA
-        excemption list,  session lifetimes, access control for creating new identities,
+        excemption list, session lifetimes, access control for creating new identities,
         and enforcing IP restrictions on token creation.
 
         :param str if_match: Version of the account settings to be updated. Specify
@@ -2265,14 +2264,16 @@ class IamIdentityV1(BaseService):
                updates.
         :param str account_id: The id of the account to update the settings for.
         :param str restrict_create_service_id: (optional) Defines whether or not
-               creating a Service Id is access controlled. Valid values:
-                 * RESTRICTED - to apply access control
-                 * NOT_RESTRICTED - to remove access control
-                 * NOT_SET - to unset a previously set value.
+               creating a service ID is access controlled. Valid values:
+                 * RESTRICTED - only users assigned the 'Service ID creator' role on the
+               IAM Identity Service can create service IDs, including the account owner
+                 * NOT_RESTRICTED - all members of an account can create service IDs
+                 * NOT_SET - to 'unset' a previous set value.
         :param str restrict_create_platform_apikey: (optional) Defines whether or
                not creating platform API keys is access controlled. Valid values:
-                 * RESTRICTED - to apply access control
-                 * NOT_RESTRICTED - to remove access control
+                 * RESTRICTED - only users assigned the 'User API key creator' role on the
+               IAM Identity Service can create API keys, including the account owner
+                 * NOT_RESTRICTED - all members of an account can create platform API keys
                  * NOT_SET - to 'unset' a previous set value.
         :param str allowed_ip_addresses: (optional) Defines the IP addresses and
                subnets from which IAM tokens can be created for the account.
@@ -2528,6 +2529,920 @@ class IamIdentityV1(BaseService):
         return response
 
     #########################
+    # accountSettingsAssignments
+    #########################
+
+    def list_account_settings_assignments(
+        self,
+        *,
+        account_id: str = None,
+        template_id: str = None,
+        template_version: str = None,
+        target: str = None,
+        target_type: str = None,
+        limit: int = None,
+        pagetoken: str = None,
+        sort: str = None,
+        order: str = None,
+        include_history: bool = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        List assignments.
+
+        List account settings assignments.
+
+        :param str account_id: (optional) Account ID of the Assignments to query.
+               This parameter is required unless using a pagetoken.
+        :param str template_id: (optional) Filter results by Template Id.
+        :param str template_version: (optional) Filter results Template Version.
+        :param str target: (optional) Filter results by the assignment target.
+        :param str target_type: (optional) Filter results by the assignment's
+               target type.
+        :param int limit: (optional) Optional size of a single page. Default is 20
+               items per page. Valid range is 1 to 100.
+        :param str pagetoken: (optional) Optional Prev or Next page token returned
+               from a previous query execution. Default is start with first page.
+        :param str sort: (optional) If specified, the items are sorted by the value
+               of this property.
+        :param str order: (optional) Sort order.
+        :param bool include_history: (optional) Defines if the entity history is
+               included in the response.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `TemplateAssignmentListResponse` object
+        """
+
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='list_account_settings_assignments',
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'account_id': account_id,
+            'template_id': template_id,
+            'template_version': template_version,
+            'target': target,
+            'target_type': target_type,
+            'limit': limit,
+            'pagetoken': pagetoken,
+            'sort': sort,
+            'order': order,
+            'include_history': include_history,
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v1/account_settings_assignments/'
+        request = self.prepare_request(
+            method='GET',
+            url=url,
+            headers=headers,
+            params=params,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def create_account_settings_assignment(
+        self,
+        template_id: str,
+        template_version: int,
+        target_type: str,
+        target: str,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Create assignment.
+
+        Create an assigment for an account settings template.
+
+        :param str template_id: ID of the template to assign.
+        :param int template_version: Version of the template to assign.
+        :param str target_type: Type of target to deploy to.
+        :param str target: Identifier of target to deploy to.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `TemplateAssignmentResponse` object
+        """
+
+        if template_id is None:
+            raise ValueError('template_id must be provided')
+        if template_version is None:
+            raise ValueError('template_version must be provided')
+        if target_type is None:
+            raise ValueError('target_type must be provided')
+        if target is None:
+            raise ValueError('target must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='create_account_settings_assignment',
+        )
+        headers.update(sdk_headers)
+
+        data = {
+            'template_id': template_id,
+            'template_version': template_version,
+            'target_type': target_type,
+            'target': target,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v1/account_settings_assignments/'
+        request = self.prepare_request(
+            method='POST',
+            url=url,
+            headers=headers,
+            data=data,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def get_account_settings_assignment(
+        self,
+        assignment_id: str,
+        *,
+        include_history: bool = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Get assignment.
+
+        Get an assigment for an account settings template.
+
+        :param str assignment_id: ID of the Assignment Record.
+        :param bool include_history: (optional) Defines if the entity history is
+               included in the response.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `TemplateAssignmentResponse` object
+        """
+
+        if not assignment_id:
+            raise ValueError('assignment_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='get_account_settings_assignment',
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'include_history': include_history,
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['assignment_id']
+        path_param_values = self.encode_path_vars(assignment_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/account_settings_assignments/{assignment_id}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='GET',
+            url=url,
+            headers=headers,
+            params=params,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def delete_account_settings_assignment(
+        self,
+        assignment_id: str,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Delete assignment.
+
+        Delete an account settings template assignment. This removes any IAM resources
+        created by this assignment in child accounts.
+
+        :param str assignment_id: ID of the Assignment Record.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `ExceptionResponse` object
+        """
+
+        if not assignment_id:
+            raise ValueError('assignment_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='delete_account_settings_assignment',
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['assignment_id']
+        path_param_values = self.encode_path_vars(assignment_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/account_settings_assignments/{assignment_id}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='DELETE',
+            url=url,
+            headers=headers,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def update_account_settings_assignment(
+        self,
+        assignment_id: str,
+        if_match: str,
+        template_version: int,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Update assignment.
+
+        Update an account settings assignment. Call this method to retry failed
+        assignments or migrate the settings in child accounts to a new version.
+
+        :param str assignment_id: ID of the Assignment Record.
+        :param str if_match: Version of the assignment to be updated. Specify the
+               version that you retrieved when reading the assignment. This value  helps
+               identifying parallel usage of this API. Pass * to indicate to update any
+               version available. This might result in stale updates.
+        :param int template_version: Template version to be applied to the
+               assignment. To retry all failed assignemtns, provide the existing version.
+               To migrate to a different version, provide the new version number.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `TemplateAssignmentResponse` object
+        """
+
+        if not assignment_id:
+            raise ValueError('assignment_id must be provided')
+        if not if_match:
+            raise ValueError('if_match must be provided')
+        if template_version is None:
+            raise ValueError('template_version must be provided')
+        headers = {
+            'If-Match': if_match,
+        }
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='update_account_settings_assignment',
+        )
+        headers.update(sdk_headers)
+
+        data = {
+            'template_version': template_version,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['assignment_id']
+        path_param_values = self.encode_path_vars(assignment_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/account_settings_assignments/{assignment_id}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='PATCH',
+            url=url,
+            headers=headers,
+            data=data,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    #########################
+    # accountSettingsTemplate
+    #########################
+
+    def list_account_settings_templates(
+        self,
+        *,
+        account_id: str = None,
+        limit: str = None,
+        pagetoken: str = None,
+        sort: str = None,
+        order: str = None,
+        include_history: str = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        List account settings templates.
+
+        List account settings templates in an enterprise account.
+
+        :param str account_id: (optional) Account ID of the account settings
+               templates to query. This parameter is required unless using a pagetoken.
+        :param str limit: (optional) Optional size of a single page.
+        :param str pagetoken: (optional) Optional Prev or Next page token returned
+               from a previous query execution. Default is start with first page.
+        :param str sort: (optional) Optional sort property. If specified, the
+               returned templated are sorted according to this property.
+        :param str order: (optional) Optional sort order.
+        :param str include_history: (optional) Defines if the entity history is
+               included in the response.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `AccountSettingsTemplateList` object
+        """
+
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='list_account_settings_templates',
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'account_id': account_id,
+            'limit': limit,
+            'pagetoken': pagetoken,
+            'sort': sort,
+            'order': order,
+            'include_history': include_history,
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v1/account_settings_templates'
+        request = self.prepare_request(
+            method='GET',
+            url=url,
+            headers=headers,
+            params=params,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def create_account_settings_template(
+        self,
+        *,
+        account_id: str = None,
+        name: str = None,
+        description: str = None,
+        account_settings: 'AccountSettingsComponent' = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Create an account settings template.
+
+        Create a new account settings template in an enterprise account.
+
+        :param str account_id: (optional) ID of the account where the template
+               resides.
+        :param str name: (optional) The name of the trusted profile template. This
+               is visible only in the enterprise account.
+        :param str description: (optional) The description of the trusted profile
+               template. Describe the template for enterprise account users.
+        :param AccountSettingsComponent account_settings: (optional)
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `AccountSettingsTemplateResponse` object
+        """
+
+        if account_settings is not None:
+            account_settings = convert_model(account_settings)
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='create_account_settings_template',
+        )
+        headers.update(sdk_headers)
+
+        data = {
+            'account_id': account_id,
+            'name': name,
+            'description': description,
+            'account_settings': account_settings,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v1/account_settings_templates'
+        request = self.prepare_request(
+            method='POST',
+            url=url,
+            headers=headers,
+            data=data,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def get_latest_account_settings_template_version(
+        self,
+        template_id: str,
+        *,
+        include_history: bool = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Get latest version of an account settings template.
+
+        Get the latest version of a specific account settings template in an enterprise
+        account.
+
+        :param str template_id: ID of the account settings template.
+        :param bool include_history: (optional) Defines if the entity history is
+               included in the response.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `AccountSettingsTemplateResponse` object
+        """
+
+        if not template_id:
+            raise ValueError('template_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='get_latest_account_settings_template_version',
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'include_history': include_history,
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['template_id']
+        path_param_values = self.encode_path_vars(template_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/account_settings_templates/{template_id}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='GET',
+            url=url,
+            headers=headers,
+            params=params,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def delete_all_versions_of_account_settings_template(
+        self,
+        template_id: str,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Delete all versions of an account settings template.
+
+        Delete all versions of an account settings template in an enterprise account. If
+        any version is assigned to child accounts, you must first delete the assignment.
+
+        :param str template_id: ID of the account settings template.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse
+        """
+
+        if not template_id:
+            raise ValueError('template_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='delete_all_versions_of_account_settings_template',
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+
+        path_param_keys = ['template_id']
+        path_param_values = self.encode_path_vars(template_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/account_settings_templates/{template_id}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='DELETE',
+            url=url,
+            headers=headers,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def list_versions_of_account_settings_template(
+        self,
+        template_id: str,
+        *,
+        limit: str = None,
+        pagetoken: str = None,
+        sort: str = None,
+        order: str = None,
+        include_history: str = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        List account settings template versions.
+
+        List the versions of a specific account settings template in an enterprise
+        account.
+
+        :param str template_id: ID of the account settings template.
+        :param str limit: (optional) Optional size of a single page.
+        :param str pagetoken: (optional) Optional Prev or Next page token returned
+               from a previous query execution. Default is start with first page.
+        :param str sort: (optional) Optional sort property. If specified, the
+               returned templated are sorted according to this property.
+        :param str order: (optional) Optional sort order.
+        :param str include_history: (optional) Defines if the entity history is
+               included in the response.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `AccountSettingsTemplateList` object
+        """
+
+        if not template_id:
+            raise ValueError('template_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='list_versions_of_account_settings_template',
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'limit': limit,
+            'pagetoken': pagetoken,
+            'sort': sort,
+            'order': order,
+            'include_history': include_history,
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['template_id']
+        path_param_values = self.encode_path_vars(template_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/account_settings_templates/{template_id}/versions'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='GET',
+            url=url,
+            headers=headers,
+            params=params,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def create_account_settings_template_version(
+        self,
+        template_id: str,
+        *,
+        account_id: str = None,
+        name: str = None,
+        description: str = None,
+        account_settings: 'AccountSettingsComponent' = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Create a new version of an account settings template.
+
+        Create a new version of an account settings template in an Enterprise Account.
+
+        :param str template_id: ID of the account settings template.
+        :param str account_id: (optional) ID of the account where the template
+               resides.
+        :param str name: (optional) The name of the trusted profile template. This
+               is visible only in the enterprise account.
+        :param str description: (optional) The description of the trusted profile
+               template. Describe the template for enterprise account users.
+        :param AccountSettingsComponent account_settings: (optional)
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `AccountSettingsTemplateResponse` object
+        """
+
+        if not template_id:
+            raise ValueError('template_id must be provided')
+        if account_settings is not None:
+            account_settings = convert_model(account_settings)
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='create_account_settings_template_version',
+        )
+        headers.update(sdk_headers)
+
+        data = {
+            'account_id': account_id,
+            'name': name,
+            'description': description,
+            'account_settings': account_settings,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['template_id']
+        path_param_values = self.encode_path_vars(template_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/account_settings_templates/{template_id}/versions'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='POST',
+            url=url,
+            headers=headers,
+            data=data,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def get_account_settings_template_version(
+        self,
+        template_id: str,
+        version: str,
+        *,
+        include_history: bool = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Get version of an account settings template.
+
+        Get a specific version of an account settings template in an Enterprise Account.
+
+        :param str template_id: ID of the account settings template.
+        :param str version: Version of the account settings template.
+        :param bool include_history: (optional) Defines if the entity history is
+               included in the response.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `AccountSettingsTemplateResponse` object
+        """
+
+        if not template_id:
+            raise ValueError('template_id must be provided')
+        if not version:
+            raise ValueError('version must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='get_account_settings_template_version',
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'include_history': include_history,
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['template_id', 'version']
+        path_param_values = self.encode_path_vars(template_id, version)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/account_settings_templates/{template_id}/versions/{version}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='GET',
+            url=url,
+            headers=headers,
+            params=params,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def update_account_settings_template_version(
+        self,
+        if_match: str,
+        template_id: str,
+        version: str,
+        *,
+        account_id: str = None,
+        name: str = None,
+        description: str = None,
+        account_settings: 'AccountSettingsComponent' = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Update version of an account settings template.
+
+        Update a specific version of an account settings template in an Enterprise
+        Account.
+
+        :param str if_match: Entity tag of the Template to be updated. Specify the
+               tag that you retrieved when reading the account settings template. This
+               value helps identifying parallel usage of this API. Pass * to indicate to
+               update any version available. This might result in stale updates.
+        :param str template_id: ID of the account settings template.
+        :param str version: Version of the account settings template.
+        :param str account_id: (optional) ID of the account where the template
+               resides.
+        :param str name: (optional) The name of the trusted profile template. This
+               is visible only in the enterprise account.
+        :param str description: (optional) The description of the trusted profile
+               template. Describe the template for enterprise account users.
+        :param AccountSettingsComponent account_settings: (optional)
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `AccountSettingsTemplateResponse` object
+        """
+
+        if not if_match:
+            raise ValueError('if_match must be provided')
+        if not template_id:
+            raise ValueError('template_id must be provided')
+        if not version:
+            raise ValueError('version must be provided')
+        if account_settings is not None:
+            account_settings = convert_model(account_settings)
+        headers = {
+            'If-Match': if_match,
+        }
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='update_account_settings_template_version',
+        )
+        headers.update(sdk_headers)
+
+        data = {
+            'account_id': account_id,
+            'name': name,
+            'description': description,
+            'account_settings': account_settings,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['template_id', 'version']
+        path_param_values = self.encode_path_vars(template_id, version)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/account_settings_templates/{template_id}/versions/{version}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='PUT',
+            url=url,
+            headers=headers,
+            data=data,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def delete_account_settings_template_version(
+        self,
+        template_id: str,
+        version: str,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Delete version of an account settings template.
+
+        Delete a specific version of an account settings template in an Enterprise
+        Account.
+
+        :param str template_id: ID of the account settings template.
+        :param str version: Version of the account settings template.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse
+        """
+
+        if not template_id:
+            raise ValueError('template_id must be provided')
+        if not version:
+            raise ValueError('version must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='delete_account_settings_template_version',
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+
+        path_param_keys = ['template_id', 'version']
+        path_param_values = self.encode_path_vars(template_id, version)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/account_settings_templates/{template_id}/versions/{version}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='DELETE',
+            url=url,
+            headers=headers,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def commit_account_settings_template(
+        self,
+        template_id: str,
+        version: str,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Commit a template version.
+
+        Commit a specific version of an account settings template in an Enterprise
+        Account. A Template must be committed before being assigned, and once committed,
+        can no longer be modified.
+
+        :param str template_id: ID of the account settings template.
+        :param str version: Version of the account settings template.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse
+        """
+
+        if not template_id:
+            raise ValueError('template_id must be provided')
+        if not version:
+            raise ValueError('version must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='commit_account_settings_template',
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+
+        path_param_keys = ['template_id', 'version']
+        path_param_values = self.encode_path_vars(template_id, version)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/account_settings_templates/{template_id}/versions/{version}/commit'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='POST',
+            url=url,
+            headers=headers,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    #########################
     # activityOperations
     #########################
 
@@ -2549,8 +3464,8 @@ class IamIdentityV1(BaseService):
         :param str type: (optional) Optional report type. The supported value is
                'inactive'. List all identities that have not authenticated within the time
                indicated by duration.
-        :param str duration: (optional) Optional duration of the report. The
-               supported unit of duration is hours.
+        :param str duration: (optional) Optional duration of the report, supported
+               unit of duration is hours.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `ReportReference` object
@@ -2597,7 +3512,7 @@ class IamIdentityV1(BaseService):
         **kwargs,
     ) -> DetailedResponse:
         """
-        Get activity report for the account.
+        Get activity report across on account scope.
 
         Get activity report for the account by specifying the account ID and the reference
         that is generated by triggering the report. Reports older than a day are deleted
@@ -2641,6 +3556,948 @@ class IamIdentityV1(BaseService):
         response = self.send(request, **kwargs)
         return response
 
+    #########################
+    # trustedProfileAssignments
+    #########################
+
+    def list_trusted_profile_assignments(
+        self,
+        *,
+        account_id: str = None,
+        template_id: str = None,
+        template_version: str = None,
+        target: str = None,
+        target_type: str = None,
+        limit: int = None,
+        pagetoken: str = None,
+        sort: str = None,
+        order: str = None,
+        include_history: bool = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        List assignments.
+
+        List trusted profile template assignments.
+
+        :param str account_id: (optional) Account ID of the Assignments to query.
+               This parameter is required unless using a pagetoken.
+        :param str template_id: (optional) Filter results by Template Id.
+        :param str template_version: (optional) Filter results Template Version.
+        :param str target: (optional) Filter results by the assignment target.
+        :param str target_type: (optional) Filter results by the assignment's
+               target type.
+        :param int limit: (optional) Optional size of a single page. Default is 20
+               items per page. Valid range is 1 to 100.
+        :param str pagetoken: (optional) Optional Prev or Next page token returned
+               from a previous query execution. Default is start with first page.
+        :param str sort: (optional) If specified, the items are sorted by the value
+               of this property.
+        :param str order: (optional) Sort order.
+        :param bool include_history: (optional) Defines if the entity history is
+               included in the response.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `TemplateAssignmentListResponse` object
+        """
+
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='list_trusted_profile_assignments',
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'account_id': account_id,
+            'template_id': template_id,
+            'template_version': template_version,
+            'target': target,
+            'target_type': target_type,
+            'limit': limit,
+            'pagetoken': pagetoken,
+            'sort': sort,
+            'order': order,
+            'include_history': include_history,
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v1/profile_assignments/'
+        request = self.prepare_request(
+            method='GET',
+            url=url,
+            headers=headers,
+            params=params,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def create_trusted_profile_assignment(
+        self,
+        template_id: str,
+        template_version: int,
+        target_type: str,
+        target: str,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Create assignment.
+
+        Create an assigment for a trusted profile template.
+
+        :param str template_id: ID of the template to assign.
+        :param int template_version: Version of the template to assign.
+        :param str target_type: Type of target to deploy to.
+        :param str target: Identifier of target to deploy to.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `TemplateAssignmentResponse` object
+        """
+
+        if template_id is None:
+            raise ValueError('template_id must be provided')
+        if template_version is None:
+            raise ValueError('template_version must be provided')
+        if target_type is None:
+            raise ValueError('target_type must be provided')
+        if target is None:
+            raise ValueError('target must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='create_trusted_profile_assignment',
+        )
+        headers.update(sdk_headers)
+
+        data = {
+            'template_id': template_id,
+            'template_version': template_version,
+            'target_type': target_type,
+            'target': target,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v1/profile_assignments/'
+        request = self.prepare_request(
+            method='POST',
+            url=url,
+            headers=headers,
+            data=data,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def get_trusted_profile_assignment(
+        self,
+        assignment_id: str,
+        *,
+        include_history: bool = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Get assignment.
+
+        Get an assigment for a trusted profile template.
+
+        :param str assignment_id: ID of the Assignment Record.
+        :param bool include_history: (optional) Defines if the entity history is
+               included in the response.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `TemplateAssignmentResponse` object
+        """
+
+        if not assignment_id:
+            raise ValueError('assignment_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='get_trusted_profile_assignment',
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'include_history': include_history,
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['assignment_id']
+        path_param_values = self.encode_path_vars(assignment_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/profile_assignments/{assignment_id}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='GET',
+            url=url,
+            headers=headers,
+            params=params,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def delete_trusted_profile_assignment(
+        self,
+        assignment_id: str,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Delete assignment.
+
+        Delete a trusted profile assignment. This removes any IAM resources created by
+        this assignment in child accounts.
+
+        :param str assignment_id: ID of the Assignment Record.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `ExceptionResponse` object
+        """
+
+        if not assignment_id:
+            raise ValueError('assignment_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='delete_trusted_profile_assignment',
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['assignment_id']
+        path_param_values = self.encode_path_vars(assignment_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/profile_assignments/{assignment_id}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='DELETE',
+            url=url,
+            headers=headers,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def update_trusted_profile_assignment(
+        self,
+        assignment_id: str,
+        if_match: str,
+        template_version: int,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Update assignment.
+
+        Update a trusted profile assignment. Call this method to retry failed assignments
+        or migrate the trusted profile in child accounts to a new version.
+
+        :param str assignment_id: ID of the Assignment Record.
+        :param str if_match: Version of the Assignment to be updated. Specify the
+               version that you retrieved when reading the Assignment. This value  helps
+               identifying parallel usage of this API. Pass * to indicate to update any
+               version available. This might result in stale updates.
+        :param int template_version: Template version to be applied to the
+               assignment. To retry all failed assignemtns, provide the existing version.
+               To migrate to a different version, provide the new version number.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `TemplateAssignmentResponse` object
+        """
+
+        if not assignment_id:
+            raise ValueError('assignment_id must be provided')
+        if not if_match:
+            raise ValueError('if_match must be provided')
+        if template_version is None:
+            raise ValueError('template_version must be provided')
+        headers = {
+            'If-Match': if_match,
+        }
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='update_trusted_profile_assignment',
+        )
+        headers.update(sdk_headers)
+
+        data = {
+            'template_version': template_version,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['assignment_id']
+        path_param_values = self.encode_path_vars(assignment_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/profile_assignments/{assignment_id}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='PATCH',
+            url=url,
+            headers=headers,
+            data=data,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    #########################
+    # trustedProfileTemplate
+    #########################
+
+    def list_profile_templates(
+        self,
+        *,
+        account_id: str = None,
+        limit: str = None,
+        pagetoken: str = None,
+        sort: str = None,
+        order: str = None,
+        include_history: str = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        List trusted profile templates.
+
+        List the trusted profile templates in an enterprise account.
+
+        :param str account_id: (optional) Account ID of the trusted profile
+               templates to query. This parameter is required unless using a pagetoken.
+        :param str limit: (optional) Optional size of a single page.
+        :param str pagetoken: (optional) Optional Prev or Next page token returned
+               from a previous query execution. Default is start with first page.
+        :param str sort: (optional) Optional sort property. If specified, the
+               returned templates are sorted according to this property.
+        :param str order: (optional) Optional sort order.
+        :param str include_history: (optional) Defines if the entity history is
+               included in the response.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `TrustedProfileTemplateList` object
+        """
+
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='list_profile_templates',
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'account_id': account_id,
+            'limit': limit,
+            'pagetoken': pagetoken,
+            'sort': sort,
+            'order': order,
+            'include_history': include_history,
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v1/profile_templates'
+        request = self.prepare_request(
+            method='GET',
+            url=url,
+            headers=headers,
+            params=params,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def create_profile_template(
+        self,
+        *,
+        account_id: str = None,
+        name: str = None,
+        description: str = None,
+        profile: 'TemplateProfileComponentRequest' = None,
+        policy_template_references: List['PolicyTemplateReference'] = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Create a trusted profile template.
+
+        Create a new trusted profile template in an enterprise account.
+
+        :param str account_id: (optional) ID of the account where the template
+               resides.
+        :param str name: (optional) The name of the trusted profile template. This
+               is visible only in the enterprise account. Required field when creating a
+               new template. Otherwise this field is optional. If the field is included it
+               will change the name value for all existing versions of the template.
+        :param str description: (optional) The description of the trusted profile
+               template. Describe the template for enterprise account users.
+        :param TemplateProfileComponentRequest profile: (optional) Input body
+               parameters for the TemplateProfileComponent.
+        :param List[PolicyTemplateReference] policy_template_references: (optional)
+               Existing policy templates that you can reference to assign access in the
+               trusted profile component.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `TrustedProfileTemplateResponse` object
+        """
+
+        if profile is not None:
+            profile = convert_model(profile)
+        if policy_template_references is not None:
+            policy_template_references = [convert_model(x) for x in policy_template_references]
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='create_profile_template',
+        )
+        headers.update(sdk_headers)
+
+        data = {
+            'account_id': account_id,
+            'name': name,
+            'description': description,
+            'profile': profile,
+            'policy_template_references': policy_template_references,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v1/profile_templates'
+        request = self.prepare_request(
+            method='POST',
+            url=url,
+            headers=headers,
+            data=data,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def get_latest_profile_template_version(
+        self,
+        template_id: str,
+        *,
+        include_history: bool = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Get latest version of a trusted profile template.
+
+        Get the latest version of a trusted profile template in an enterprise account.
+
+        :param str template_id: ID of the trusted profile template.
+        :param bool include_history: (optional) Defines if the entity history is
+               included in the response.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `TrustedProfileTemplateResponse` object
+        """
+
+        if not template_id:
+            raise ValueError('template_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='get_latest_profile_template_version',
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'include_history': include_history,
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['template_id']
+        path_param_values = self.encode_path_vars(template_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/profile_templates/{template_id}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='GET',
+            url=url,
+            headers=headers,
+            params=params,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def delete_all_versions_of_profile_template(
+        self,
+        template_id: str,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Delete all versions of a trusted profile template.
+
+        Delete all versions of a trusted profile template in an enterprise account. If any
+        version is assigned to child accounts, you must first delete the assignment.
+
+        :param str template_id: ID of the trusted profile template.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse
+        """
+
+        if not template_id:
+            raise ValueError('template_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='delete_all_versions_of_profile_template',
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+
+        path_param_keys = ['template_id']
+        path_param_values = self.encode_path_vars(template_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/profile_templates/{template_id}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='DELETE',
+            url=url,
+            headers=headers,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def list_versions_of_profile_template(
+        self,
+        template_id: str,
+        *,
+        limit: str = None,
+        pagetoken: str = None,
+        sort: str = None,
+        order: str = None,
+        include_history: str = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        List trusted profile template versions.
+
+        List the versions of a trusted profile template in an enterprise account.
+
+        :param str template_id: ID of the trusted profile template.
+        :param str limit: (optional) Optional size of a single page.
+        :param str pagetoken: (optional) Optional Prev or Next page token returned
+               from a previous query execution. Default is start with first page.
+        :param str sort: (optional) Optional sort property. If specified, the
+               returned templated are sorted according to this property.
+        :param str order: (optional) Optional sort order.
+        :param str include_history: (optional) Defines if the entity history is
+               included in the response.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `TrustedProfileTemplateList` object
+        """
+
+        if not template_id:
+            raise ValueError('template_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='list_versions_of_profile_template',
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'limit': limit,
+            'pagetoken': pagetoken,
+            'sort': sort,
+            'order': order,
+            'include_history': include_history,
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['template_id']
+        path_param_values = self.encode_path_vars(template_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/profile_templates/{template_id}/versions'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='GET',
+            url=url,
+            headers=headers,
+            params=params,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def create_profile_template_version(
+        self,
+        template_id: str,
+        *,
+        account_id: str = None,
+        name: str = None,
+        description: str = None,
+        profile: 'TemplateProfileComponentRequest' = None,
+        policy_template_references: List['PolicyTemplateReference'] = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Create new version of a trusted profile template.
+
+        Create a new version of a trusted profile template in an enterprise account.
+
+        :param str template_id: ID of the trusted profile template.
+        :param str account_id: (optional) ID of the account where the template
+               resides.
+        :param str name: (optional) The name of the trusted profile template. This
+               is visible only in the enterprise account. Required field when creating a
+               new template. Otherwise this field is optional. If the field is included it
+               will change the name value for all existing versions of the template.
+        :param str description: (optional) The description of the trusted profile
+               template. Describe the template for enterprise account users.
+        :param TemplateProfileComponentRequest profile: (optional) Input body
+               parameters for the TemplateProfileComponent.
+        :param List[PolicyTemplateReference] policy_template_references: (optional)
+               Existing policy templates that you can reference to assign access in the
+               trusted profile component.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `TrustedProfileTemplateResponse` object
+        """
+
+        if not template_id:
+            raise ValueError('template_id must be provided')
+        if profile is not None:
+            profile = convert_model(profile)
+        if policy_template_references is not None:
+            policy_template_references = [convert_model(x) for x in policy_template_references]
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='create_profile_template_version',
+        )
+        headers.update(sdk_headers)
+
+        data = {
+            'account_id': account_id,
+            'name': name,
+            'description': description,
+            'profile': profile,
+            'policy_template_references': policy_template_references,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['template_id']
+        path_param_values = self.encode_path_vars(template_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/profile_templates/{template_id}/versions'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='POST',
+            url=url,
+            headers=headers,
+            data=data,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def get_profile_template_version(
+        self,
+        template_id: str,
+        version: str,
+        *,
+        include_history: bool = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Get version of trusted profile template.
+
+        Get a specific version of a trusted profile template in an enterprise account.
+
+        :param str template_id: ID of the trusted profile template.
+        :param str version: Version of the Profile Template.
+        :param bool include_history: (optional) Defines if the entity history is
+               included in the response.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `TrustedProfileTemplateResponse` object
+        """
+
+        if not template_id:
+            raise ValueError('template_id must be provided')
+        if not version:
+            raise ValueError('version must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='get_profile_template_version',
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'include_history': include_history,
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['template_id', 'version']
+        path_param_values = self.encode_path_vars(template_id, version)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/profile_templates/{template_id}/versions/{version}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='GET',
+            url=url,
+            headers=headers,
+            params=params,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def update_profile_template_version(
+        self,
+        if_match: str,
+        template_id: str,
+        version: str,
+        *,
+        account_id: str = None,
+        name: str = None,
+        description: str = None,
+        profile: 'TemplateProfileComponentRequest' = None,
+        policy_template_references: List['PolicyTemplateReference'] = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Update version of trusted profile template.
+
+        Update a specific version of a trusted profile template in an enterprise account.
+
+        :param str if_match: Entity tag of the Template to be updated. Specify the
+               tag that you retrieved when reading the Profile Template. This value helps
+               identifying parallel usage of this API. Pass * to indicate to update any
+               version available. This might result in stale updates.
+        :param str template_id: ID of the trusted profile template.
+        :param str version: Version of the Profile Template.
+        :param str account_id: (optional) ID of the account where the template
+               resides.
+        :param str name: (optional) The name of the trusted profile template. This
+               is visible only in the enterprise account. Required field when creating a
+               new template. Otherwise this field is optional. If the field is included it
+               will change the name value for all existing versions of the template.
+        :param str description: (optional) The description of the trusted profile
+               template. Describe the template for enterprise account users.
+        :param TemplateProfileComponentRequest profile: (optional) Input body
+               parameters for the TemplateProfileComponent.
+        :param List[PolicyTemplateReference] policy_template_references: (optional)
+               Existing policy templates that you can reference to assign access in the
+               trusted profile component.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `TrustedProfileTemplateResponse` object
+        """
+
+        if not if_match:
+            raise ValueError('if_match must be provided')
+        if not template_id:
+            raise ValueError('template_id must be provided')
+        if not version:
+            raise ValueError('version must be provided')
+        if profile is not None:
+            profile = convert_model(profile)
+        if policy_template_references is not None:
+            policy_template_references = [convert_model(x) for x in policy_template_references]
+        headers = {
+            'If-Match': if_match,
+        }
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='update_profile_template_version',
+        )
+        headers.update(sdk_headers)
+
+        data = {
+            'account_id': account_id,
+            'name': name,
+            'description': description,
+            'profile': profile,
+            'policy_template_references': policy_template_references,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['template_id', 'version']
+        path_param_values = self.encode_path_vars(template_id, version)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/profile_templates/{template_id}/versions/{version}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='PUT',
+            url=url,
+            headers=headers,
+            data=data,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def delete_profile_template_version(
+        self,
+        template_id: str,
+        version: str,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Delete version of trusted profile template.
+
+        Delete a specific version of a trusted profile template in an enterprise account.
+        If the version is assigned to child accounts, you must first delete the
+        assignment.
+
+        :param str template_id: ID of the trusted profile template.
+        :param str version: Version of the Profile Template.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse
+        """
+
+        if not template_id:
+            raise ValueError('template_id must be provided')
+        if not version:
+            raise ValueError('version must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='delete_profile_template_version',
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+
+        path_param_keys = ['template_id', 'version']
+        path_param_values = self.encode_path_vars(template_id, version)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/profile_templates/{template_id}/versions/{version}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='DELETE',
+            url=url,
+            headers=headers,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def commit_profile_template(
+        self,
+        template_id: str,
+        version: str,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Commit a template version.
+
+        Commit a specific version of a trusted profile template in an enterprise account.
+        You must commit a template before you can assign it to child accounts. Once a
+        template is committed, you can no longer modify the template.
+
+        :param str template_id: ID of the trusted profile template.
+        :param str version: Version of the Profile Template.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse
+        """
+
+        if not template_id:
+            raise ValueError('template_id must be provided')
+        if not version:
+            raise ValueError('version must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='commit_profile_template',
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+
+        path_param_keys = ['template_id', 'version']
+        path_param_values = self.encode_path_vars(template_id, version)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/profile_templates/{template_id}/versions/{version}/commit'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='POST',
+            url=url,
+            headers=headers,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
 
 class ListApiKeysEnums:
     """
@@ -2649,22 +4506,20 @@ class ListApiKeysEnums:
 
     class Scope(str, Enum):
         """
-        Optional parameter to define the scope of the queried API keys. Can be 'entity'
+        Optional parameter to define the scope of the queried API Keys. Can be 'entity'
         (default) or 'account'.
         """
 
         ENTITY = 'entity'
         ACCOUNT = 'account'
-
     class Type(str, Enum):
         """
-        Optional parameter to filter the type of the queried API keys. Can be 'user' or
+        Optional parameter to filter the type of the queried API Keys. Can be 'user' or
         'serviceid'.
         """
 
         USER = 'user'
         SERVICEID = 'serviceid'
-
     class Order(str, Enum):
         """
         Optional sort order, valid values are asc and desc. Default: asc.
@@ -2745,6 +4600,156 @@ class DeleteProfileIdentityEnums:
         USER = 'user'
         SERVICEID = 'serviceid'
         CRN = 'crn'
+
+
+class ListAccountSettingsAssignmentsEnums:
+    """
+    Enums for list_account_settings_assignments parameters.
+    """
+
+    class TargetType(str, Enum):
+        """
+        Filter results by the assignment's target type.
+        """
+
+        ACCOUNT = 'Account'
+        ACCOUNTGROUP = 'AccountGroup'
+    class Sort(str, Enum):
+        """
+        If specified, the items are sorted by the value of this property.
+        """
+
+        TEMPLATE_ID = 'template_id'
+        CREATED_AT = 'created_at'
+        LAST_MODIFIED_AT = 'last_modified_at'
+    class Order(str, Enum):
+        """
+        Sort order.
+        """
+
+        ASC = 'asc'
+        DESC = 'desc'
+
+
+class ListAccountSettingsTemplatesEnums:
+    """
+    Enums for list_account_settings_templates parameters.
+    """
+
+    class Sort(str, Enum):
+        """
+        Optional sort property. If specified, the returned templated are sorted according
+        to this property.
+        """
+
+        CREATED_AT = 'created_at'
+        LAST_MODIFIED_AT = 'last_modified_at'
+        NAME = 'name'
+    class Order(str, Enum):
+        """
+        Optional sort order.
+        """
+
+        ASC = 'asc'
+        DESC = 'desc'
+
+
+class ListVersionsOfAccountSettingsTemplateEnums:
+    """
+    Enums for list_versions_of_account_settings_template parameters.
+    """
+
+    class Sort(str, Enum):
+        """
+        Optional sort property. If specified, the returned templated are sorted according
+        to this property.
+        """
+
+        CREATED_AT = 'created_at'
+        LAST_MODIFIED_AT = 'last_modified_at'
+        NAME = 'name'
+    class Order(str, Enum):
+        """
+        Optional sort order.
+        """
+
+        ASC = 'asc'
+        DESC = 'desc'
+
+
+class ListTrustedProfileAssignmentsEnums:
+    """
+    Enums for list_trusted_profile_assignments parameters.
+    """
+
+    class TargetType(str, Enum):
+        """
+        Filter results by the assignment's target type.
+        """
+
+        ACCOUNT = 'Account'
+        ACCOUNTGROUP = 'AccountGroup'
+    class Sort(str, Enum):
+        """
+        If specified, the items are sorted by the value of this property.
+        """
+
+        TEMPLATE_ID = 'template_id'
+        CREATED_AT = 'created_at'
+        LAST_MODIFIED_AT = 'last_modified_at'
+    class Order(str, Enum):
+        """
+        Sort order.
+        """
+
+        ASC = 'asc'
+        DESC = 'desc'
+
+
+class ListProfileTemplatesEnums:
+    """
+    Enums for list_profile_templates parameters.
+    """
+
+    class Sort(str, Enum):
+        """
+        Optional sort property. If specified, the returned templates are sorted according
+        to this property.
+        """
+
+        CREATED_AT = 'created_at'
+        LAST_MODIFIED_AT = 'last_modified_at'
+        NAME = 'name'
+    class Order(str, Enum):
+        """
+        Optional sort order.
+        """
+
+        ASC = 'asc'
+        DESC = 'desc'
+
+
+class ListVersionsOfProfileTemplateEnums:
+    """
+    Enums for list_versions_of_profile_template parameters.
+    """
+
+    class Sort(str, Enum):
+        """
+        Optional sort property. If specified, the returned templated are sorted according
+        to this property.
+        """
+
+        CREATED_AT = 'created_at'
+        LAST_MODIFIED_AT = 'last_modified_at'
+        NAME = 'name'
+    class Order(str, Enum):
+        """
+        Optional sort order.
+        """
+
+        ASC = 'asc'
+        DESC = 'desc'
 
 
 ##############################################################################
@@ -2850,6 +4855,256 @@ class AccountBasedMfaEnrollment:
         return not self == other
 
 
+class AccountSettingsComponent:
+    """
+    AccountSettingsComponent.
+
+    :attr str restrict_create_service_id: (optional) Defines whether or not creating
+          a service ID is access controlled. Valid values:
+            * RESTRICTED - only users assigned the 'Service ID creator' role on the IAM
+          Identity Service can create service IDs, including the account owner
+            * NOT_RESTRICTED - all members of an account can create service IDs
+            * NOT_SET - to 'unset' a previous set value.
+    :attr str restrict_create_platform_apikey: (optional) Defines whether or not
+          creating platform API keys is access controlled. Valid values:
+            * RESTRICTED - to apply access control
+            * NOT_RESTRICTED - to remove access control
+            * NOT_SET - to 'unset' a previous set value.
+    :attr str allowed_ip_addresses: (optional) Defines the IP addresses and subnets
+          from which IAM tokens can be created for the account.
+    :attr str mfa: (optional) Defines the MFA trait for the account. Valid values:
+            * NONE - No MFA trait set
+            * TOTP - For all non-federated IBMId users
+            * TOTP4ALL - For all users
+            * LEVEL1 - Email-based MFA for all users
+            * LEVEL2 - TOTP-based MFA for all users
+            * LEVEL3 - U2F MFA for all users.
+    :attr List[AccountSettingsUserMFA] user_mfa: (optional) List of users that are
+          exempted from the MFA requirement of the account.
+    :attr str session_expiration_in_seconds: (optional) Defines the session
+          expiration in seconds for the account. Valid values:
+            * Any whole number between between '900' and '86400'
+            * NOT_SET - To unset account setting and use service default.
+    :attr str session_invalidation_in_seconds: (optional) Defines the period of time
+          in seconds in which a session will be invalidated due to inactivity. Valid
+          values:
+            * Any whole number between '900' and '7200'
+            * NOT_SET - To unset account setting and use service default.
+    :attr str max_sessions_per_identity: (optional) Defines the max allowed sessions
+          per identity required by the account. Valid values:
+            * Any whole number greater than 0
+            * NOT_SET - To unset account setting and use service default.
+    :attr str system_access_token_expiration_in_seconds: (optional) Defines the
+          access token expiration in seconds. Valid values:
+            * Any whole number between '900' and '3600'
+            * NOT_SET - To unset account setting and use service default.
+    :attr str system_refresh_token_expiration_in_seconds: (optional) Defines the
+          refresh token expiration in seconds. Valid values:
+            * Any whole number between '900' and '259200'
+            * NOT_SET - To unset account setting and use service default.
+    """
+
+    def __init__(
+        self,
+        *,
+        restrict_create_service_id: str = None,
+        restrict_create_platform_apikey: str = None,
+        allowed_ip_addresses: str = None,
+        mfa: str = None,
+        user_mfa: List['AccountSettingsUserMFA'] = None,
+        session_expiration_in_seconds: str = None,
+        session_invalidation_in_seconds: str = None,
+        max_sessions_per_identity: str = None,
+        system_access_token_expiration_in_seconds: str = None,
+        system_refresh_token_expiration_in_seconds: str = None,
+    ) -> None:
+        """
+        Initialize a AccountSettingsComponent object.
+
+        :param str restrict_create_service_id: (optional) Defines whether or not
+               creating a service ID is access controlled. Valid values:
+                 * RESTRICTED - only users assigned the 'Service ID creator' role on the
+               IAM Identity Service can create service IDs, including the account owner
+                 * NOT_RESTRICTED - all members of an account can create service IDs
+                 * NOT_SET - to 'unset' a previous set value.
+        :param str restrict_create_platform_apikey: (optional) Defines whether or
+               not creating platform API keys is access controlled. Valid values:
+                 * RESTRICTED - to apply access control
+                 * NOT_RESTRICTED - to remove access control
+                 * NOT_SET - to 'unset' a previous set value.
+        :param str allowed_ip_addresses: (optional) Defines the IP addresses and
+               subnets from which IAM tokens can be created for the account.
+        :param str mfa: (optional) Defines the MFA trait for the account. Valid
+               values:
+                 * NONE - No MFA trait set
+                 * TOTP - For all non-federated IBMId users
+                 * TOTP4ALL - For all users
+                 * LEVEL1 - Email-based MFA for all users
+                 * LEVEL2 - TOTP-based MFA for all users
+                 * LEVEL3 - U2F MFA for all users.
+        :param List[AccountSettingsUserMFA] user_mfa: (optional) List of users that
+               are exempted from the MFA requirement of the account.
+        :param str session_expiration_in_seconds: (optional) Defines the session
+               expiration in seconds for the account. Valid values:
+                 * Any whole number between between '900' and '86400'
+                 * NOT_SET - To unset account setting and use service default.
+        :param str session_invalidation_in_seconds: (optional) Defines the period
+               of time in seconds in which a session will be invalidated due to
+               inactivity. Valid values:
+                 * Any whole number between '900' and '7200'
+                 * NOT_SET - To unset account setting and use service default.
+        :param str max_sessions_per_identity: (optional) Defines the max allowed
+               sessions per identity required by the account. Valid values:
+                 * Any whole number greater than 0
+                 * NOT_SET - To unset account setting and use service default.
+        :param str system_access_token_expiration_in_seconds: (optional) Defines
+               the access token expiration in seconds. Valid values:
+                 * Any whole number between '900' and '3600'
+                 * NOT_SET - To unset account setting and use service default.
+        :param str system_refresh_token_expiration_in_seconds: (optional) Defines
+               the refresh token expiration in seconds. Valid values:
+                 * Any whole number between '900' and '259200'
+                 * NOT_SET - To unset account setting and use service default.
+        """
+        self.restrict_create_service_id = restrict_create_service_id
+        self.restrict_create_platform_apikey = restrict_create_platform_apikey
+        self.allowed_ip_addresses = allowed_ip_addresses
+        self.mfa = mfa
+        self.user_mfa = user_mfa
+        self.session_expiration_in_seconds = session_expiration_in_seconds
+        self.session_invalidation_in_seconds = session_invalidation_in_seconds
+        self.max_sessions_per_identity = max_sessions_per_identity
+        self.system_access_token_expiration_in_seconds = system_access_token_expiration_in_seconds
+        self.system_refresh_token_expiration_in_seconds = system_refresh_token_expiration_in_seconds
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'AccountSettingsComponent':
+        """Initialize a AccountSettingsComponent object from a json dictionary."""
+        args = {}
+        if 'restrict_create_service_id' in _dict:
+            args['restrict_create_service_id'] = _dict.get('restrict_create_service_id')
+        if 'restrict_create_platform_apikey' in _dict:
+            args['restrict_create_platform_apikey'] = _dict.get('restrict_create_platform_apikey')
+        if 'allowed_ip_addresses' in _dict:
+            args['allowed_ip_addresses'] = _dict.get('allowed_ip_addresses')
+        if 'mfa' in _dict:
+            args['mfa'] = _dict.get('mfa')
+        if 'user_mfa' in _dict:
+            args['user_mfa'] = [AccountSettingsUserMFA.from_dict(v) for v in _dict.get('user_mfa')]
+        if 'session_expiration_in_seconds' in _dict:
+            args['session_expiration_in_seconds'] = _dict.get('session_expiration_in_seconds')
+        if 'session_invalidation_in_seconds' in _dict:
+            args['session_invalidation_in_seconds'] = _dict.get('session_invalidation_in_seconds')
+        if 'max_sessions_per_identity' in _dict:
+            args['max_sessions_per_identity'] = _dict.get('max_sessions_per_identity')
+        if 'system_access_token_expiration_in_seconds' in _dict:
+            args['system_access_token_expiration_in_seconds'] = _dict.get('system_access_token_expiration_in_seconds')
+        if 'system_refresh_token_expiration_in_seconds' in _dict:
+            args['system_refresh_token_expiration_in_seconds'] = _dict.get('system_refresh_token_expiration_in_seconds')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a AccountSettingsComponent object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'restrict_create_service_id') and self.restrict_create_service_id is not None:
+            _dict['restrict_create_service_id'] = self.restrict_create_service_id
+        if hasattr(self, 'restrict_create_platform_apikey') and self.restrict_create_platform_apikey is not None:
+            _dict['restrict_create_platform_apikey'] = self.restrict_create_platform_apikey
+        if hasattr(self, 'allowed_ip_addresses') and self.allowed_ip_addresses is not None:
+            _dict['allowed_ip_addresses'] = self.allowed_ip_addresses
+        if hasattr(self, 'mfa') and self.mfa is not None:
+            _dict['mfa'] = self.mfa
+        if hasattr(self, 'user_mfa') and self.user_mfa is not None:
+            user_mfa_list = []
+            for v in self.user_mfa:
+                if isinstance(v, dict):
+                    user_mfa_list.append(v)
+                else:
+                    user_mfa_list.append(v.to_dict())
+            _dict['user_mfa'] = user_mfa_list
+        if hasattr(self, 'session_expiration_in_seconds') and self.session_expiration_in_seconds is not None:
+            _dict['session_expiration_in_seconds'] = self.session_expiration_in_seconds
+        if hasattr(self, 'session_invalidation_in_seconds') and self.session_invalidation_in_seconds is not None:
+            _dict['session_invalidation_in_seconds'] = self.session_invalidation_in_seconds
+        if hasattr(self, 'max_sessions_per_identity') and self.max_sessions_per_identity is not None:
+            _dict['max_sessions_per_identity'] = self.max_sessions_per_identity
+        if hasattr(self, 'system_access_token_expiration_in_seconds') and self.system_access_token_expiration_in_seconds is not None:
+            _dict['system_access_token_expiration_in_seconds'] = self.system_access_token_expiration_in_seconds
+        if hasattr(self, 'system_refresh_token_expiration_in_seconds') and self.system_refresh_token_expiration_in_seconds is not None:
+            _dict['system_refresh_token_expiration_in_seconds'] = self.system_refresh_token_expiration_in_seconds
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this AccountSettingsComponent object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'AccountSettingsComponent') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'AccountSettingsComponent') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class RestrictCreateServiceIdEnum(str, Enum):
+        """
+        Defines whether or not creating a service ID is access controlled. Valid values:
+          * RESTRICTED - only users assigned the 'Service ID creator' role on the IAM
+        Identity Service can create service IDs, including the account owner
+          * NOT_RESTRICTED - all members of an account can create service IDs
+          * NOT_SET - to 'unset' a previous set value.
+        """
+
+        RESTRICTED = 'RESTRICTED'
+        NOT_RESTRICTED = 'NOT_RESTRICTED'
+        NOT_SET = 'NOT_SET'
+
+
+    class RestrictCreatePlatformApikeyEnum(str, Enum):
+        """
+        Defines whether or not creating platform API keys is access controlled. Valid
+        values:
+          * RESTRICTED - to apply access control
+          * NOT_RESTRICTED - to remove access control
+          * NOT_SET - to 'unset' a previous set value.
+        """
+
+        RESTRICTED = 'RESTRICTED'
+        NOT_RESTRICTED = 'NOT_RESTRICTED'
+        NOT_SET = 'NOT_SET'
+
+
+    class MfaEnum(str, Enum):
+        """
+        Defines the MFA trait for the account. Valid values:
+          * NONE - No MFA trait set
+          * TOTP - For all non-federated IBMId users
+          * TOTP4ALL - For all users
+          * LEVEL1 - Email-based MFA for all users
+          * LEVEL2 - TOTP-based MFA for all users
+          * LEVEL3 - U2F MFA for all users.
+        """
+
+        NONE = 'NONE'
+        TOTP = 'TOTP'
+        TOTP4ALL = 'TOTP4ALL'
+        LEVEL1 = 'LEVEL1'
+        LEVEL2 = 'LEVEL2'
+        LEVEL3 = 'LEVEL3'
+
+
+
 class AccountSettingsResponse:
     """
     Response body format for Account Settings REST requests.
@@ -2857,10 +5112,11 @@ class AccountSettingsResponse:
     :attr ResponseContext context: (optional) Context with key properties for
           problem determination.
     :attr str account_id: Unique ID of the account.
-    :attr str restrict_create_service_id: Defines whether or not creating a Service
-          Id is access controlled. Valid values:
-            * RESTRICTED - to apply access control
-            * NOT_RESTRICTED - to remove access control
+    :attr str restrict_create_service_id: Defines whether or not creating a service
+          ID is access controlled. Valid values:
+            * RESTRICTED - only users assigned the 'Service ID creator' role on the IAM
+          Identity Service can create service IDs, including the account owner
+            * NOT_RESTRICTED - all members of an account can create service IDs
             * NOT_SET - to 'unset' a previous set value.
     :attr str restrict_create_platform_apikey: Defines whether or not creating
           platform API keys is access controlled. Valid values:
@@ -2927,9 +5183,10 @@ class AccountSettingsResponse:
 
         :param str account_id: Unique ID of the account.
         :param str restrict_create_service_id: Defines whether or not creating a
-               Service Id is access controlled. Valid values:
-                 * RESTRICTED - to apply access control
-                 * NOT_RESTRICTED - to remove access control
+               service ID is access controlled. Valid values:
+                 * RESTRICTED - only users assigned the 'Service ID creator' role on the
+               IAM Identity Service can create service IDs, including the account owner
+                 * NOT_RESTRICTED - all members of an account can create service IDs
                  * NOT_SET - to 'unset' a previous set value.
         :param str restrict_create_platform_apikey: Defines whether or not creating
                platform API keys is access controlled. Valid values:
@@ -3003,15 +5260,11 @@ class AccountSettingsResponse:
         if 'restrict_create_service_id' in _dict:
             args['restrict_create_service_id'] = _dict.get('restrict_create_service_id')
         else:
-            raise ValueError(
-                'Required property \'restrict_create_service_id\' not present in AccountSettingsResponse JSON'
-            )
+            raise ValueError('Required property \'restrict_create_service_id\' not present in AccountSettingsResponse JSON')
         if 'restrict_create_platform_apikey' in _dict:
             args['restrict_create_platform_apikey'] = _dict.get('restrict_create_platform_apikey')
         else:
-            raise ValueError(
-                'Required property \'restrict_create_platform_apikey\' not present in AccountSettingsResponse JSON'
-            )
+            raise ValueError('Required property \'restrict_create_platform_apikey\' not present in AccountSettingsResponse JSON')
         if 'allowed_ip_addresses' in _dict:
             args['allowed_ip_addresses'] = _dict.get('allowed_ip_addresses')
         else:
@@ -3033,33 +5286,23 @@ class AccountSettingsResponse:
         if 'session_expiration_in_seconds' in _dict:
             args['session_expiration_in_seconds'] = _dict.get('session_expiration_in_seconds')
         else:
-            raise ValueError(
-                'Required property \'session_expiration_in_seconds\' not present in AccountSettingsResponse JSON'
-            )
+            raise ValueError('Required property \'session_expiration_in_seconds\' not present in AccountSettingsResponse JSON')
         if 'session_invalidation_in_seconds' in _dict:
             args['session_invalidation_in_seconds'] = _dict.get('session_invalidation_in_seconds')
         else:
-            raise ValueError(
-                'Required property \'session_invalidation_in_seconds\' not present in AccountSettingsResponse JSON'
-            )
+            raise ValueError('Required property \'session_invalidation_in_seconds\' not present in AccountSettingsResponse JSON')
         if 'max_sessions_per_identity' in _dict:
             args['max_sessions_per_identity'] = _dict.get('max_sessions_per_identity')
         else:
-            raise ValueError(
-                'Required property \'max_sessions_per_identity\' not present in AccountSettingsResponse JSON'
-            )
+            raise ValueError('Required property \'max_sessions_per_identity\' not present in AccountSettingsResponse JSON')
         if 'system_access_token_expiration_in_seconds' in _dict:
             args['system_access_token_expiration_in_seconds'] = _dict.get('system_access_token_expiration_in_seconds')
         else:
-            raise ValueError(
-                'Required property \'system_access_token_expiration_in_seconds\' not present in AccountSettingsResponse JSON'
-            )
+            raise ValueError('Required property \'system_access_token_expiration_in_seconds\' not present in AccountSettingsResponse JSON')
         if 'system_refresh_token_expiration_in_seconds' in _dict:
             args['system_refresh_token_expiration_in_seconds'] = _dict.get('system_refresh_token_expiration_in_seconds')
         else:
-            raise ValueError(
-                'Required property \'system_refresh_token_expiration_in_seconds\' not present in AccountSettingsResponse JSON'
-            )
+            raise ValueError('Required property \'system_refresh_token_expiration_in_seconds\' not present in AccountSettingsResponse JSON')
         return cls(**args)
 
     @classmethod
@@ -3109,15 +5352,9 @@ class AccountSettingsResponse:
             _dict['session_invalidation_in_seconds'] = self.session_invalidation_in_seconds
         if hasattr(self, 'max_sessions_per_identity') and self.max_sessions_per_identity is not None:
             _dict['max_sessions_per_identity'] = self.max_sessions_per_identity
-        if (
-            hasattr(self, 'system_access_token_expiration_in_seconds')
-            and self.system_access_token_expiration_in_seconds is not None
-        ):
+        if hasattr(self, 'system_access_token_expiration_in_seconds') and self.system_access_token_expiration_in_seconds is not None:
             _dict['system_access_token_expiration_in_seconds'] = self.system_access_token_expiration_in_seconds
-        if (
-            hasattr(self, 'system_refresh_token_expiration_in_seconds')
-            and self.system_refresh_token_expiration_in_seconds is not None
-        ):
+        if hasattr(self, 'system_refresh_token_expiration_in_seconds') and self.system_refresh_token_expiration_in_seconds is not None:
             _dict['system_refresh_token_expiration_in_seconds'] = self.system_refresh_token_expiration_in_seconds
         return _dict
 
@@ -3141,15 +5378,17 @@ class AccountSettingsResponse:
 
     class RestrictCreateServiceIdEnum(str, Enum):
         """
-        Defines whether or not creating a Service Id is access controlled. Valid values:
-          * RESTRICTED - to apply access control
-          * NOT_RESTRICTED - to remove access control
+        Defines whether or not creating a service ID is access controlled. Valid values:
+          * RESTRICTED - only users assigned the 'Service ID creator' role on the IAM
+        Identity Service can create service IDs, including the account owner
+          * NOT_RESTRICTED - all members of an account can create service IDs
           * NOT_SET - to 'unset' a previous set value.
         """
 
         RESTRICTED = 'RESTRICTED'
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
+
 
     class RestrictCreatePlatformApikeyEnum(str, Enum):
         """
@@ -3163,6 +5402,7 @@ class AccountSettingsResponse:
         RESTRICTED = 'RESTRICTED'
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
+
 
     class MfaEnum(str, Enum):
         """
@@ -3183,6 +5423,334 @@ class AccountSettingsResponse:
         LEVEL1 = 'LEVEL1'
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
+
+
+
+class AccountSettingsTemplateList:
+    """
+    AccountSettingsTemplateList.
+
+    :attr ResponseContext context: (optional) Context with key properties for
+          problem determination.
+    :attr int offset: (optional) The offset of the current page.
+    :attr int limit: (optional) Optional size of a single page.
+    :attr str first: (optional) Link to the first page.
+    :attr str previous: (optional) Link to the previous available page. If
+          'previous' property is not part of the response no previous page is available.
+    :attr str next: (optional) Link to the next available page. If 'next' property
+          is not part of the response no next page is available.
+    :attr List[AccountSettingsTemplateResponse] account_settings_templates: List of
+          account settings templates based on the query paramters and the page size. The
+          account_settings_templates array is always part of the response but might be
+          empty depending on the query parameter values provided.
+    """
+
+    def __init__(
+        self,
+        account_settings_templates: List['AccountSettingsTemplateResponse'],
+        *,
+        context: 'ResponseContext' = None,
+        offset: int = None,
+        limit: int = None,
+        first: str = None,
+        previous: str = None,
+        next: str = None,
+    ) -> None:
+        """
+        Initialize a AccountSettingsTemplateList object.
+
+        :param List[AccountSettingsTemplateResponse] account_settings_templates:
+               List of account settings templates based on the query paramters and the
+               page size. The account_settings_templates array is always part of the
+               response but might be empty depending on the query parameter values
+               provided.
+        :param ResponseContext context: (optional) Context with key properties for
+               problem determination.
+        :param int offset: (optional) The offset of the current page.
+        :param int limit: (optional) Optional size of a single page.
+        :param str first: (optional) Link to the first page.
+        :param str previous: (optional) Link to the previous available page. If
+               'previous' property is not part of the response no previous page is
+               available.
+        :param str next: (optional) Link to the next available page. If 'next'
+               property is not part of the response no next page is available.
+        """
+        self.context = context
+        self.offset = offset
+        self.limit = limit
+        self.first = first
+        self.previous = previous
+        self.next = next
+        self.account_settings_templates = account_settings_templates
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'AccountSettingsTemplateList':
+        """Initialize a AccountSettingsTemplateList object from a json dictionary."""
+        args = {}
+        if 'context' in _dict:
+            args['context'] = ResponseContext.from_dict(_dict.get('context'))
+        if 'offset' in _dict:
+            args['offset'] = _dict.get('offset')
+        if 'limit' in _dict:
+            args['limit'] = _dict.get('limit')
+        if 'first' in _dict:
+            args['first'] = _dict.get('first')
+        if 'previous' in _dict:
+            args['previous'] = _dict.get('previous')
+        if 'next' in _dict:
+            args['next'] = _dict.get('next')
+        if 'account_settings_templates' in _dict:
+            args['account_settings_templates'] = [AccountSettingsTemplateResponse.from_dict(v) for v in _dict.get('account_settings_templates')]
+        else:
+            raise ValueError('Required property \'account_settings_templates\' not present in AccountSettingsTemplateList JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a AccountSettingsTemplateList object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'context') and self.context is not None:
+            if isinstance(self.context, dict):
+                _dict['context'] = self.context
+            else:
+                _dict['context'] = self.context.to_dict()
+        if hasattr(self, 'offset') and self.offset is not None:
+            _dict['offset'] = self.offset
+        if hasattr(self, 'limit') and self.limit is not None:
+            _dict['limit'] = self.limit
+        if hasattr(self, 'first') and self.first is not None:
+            _dict['first'] = self.first
+        if hasattr(self, 'previous') and self.previous is not None:
+            _dict['previous'] = self.previous
+        if hasattr(self, 'next') and self.next is not None:
+            _dict['next'] = self.next
+        if hasattr(self, 'account_settings_templates') and self.account_settings_templates is not None:
+            account_settings_templates_list = []
+            for v in self.account_settings_templates:
+                if isinstance(v, dict):
+                    account_settings_templates_list.append(v)
+                else:
+                    account_settings_templates_list.append(v.to_dict())
+            _dict['account_settings_templates'] = account_settings_templates_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this AccountSettingsTemplateList object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'AccountSettingsTemplateList') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'AccountSettingsTemplateList') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class AccountSettingsTemplateResponse:
+    """
+    Response body format for account settings template REST requests.
+
+    :attr str id: ID of the the template.
+    :attr int version: Version of the the template.
+    :attr str account_id: ID of the account where the template resides.
+    :attr str name: The name of the trusted profile template. This is visible only
+          in the enterprise account.
+    :attr str description: (optional) The description of the trusted profile
+          template. Describe the template for enterprise account users.
+    :attr bool committed: Committed flag determines if the template is ready for
+          assignment.
+    :attr AccountSettingsComponent account_settings:
+    :attr List[EnityHistoryRecord] history: (optional) History of the Template.
+    :attr str entity_tag: Entity tag for this templateId-version combination.
+    :attr str crn: Cloud resource name.
+    :attr str created_at: (optional) Template Created At.
+    :attr str created_by_id: (optional) IAMid of the creator.
+    :attr str last_modified_at: (optional) Template last modified at.
+    :attr str last_modified_by_id: (optional) IAMid of the identity that made the
+          latest modification.
+    """
+
+    def __init__(
+        self,
+        id: str,
+        version: int,
+        account_id: str,
+        name: str,
+        committed: bool,
+        account_settings: 'AccountSettingsComponent',
+        entity_tag: str,
+        crn: str,
+        *,
+        description: str = None,
+        history: List['EnityHistoryRecord'] = None,
+        created_at: str = None,
+        created_by_id: str = None,
+        last_modified_at: str = None,
+        last_modified_by_id: str = None,
+    ) -> None:
+        """
+        Initialize a AccountSettingsTemplateResponse object.
+
+        :param str id: ID of the the template.
+        :param int version: Version of the the template.
+        :param str account_id: ID of the account where the template resides.
+        :param str name: The name of the trusted profile template. This is visible
+               only in the enterprise account.
+        :param bool committed: Committed flag determines if the template is ready
+               for assignment.
+        :param AccountSettingsComponent account_settings:
+        :param str entity_tag: Entity tag for this templateId-version combination.
+        :param str crn: Cloud resource name.
+        :param str description: (optional) The description of the trusted profile
+               template. Describe the template for enterprise account users.
+        :param List[EnityHistoryRecord] history: (optional) History of the
+               Template.
+        :param str created_at: (optional) Template Created At.
+        :param str created_by_id: (optional) IAMid of the creator.
+        :param str last_modified_at: (optional) Template last modified at.
+        :param str last_modified_by_id: (optional) IAMid of the identity that made
+               the latest modification.
+        """
+        self.id = id
+        self.version = version
+        self.account_id = account_id
+        self.name = name
+        self.description = description
+        self.committed = committed
+        self.account_settings = account_settings
+        self.history = history
+        self.entity_tag = entity_tag
+        self.crn = crn
+        self.created_at = created_at
+        self.created_by_id = created_by_id
+        self.last_modified_at = last_modified_at
+        self.last_modified_by_id = last_modified_by_id
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'AccountSettingsTemplateResponse':
+        """Initialize a AccountSettingsTemplateResponse object from a json dictionary."""
+        args = {}
+        if 'id' in _dict:
+            args['id'] = _dict.get('id')
+        else:
+            raise ValueError('Required property \'id\' not present in AccountSettingsTemplateResponse JSON')
+        if 'version' in _dict:
+            args['version'] = _dict.get('version')
+        else:
+            raise ValueError('Required property \'version\' not present in AccountSettingsTemplateResponse JSON')
+        if 'account_id' in _dict:
+            args['account_id'] = _dict.get('account_id')
+        else:
+            raise ValueError('Required property \'account_id\' not present in AccountSettingsTemplateResponse JSON')
+        if 'name' in _dict:
+            args['name'] = _dict.get('name')
+        else:
+            raise ValueError('Required property \'name\' not present in AccountSettingsTemplateResponse JSON')
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
+        if 'committed' in _dict:
+            args['committed'] = _dict.get('committed')
+        else:
+            raise ValueError('Required property \'committed\' not present in AccountSettingsTemplateResponse JSON')
+        if 'account_settings' in _dict:
+            args['account_settings'] = AccountSettingsComponent.from_dict(_dict.get('account_settings'))
+        else:
+            raise ValueError('Required property \'account_settings\' not present in AccountSettingsTemplateResponse JSON')
+        if 'history' in _dict:
+            args['history'] = [EnityHistoryRecord.from_dict(v) for v in _dict.get('history')]
+        if 'entity_tag' in _dict:
+            args['entity_tag'] = _dict.get('entity_tag')
+        else:
+            raise ValueError('Required property \'entity_tag\' not present in AccountSettingsTemplateResponse JSON')
+        if 'crn' in _dict:
+            args['crn'] = _dict.get('crn')
+        else:
+            raise ValueError('Required property \'crn\' not present in AccountSettingsTemplateResponse JSON')
+        if 'created_at' in _dict:
+            args['created_at'] = _dict.get('created_at')
+        if 'created_by_id' in _dict:
+            args['created_by_id'] = _dict.get('created_by_id')
+        if 'last_modified_at' in _dict:
+            args['last_modified_at'] = _dict.get('last_modified_at')
+        if 'last_modified_by_id' in _dict:
+            args['last_modified_by_id'] = _dict.get('last_modified_by_id')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a AccountSettingsTemplateResponse object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'version') and self.version is not None:
+            _dict['version'] = self.version
+        if hasattr(self, 'account_id') and self.account_id is not None:
+            _dict['account_id'] = self.account_id
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'committed') and self.committed is not None:
+            _dict['committed'] = self.committed
+        if hasattr(self, 'account_settings') and self.account_settings is not None:
+            if isinstance(self.account_settings, dict):
+                _dict['account_settings'] = self.account_settings
+            else:
+                _dict['account_settings'] = self.account_settings.to_dict()
+        if hasattr(self, 'history') and self.history is not None:
+            history_list = []
+            for v in self.history:
+                if isinstance(v, dict):
+                    history_list.append(v)
+                else:
+                    history_list.append(v.to_dict())
+            _dict['history'] = history_list
+        if hasattr(self, 'entity_tag') and self.entity_tag is not None:
+            _dict['entity_tag'] = self.entity_tag
+        if hasattr(self, 'crn') and self.crn is not None:
+            _dict['crn'] = self.crn
+        if hasattr(self, 'created_at') and self.created_at is not None:
+            _dict['created_at'] = self.created_at
+        if hasattr(self, 'created_by_id') and self.created_by_id is not None:
+            _dict['created_by_id'] = self.created_by_id
+        if hasattr(self, 'last_modified_at') and self.last_modified_at is not None:
+            _dict['last_modified_at'] = self.last_modified_at
+        if hasattr(self, 'last_modified_by_id') and self.last_modified_by_id is not None:
+            _dict['last_modified_by_id'] = self.last_modified_by_id
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this AccountSettingsTemplateResponse object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'AccountSettingsTemplateResponse') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'AccountSettingsTemplateResponse') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
 
 
 class AccountSettingsUserMFA:
@@ -3286,6 +5854,7 @@ class AccountSettingsUserMFA:
         LEVEL1 = 'LEVEL1'
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
+
 
 
 class Activity:
@@ -4357,6 +6926,197 @@ class EntityActivity:
         return not self == other
 
 
+class Error:
+    """
+    Error information.
+
+    :attr str code: Error code of the REST Exception.
+    :attr str message_code: Error message code of the REST Exception.
+    :attr str message: Error message of the REST Exception. Error messages are
+          derived base on the input locale of the REST request and the available Message
+          catalogs. Dynamic fallback to 'us-english' is happening if no message catalog is
+          available for the provided input locale.
+    :attr str details: (optional) Error details of the REST Exception.
+    """
+
+    def __init__(
+        self,
+        code: str,
+        message_code: str,
+        message: str,
+        *,
+        details: str = None,
+    ) -> None:
+        """
+        Initialize a Error object.
+
+        :param str code: Error code of the REST Exception.
+        :param str message_code: Error message code of the REST Exception.
+        :param str message: Error message of the REST Exception. Error messages are
+               derived base on the input locale of the REST request and the available
+               Message catalogs. Dynamic fallback to 'us-english' is happening if no
+               message catalog is available for the provided input locale.
+        :param str details: (optional) Error details of the REST Exception.
+        """
+        self.code = code
+        self.message_code = message_code
+        self.message = message
+        self.details = details
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'Error':
+        """Initialize a Error object from a json dictionary."""
+        args = {}
+        if 'code' in _dict:
+            args['code'] = _dict.get('code')
+        else:
+            raise ValueError('Required property \'code\' not present in Error JSON')
+        if 'message_code' in _dict:
+            args['message_code'] = _dict.get('message_code')
+        else:
+            raise ValueError('Required property \'message_code\' not present in Error JSON')
+        if 'message' in _dict:
+            args['message'] = _dict.get('message')
+        else:
+            raise ValueError('Required property \'message\' not present in Error JSON')
+        if 'details' in _dict:
+            args['details'] = _dict.get('details')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a Error object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'code') and self.code is not None:
+            _dict['code'] = self.code
+        if hasattr(self, 'message_code') and self.message_code is not None:
+            _dict['message_code'] = self.message_code
+        if hasattr(self, 'message') and self.message is not None:
+            _dict['message'] = self.message
+        if hasattr(self, 'details') and self.details is not None:
+            _dict['details'] = self.details
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this Error object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'Error') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'Error') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class ExceptionResponse:
+    """
+    Response body parameters in case of error situations.
+
+    :attr ResponseContext context: (optional) Context with key properties for
+          problem determination.
+    :attr str status_code: Error message code of the REST Exception.
+    :attr List[Error] errors: List of errors that occured.
+    :attr str trace: (optional) Unique ID of the requst.
+    """
+
+    def __init__(
+        self,
+        status_code: str,
+        errors: List['Error'],
+        *,
+        context: 'ResponseContext' = None,
+        trace: str = None,
+    ) -> None:
+        """
+        Initialize a ExceptionResponse object.
+
+        :param str status_code: Error message code of the REST Exception.
+        :param List[Error] errors: List of errors that occured.
+        :param ResponseContext context: (optional) Context with key properties for
+               problem determination.
+        :param str trace: (optional) Unique ID of the requst.
+        """
+        self.context = context
+        self.status_code = status_code
+        self.errors = errors
+        self.trace = trace
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'ExceptionResponse':
+        """Initialize a ExceptionResponse object from a json dictionary."""
+        args = {}
+        if 'context' in _dict:
+            args['context'] = ResponseContext.from_dict(_dict.get('context'))
+        if 'status_code' in _dict:
+            args['status_code'] = _dict.get('status_code')
+        else:
+            raise ValueError('Required property \'status_code\' not present in ExceptionResponse JSON')
+        if 'errors' in _dict:
+            args['errors'] = [Error.from_dict(v) for v in _dict.get('errors')]
+        else:
+            raise ValueError('Required property \'errors\' not present in ExceptionResponse JSON')
+        if 'trace' in _dict:
+            args['trace'] = _dict.get('trace')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a ExceptionResponse object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'context') and self.context is not None:
+            if isinstance(self.context, dict):
+                _dict['context'] = self.context
+            else:
+                _dict['context'] = self.context.to_dict()
+        if hasattr(self, 'status_code') and self.status_code is not None:
+            _dict['status_code'] = self.status_code
+        if hasattr(self, 'errors') and self.errors is not None:
+            errors_list = []
+            for v in self.errors:
+                if isinstance(v, dict):
+                    errors_list.append(v)
+                else:
+                    errors_list.append(v.to_dict())
+            _dict['errors'] = errors_list
+        if hasattr(self, 'trace') and self.trace is not None:
+            _dict['trace'] = self.trace
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this ExceptionResponse object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'ExceptionResponse') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'ExceptionResponse') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class IdBasedMfaEnrollment:
     """
     IdBasedMfaEnrollment.
@@ -4511,6 +7271,7 @@ class IdBasedMfaEnrollment:
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
 
+
     class TraitUserSpecificEnum(str, Enum):
         """
         Defines the MFA trait for the account. Valid values:
@@ -4531,6 +7292,7 @@ class IdBasedMfaEnrollment:
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
 
+
     class TraitEffectiveEnum(str, Enum):
         """
         Defines the MFA trait for the account. Valid values:
@@ -4550,6 +7312,7 @@ class IdBasedMfaEnrollment:
         LEVEL1 = 'LEVEL1'
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
+
 
 
 class MfaEnrollmentTypeStatus:
@@ -4701,6 +7464,75 @@ class MfaEnrollments:
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other: 'MfaEnrollments') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class PolicyTemplateReference:
+    """
+    Metadata for external access policy.
+
+    :attr str id: ID of Access Policy Template.
+    :attr str version: Version of Access Policy Template.
+    """
+
+    def __init__(
+        self,
+        id: str,
+        version: str,
+    ) -> None:
+        """
+        Initialize a PolicyTemplateReference object.
+
+        :param str id: ID of Access Policy Template.
+        :param str version: Version of Access Policy Template.
+        """
+        self.id = id
+        self.version = version
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolicyTemplateReference':
+        """Initialize a PolicyTemplateReference object from a json dictionary."""
+        args = {}
+        if 'id' in _dict:
+            args['id'] = _dict.get('id')
+        else:
+            raise ValueError('Required property \'id\' not present in PolicyTemplateReference JSON')
+        if 'version' in _dict:
+            args['version'] = _dict.get('version')
+        else:
+            raise ValueError('Required property \'version\' not present in PolicyTemplateReference JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolicyTemplateReference object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'version') and self.version is not None:
+            _dict['version'] = self.version
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyTemplateReference object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyTemplateReference') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyTemplateReference') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -4868,8 +7700,7 @@ class ProfileClaimRuleConditions:
     """
     ProfileClaimRuleConditions.
 
-    :attr str claim: The claim to evaluate against. [Learn
-          more](/docs/account?topic=account-iam-condition-properties&interface=ui#cr-attribute-names).
+    :attr str claim: The claim to evaluate against.
     :attr str operator: The operation to perform on the claim. valid values are
           EQUALS, NOT_EQUALS, EQUALS_IGNORE_CASE, NOT_EQUALS_IGNORE_CASE, CONTAINS, IN.
     :attr str value: The stringified JSON value that the claim is compared to using
@@ -4885,8 +7716,7 @@ class ProfileClaimRuleConditions:
         """
         Initialize a ProfileClaimRuleConditions object.
 
-        :param str claim: The claim to evaluate against. [Learn
-               more](/docs/account?topic=account-iam-condition-properties&interface=ui#cr-attribute-names).
+        :param str claim: The claim to evaluate against.
         :param str operator: The operation to perform on the claim. valid values
                are EQUALS, NOT_EQUALS, EQUALS_IGNORE_CASE, NOT_EQUALS_IGNORE_CASE,
                CONTAINS, IN.
@@ -5034,21 +7864,22 @@ class ProfileIdentitiesResponse:
     ProfileIdentitiesResponse.
 
     :attr str entity_tag: (optional) Entity tag of the profile identities response.
-    :attr List[ProfileIdentity] identities: (optional) List of identities.
+    :attr List[ProfileIdentityResponse] identities: (optional) List of identities.
     """
 
     def __init__(
         self,
         *,
         entity_tag: str = None,
-        identities: List['ProfileIdentity'] = None,
+        identities: List['ProfileIdentityResponse'] = None,
     ) -> None:
         """
         Initialize a ProfileIdentitiesResponse object.
 
         :param str entity_tag: (optional) Entity tag of the profile identities
                response.
-        :param List[ProfileIdentity] identities: (optional) List of identities.
+        :param List[ProfileIdentityResponse] identities: (optional) List of
+               identities.
         """
         self.entity_tag = entity_tag
         self.identities = identities
@@ -5060,7 +7891,7 @@ class ProfileIdentitiesResponse:
         if 'entity_tag' in _dict:
             args['entity_tag'] = _dict.get('entity_tag')
         if 'identities' in _dict:
-            args['identities'] = [ProfileIdentity.from_dict(v) for v in _dict.get('identities')]
+            args['identities'] = [ProfileIdentityResponse.from_dict(v) for v in _dict.get('identities')]
         return cls(**args)
 
     @classmethod
@@ -5102,11 +7933,10 @@ class ProfileIdentitiesResponse:
         return not self == other
 
 
-class ProfileIdentity:
+class ProfileIdentityRequest:
     """
-    ProfileIdentity.
+    ProfileIdentityRequest.
 
-    :attr str iam_id: (optional) IAM ID of the identity.
     :attr str identifier: Identifier of the identity that can assume the trusted
           profiles. This can be a user identifier (IAM id), serviceid or crn. Internally
           it uses account id of the service id for the identifier 'serviceid' and for the
@@ -5126,12 +7956,11 @@ class ProfileIdentity:
         identifier: str,
         type: str,
         *,
-        iam_id: str = None,
         accounts: List[str] = None,
         description: str = None,
     ) -> None:
         """
-        Initialize a ProfileIdentity object.
+        Initialize a ProfileIdentityRequest object.
 
         :param str identifier: Identifier of the identity that can assume the
                trusted profiles. This can be a user identifier (IAM id), serviceid or crn.
@@ -5139,7 +7968,123 @@ class ProfileIdentity:
                'serviceid' and for the identifier 'crn' it uses account id contained in
                the CRN.
         :param str type: Type of the identity.
-        :param str iam_id: (optional) IAM ID of the identity.
+        :param List[str] accounts: (optional) Only valid for the type user.
+               Accounts from which a user can assume the trusted profile.
+        :param str description: (optional) Description of the identity that can
+               assume the trusted profile. This is optional field for all the types of
+               identities. When this field is not set for the identity type 'serviceid'
+               then the description of the service id is used. Description is recommended
+               for the identity type 'crn' E.g. 'Instance 1234 of IBM Cloud Service
+               project'.
+        """
+        self.identifier = identifier
+        self.type = type
+        self.accounts = accounts
+        self.description = description
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'ProfileIdentityRequest':
+        """Initialize a ProfileIdentityRequest object from a json dictionary."""
+        args = {}
+        if 'identifier' in _dict:
+            args['identifier'] = _dict.get('identifier')
+        else:
+            raise ValueError('Required property \'identifier\' not present in ProfileIdentityRequest JSON')
+        if 'type' in _dict:
+            args['type'] = _dict.get('type')
+        else:
+            raise ValueError('Required property \'type\' not present in ProfileIdentityRequest JSON')
+        if 'accounts' in _dict:
+            args['accounts'] = _dict.get('accounts')
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a ProfileIdentityRequest object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'identifier') and self.identifier is not None:
+            _dict['identifier'] = self.identifier
+        if hasattr(self, 'type') and self.type is not None:
+            _dict['type'] = self.type
+        if hasattr(self, 'accounts') and self.accounts is not None:
+            _dict['accounts'] = self.accounts
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this ProfileIdentityRequest object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'ProfileIdentityRequest') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'ProfileIdentityRequest') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class TypeEnum(str, Enum):
+        """
+        Type of the identity.
+        """
+
+        USER = 'user'
+        SERVICEID = 'serviceid'
+        CRN = 'crn'
+
+
+
+class ProfileIdentityResponse:
+    """
+    ProfileIdentityResponse.
+
+    :attr str iam_id: IAM ID of the identity.
+    :attr str identifier: Identifier of the identity that can assume the trusted
+          profiles. This can be a user identifier (IAM id), serviceid or crn. Internally
+          it uses account id of the service id for the identifier 'serviceid' and for the
+          identifier 'crn' it uses account id contained in the CRN.
+    :attr str type: Type of the identity.
+    :attr List[str] accounts: (optional) Only valid for the type user. Accounts from
+          which a user can assume the trusted profile.
+    :attr str description: (optional) Description of the identity that can assume
+          the trusted profile. This is optional field for all the types of identities.
+          When this field is not set for the identity type 'serviceid' then the
+          description of the service id is used. Description is recommended for the
+          identity type 'crn' E.g. 'Instance 1234 of IBM Cloud Service project'.
+    """
+
+    def __init__(
+        self,
+        iam_id: str,
+        identifier: str,
+        type: str,
+        *,
+        accounts: List[str] = None,
+        description: str = None,
+    ) -> None:
+        """
+        Initialize a ProfileIdentityResponse object.
+
+        :param str iam_id: IAM ID of the identity.
+        :param str identifier: Identifier of the identity that can assume the
+               trusted profiles. This can be a user identifier (IAM id), serviceid or crn.
+               Internally it uses account id of the service id for the identifier
+               'serviceid' and for the identifier 'crn' it uses account id contained in
+               the CRN.
+        :param str type: Type of the identity.
         :param List[str] accounts: (optional) Only valid for the type user.
                Accounts from which a user can assume the trusted profile.
         :param str description: (optional) Description of the identity that can
@@ -5156,19 +8101,21 @@ class ProfileIdentity:
         self.description = description
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> 'ProfileIdentity':
-        """Initialize a ProfileIdentity object from a json dictionary."""
+    def from_dict(cls, _dict: Dict) -> 'ProfileIdentityResponse':
+        """Initialize a ProfileIdentityResponse object from a json dictionary."""
         args = {}
         if 'iam_id' in _dict:
             args['iam_id'] = _dict.get('iam_id')
+        else:
+            raise ValueError('Required property \'iam_id\' not present in ProfileIdentityResponse JSON')
         if 'identifier' in _dict:
             args['identifier'] = _dict.get('identifier')
         else:
-            raise ValueError('Required property \'identifier\' not present in ProfileIdentity JSON')
+            raise ValueError('Required property \'identifier\' not present in ProfileIdentityResponse JSON')
         if 'type' in _dict:
             args['type'] = _dict.get('type')
         else:
-            raise ValueError('Required property \'type\' not present in ProfileIdentity JSON')
+            raise ValueError('Required property \'type\' not present in ProfileIdentityResponse JSON')
         if 'accounts' in _dict:
             args['accounts'] = _dict.get('accounts')
         if 'description' in _dict:
@@ -5177,7 +8124,7 @@ class ProfileIdentity:
 
     @classmethod
     def _from_dict(cls, _dict):
-        """Initialize a ProfileIdentity object from a json dictionary."""
+        """Initialize a ProfileIdentityResponse object from a json dictionary."""
         return cls.from_dict(_dict)
 
     def to_dict(self) -> Dict:
@@ -5200,16 +8147,16 @@ class ProfileIdentity:
         return self.to_dict()
 
     def __str__(self) -> str:
-        """Return a `str` version of this ProfileIdentity object."""
+        """Return a `str` version of this ProfileIdentityResponse object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: 'ProfileIdentity') -> bool:
+    def __eq__(self, other: 'ProfileIdentityResponse') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: 'ProfileIdentity') -> bool:
+    def __ne__(self, other: 'ProfileIdentityResponse') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -5221,6 +8168,7 @@ class ProfileIdentity:
         USER = 'user'
         SERVICEID = 'serviceid'
         CRN = 'crn'
+
 
 
 class ProfileLink:
@@ -6330,6 +9278,917 @@ class ServiceIdList:
         return not self == other
 
 
+class TemplateAssignmentListResponse:
+    """
+    List Response body format for Template Assignments Records.
+
+    :attr ResponseContext context: (optional) Context with key properties for
+          problem determination.
+    :attr int offset: (optional) The offset of the current page.
+    :attr int limit: (optional) Optional size of a single page. Default is 20 items
+          per page. Valid range is 1 to 100.
+    :attr str first: (optional) Link to the first page.
+    :attr str previous: (optional) Link to the previous available page. If
+          'previous' property is not part of the response no previous page is available.
+    :attr str next: (optional) Link to the next available page. If 'next' property
+          is not part of the response no next page is available.
+    :attr List[TemplateAssignmentResponse] assignments: List of Assignments based on
+          the query paramters and the page size. The assignments array is always part of
+          the response but might be empty depending on the query parameter values
+          provided.
+    """
+
+    def __init__(
+        self,
+        assignments: List['TemplateAssignmentResponse'],
+        *,
+        context: 'ResponseContext' = None,
+        offset: int = None,
+        limit: int = None,
+        first: str = None,
+        previous: str = None,
+        next: str = None,
+    ) -> None:
+        """
+        Initialize a TemplateAssignmentListResponse object.
+
+        :param List[TemplateAssignmentResponse] assignments: List of Assignments
+               based on the query paramters and the page size. The assignments array is
+               always part of the response but might be empty depending on the query
+               parameter values provided.
+        :param ResponseContext context: (optional) Context with key properties for
+               problem determination.
+        :param int offset: (optional) The offset of the current page.
+        :param int limit: (optional) Optional size of a single page. Default is 20
+               items per page. Valid range is 1 to 100.
+        :param str first: (optional) Link to the first page.
+        :param str previous: (optional) Link to the previous available page. If
+               'previous' property is not part of the response no previous page is
+               available.
+        :param str next: (optional) Link to the next available page. If 'next'
+               property is not part of the response no next page is available.
+        """
+        self.context = context
+        self.offset = offset
+        self.limit = limit
+        self.first = first
+        self.previous = previous
+        self.next = next
+        self.assignments = assignments
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TemplateAssignmentListResponse':
+        """Initialize a TemplateAssignmentListResponse object from a json dictionary."""
+        args = {}
+        if 'context' in _dict:
+            args['context'] = ResponseContext.from_dict(_dict.get('context'))
+        if 'offset' in _dict:
+            args['offset'] = _dict.get('offset')
+        if 'limit' in _dict:
+            args['limit'] = _dict.get('limit')
+        if 'first' in _dict:
+            args['first'] = _dict.get('first')
+        if 'previous' in _dict:
+            args['previous'] = _dict.get('previous')
+        if 'next' in _dict:
+            args['next'] = _dict.get('next')
+        if 'assignments' in _dict:
+            args['assignments'] = [TemplateAssignmentResponse.from_dict(v) for v in _dict.get('assignments')]
+        else:
+            raise ValueError('Required property \'assignments\' not present in TemplateAssignmentListResponse JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TemplateAssignmentListResponse object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'context') and self.context is not None:
+            if isinstance(self.context, dict):
+                _dict['context'] = self.context
+            else:
+                _dict['context'] = self.context.to_dict()
+        if hasattr(self, 'offset') and self.offset is not None:
+            _dict['offset'] = self.offset
+        if hasattr(self, 'limit') and self.limit is not None:
+            _dict['limit'] = self.limit
+        if hasattr(self, 'first') and self.first is not None:
+            _dict['first'] = self.first
+        if hasattr(self, 'previous') and self.previous is not None:
+            _dict['previous'] = self.previous
+        if hasattr(self, 'next') and self.next is not None:
+            _dict['next'] = self.next
+        if hasattr(self, 'assignments') and self.assignments is not None:
+            assignments_list = []
+            for v in self.assignments:
+                if isinstance(v, dict):
+                    assignments_list.append(v)
+                else:
+                    assignments_list.append(v.to_dict())
+            _dict['assignments'] = assignments_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TemplateAssignmentListResponse object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TemplateAssignmentListResponse') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TemplateAssignmentListResponse') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class TemplateAssignmentResource:
+    """
+    Body parameters for created resource.
+
+    :attr str id: (optional) Id of the created resource.
+    """
+
+    def __init__(
+        self,
+        *,
+        id: str = None,
+    ) -> None:
+        """
+        Initialize a TemplateAssignmentResource object.
+
+        :param str id: (optional) Id of the created resource.
+        """
+        self.id = id
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TemplateAssignmentResource':
+        """Initialize a TemplateAssignmentResource object from a json dictionary."""
+        args = {}
+        if 'id' in _dict:
+            args['id'] = _dict.get('id')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TemplateAssignmentResource object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TemplateAssignmentResource object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TemplateAssignmentResource') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TemplateAssignmentResource') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class TemplateAssignmentResourceError:
+    """
+    Body parameters for assignment error.
+
+    :attr str name: (optional) Name of the error.
+    :attr str error_code: (optional) Internal error code.
+    :attr str message: (optional) Error message detailing the nature of the error.
+    :attr str status_code: (optional) Internal status code for the error.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str = None,
+        error_code: str = None,
+        message: str = None,
+        status_code: str = None,
+    ) -> None:
+        """
+        Initialize a TemplateAssignmentResourceError object.
+
+        :param str name: (optional) Name of the error.
+        :param str error_code: (optional) Internal error code.
+        :param str message: (optional) Error message detailing the nature of the
+               error.
+        :param str status_code: (optional) Internal status code for the error.
+        """
+        self.name = name
+        self.error_code = error_code
+        self.message = message
+        self.status_code = status_code
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TemplateAssignmentResourceError':
+        """Initialize a TemplateAssignmentResourceError object from a json dictionary."""
+        args = {}
+        if 'name' in _dict:
+            args['name'] = _dict.get('name')
+        if 'errorCode' in _dict:
+            args['error_code'] = _dict.get('errorCode')
+        if 'message' in _dict:
+            args['message'] = _dict.get('message')
+        if 'statusCode' in _dict:
+            args['status_code'] = _dict.get('statusCode')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TemplateAssignmentResourceError object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'error_code') and self.error_code is not None:
+            _dict['errorCode'] = self.error_code
+        if hasattr(self, 'message') and self.message is not None:
+            _dict['message'] = self.message
+        if hasattr(self, 'status_code') and self.status_code is not None:
+            _dict['statusCode'] = self.status_code
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TemplateAssignmentResourceError object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TemplateAssignmentResourceError') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TemplateAssignmentResourceError') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class TemplateAssignmentResponse:
+    """
+    Response body format for Template Assignment Record.
+
+    :attr ResponseContext context: (optional) Context with key properties for
+          problem determination.
+    :attr str id: Assignment record Id.
+    :attr str account_id: Enterprise account Id.
+    :attr str template_id: Template Id.
+    :attr int template_version: Template version.
+    :attr str target_type: Assignment target type.
+    :attr str target: Assignment target.
+    :attr str status: Assignment status.
+    :attr List[TemplateAssignmentResponseResource] resources: (optional) Status
+          breakdown per target account of IAM resources created or errors encountered in
+          attempting to create those IAM resources. IAM resources are only included in the
+          response providing the assignment is not in progress. IAM resources are also
+          only included when getting a single assignment, and excluded by list APIs.
+    :attr List[EnityHistoryRecord] history: (optional) Assignment history.
+    :attr str href: (optional) Href.
+    :attr str created_at: Assignment created at.
+    :attr str created_by_id: IAMid of the identity that created the assignment.
+    :attr str last_modified_at: Assignment modified at.
+    :attr str last_modified_by_id: IAMid of the identity that last modified the
+          assignment.
+    :attr str entity_tag: Entity tag for this assignment record.
+    """
+
+    def __init__(
+        self,
+        id: str,
+        account_id: str,
+        template_id: str,
+        template_version: int,
+        target_type: str,
+        target: str,
+        status: str,
+        created_at: str,
+        created_by_id: str,
+        last_modified_at: str,
+        last_modified_by_id: str,
+        entity_tag: str,
+        *,
+        context: 'ResponseContext' = None,
+        resources: List['TemplateAssignmentResponseResource'] = None,
+        history: List['EnityHistoryRecord'] = None,
+        href: str = None,
+    ) -> None:
+        """
+        Initialize a TemplateAssignmentResponse object.
+
+        :param str id: Assignment record Id.
+        :param str account_id: Enterprise account Id.
+        :param str template_id: Template Id.
+        :param int template_version: Template version.
+        :param str target_type: Assignment target type.
+        :param str target: Assignment target.
+        :param str status: Assignment status.
+        :param str created_at: Assignment created at.
+        :param str created_by_id: IAMid of the identity that created the
+               assignment.
+        :param str last_modified_at: Assignment modified at.
+        :param str last_modified_by_id: IAMid of the identity that last modified
+               the assignment.
+        :param str entity_tag: Entity tag for this assignment record.
+        :param ResponseContext context: (optional) Context with key properties for
+               problem determination.
+        :param List[TemplateAssignmentResponseResource] resources: (optional)
+               Status breakdown per target account of IAM resources created or errors
+               encountered in attempting to create those IAM resources. IAM resources are
+               only included in the response providing the assignment is not in progress.
+               IAM resources are also only included when getting a single assignment, and
+               excluded by list APIs.
+        :param List[EnityHistoryRecord] history: (optional) Assignment history.
+        :param str href: (optional) Href.
+        """
+        self.context = context
+        self.id = id
+        self.account_id = account_id
+        self.template_id = template_id
+        self.template_version = template_version
+        self.target_type = target_type
+        self.target = target
+        self.status = status
+        self.resources = resources
+        self.history = history
+        self.href = href
+        self.created_at = created_at
+        self.created_by_id = created_by_id
+        self.last_modified_at = last_modified_at
+        self.last_modified_by_id = last_modified_by_id
+        self.entity_tag = entity_tag
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TemplateAssignmentResponse':
+        """Initialize a TemplateAssignmentResponse object from a json dictionary."""
+        args = {}
+        if 'context' in _dict:
+            args['context'] = ResponseContext.from_dict(_dict.get('context'))
+        if 'id' in _dict:
+            args['id'] = _dict.get('id')
+        else:
+            raise ValueError('Required property \'id\' not present in TemplateAssignmentResponse JSON')
+        if 'account_id' in _dict:
+            args['account_id'] = _dict.get('account_id')
+        else:
+            raise ValueError('Required property \'account_id\' not present in TemplateAssignmentResponse JSON')
+        if 'template_id' in _dict:
+            args['template_id'] = _dict.get('template_id')
+        else:
+            raise ValueError('Required property \'template_id\' not present in TemplateAssignmentResponse JSON')
+        if 'template_version' in _dict:
+            args['template_version'] = _dict.get('template_version')
+        else:
+            raise ValueError('Required property \'template_version\' not present in TemplateAssignmentResponse JSON')
+        if 'target_type' in _dict:
+            args['target_type'] = _dict.get('target_type')
+        else:
+            raise ValueError('Required property \'target_type\' not present in TemplateAssignmentResponse JSON')
+        if 'target' in _dict:
+            args['target'] = _dict.get('target')
+        else:
+            raise ValueError('Required property \'target\' not present in TemplateAssignmentResponse JSON')
+        if 'status' in _dict:
+            args['status'] = _dict.get('status')
+        else:
+            raise ValueError('Required property \'status\' not present in TemplateAssignmentResponse JSON')
+        if 'resources' in _dict:
+            args['resources'] = [TemplateAssignmentResponseResource.from_dict(v) for v in _dict.get('resources')]
+        if 'history' in _dict:
+            args['history'] = [EnityHistoryRecord.from_dict(v) for v in _dict.get('history')]
+        if 'href' in _dict:
+            args['href'] = _dict.get('href')
+        if 'created_at' in _dict:
+            args['created_at'] = _dict.get('created_at')
+        else:
+            raise ValueError('Required property \'created_at\' not present in TemplateAssignmentResponse JSON')
+        if 'created_by_id' in _dict:
+            args['created_by_id'] = _dict.get('created_by_id')
+        else:
+            raise ValueError('Required property \'created_by_id\' not present in TemplateAssignmentResponse JSON')
+        if 'last_modified_at' in _dict:
+            args['last_modified_at'] = _dict.get('last_modified_at')
+        else:
+            raise ValueError('Required property \'last_modified_at\' not present in TemplateAssignmentResponse JSON')
+        if 'last_modified_by_id' in _dict:
+            args['last_modified_by_id'] = _dict.get('last_modified_by_id')
+        else:
+            raise ValueError('Required property \'last_modified_by_id\' not present in TemplateAssignmentResponse JSON')
+        if 'entity_tag' in _dict:
+            args['entity_tag'] = _dict.get('entity_tag')
+        else:
+            raise ValueError('Required property \'entity_tag\' not present in TemplateAssignmentResponse JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TemplateAssignmentResponse object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'context') and self.context is not None:
+            if isinstance(self.context, dict):
+                _dict['context'] = self.context
+            else:
+                _dict['context'] = self.context.to_dict()
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'account_id') and self.account_id is not None:
+            _dict['account_id'] = self.account_id
+        if hasattr(self, 'template_id') and self.template_id is not None:
+            _dict['template_id'] = self.template_id
+        if hasattr(self, 'template_version') and self.template_version is not None:
+            _dict['template_version'] = self.template_version
+        if hasattr(self, 'target_type') and self.target_type is not None:
+            _dict['target_type'] = self.target_type
+        if hasattr(self, 'target') and self.target is not None:
+            _dict['target'] = self.target
+        if hasattr(self, 'status') and self.status is not None:
+            _dict['status'] = self.status
+        if hasattr(self, 'resources') and self.resources is not None:
+            resources_list = []
+            for v in self.resources:
+                if isinstance(v, dict):
+                    resources_list.append(v)
+                else:
+                    resources_list.append(v.to_dict())
+            _dict['resources'] = resources_list
+        if hasattr(self, 'history') and self.history is not None:
+            history_list = []
+            for v in self.history:
+                if isinstance(v, dict):
+                    history_list.append(v)
+                else:
+                    history_list.append(v.to_dict())
+            _dict['history'] = history_list
+        if hasattr(self, 'href') and self.href is not None:
+            _dict['href'] = self.href
+        if hasattr(self, 'created_at') and self.created_at is not None:
+            _dict['created_at'] = self.created_at
+        if hasattr(self, 'created_by_id') and self.created_by_id is not None:
+            _dict['created_by_id'] = self.created_by_id
+        if hasattr(self, 'last_modified_at') and self.last_modified_at is not None:
+            _dict['last_modified_at'] = self.last_modified_at
+        if hasattr(self, 'last_modified_by_id') and self.last_modified_by_id is not None:
+            _dict['last_modified_by_id'] = self.last_modified_by_id
+        if hasattr(self, 'entity_tag') and self.entity_tag is not None:
+            _dict['entity_tag'] = self.entity_tag
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TemplateAssignmentResponse object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TemplateAssignmentResponse') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TemplateAssignmentResponse') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class TemplateAssignmentResponseResource:
+    """
+    Overview of resources assignment per target account.
+
+    :attr str target: Target account where the IAM resource is created.
+    :attr TemplateAssignmentResponseResourceDetail profile: (optional)
+    :attr TemplateAssignmentResponseResourceDetail account_settings: (optional)
+    :attr List[TemplateAssignmentResponseResourceDetail] policy_template_refs:
+          (optional) Policy resource(s) included only for trusted profile assignments with
+          policy references.
+    """
+
+    def __init__(
+        self,
+        target: str,
+        *,
+        profile: 'TemplateAssignmentResponseResourceDetail' = None,
+        account_settings: 'TemplateAssignmentResponseResourceDetail' = None,
+        policy_template_refs: List['TemplateAssignmentResponseResourceDetail'] = None,
+    ) -> None:
+        """
+        Initialize a TemplateAssignmentResponseResource object.
+
+        :param str target: Target account where the IAM resource is created.
+        :param TemplateAssignmentResponseResourceDetail profile: (optional)
+        :param TemplateAssignmentResponseResourceDetail account_settings:
+               (optional)
+        :param List[TemplateAssignmentResponseResourceDetail] policy_template_refs:
+               (optional) Policy resource(s) included only for trusted profile assignments
+               with policy references.
+        """
+        self.target = target
+        self.profile = profile
+        self.account_settings = account_settings
+        self.policy_template_refs = policy_template_refs
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TemplateAssignmentResponseResource':
+        """Initialize a TemplateAssignmentResponseResource object from a json dictionary."""
+        args = {}
+        if 'target' in _dict:
+            args['target'] = _dict.get('target')
+        else:
+            raise ValueError('Required property \'target\' not present in TemplateAssignmentResponseResource JSON')
+        if 'profile' in _dict:
+            args['profile'] = TemplateAssignmentResponseResourceDetail.from_dict(_dict.get('profile'))
+        if 'account_settings' in _dict:
+            args['account_settings'] = TemplateAssignmentResponseResourceDetail.from_dict(_dict.get('account_settings'))
+        if 'policy_template_refs' in _dict:
+            args['policy_template_refs'] = [TemplateAssignmentResponseResourceDetail.from_dict(v) for v in _dict.get('policy_template_refs')]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TemplateAssignmentResponseResource object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'target') and self.target is not None:
+            _dict['target'] = self.target
+        if hasattr(self, 'profile') and self.profile is not None:
+            if isinstance(self.profile, dict):
+                _dict['profile'] = self.profile
+            else:
+                _dict['profile'] = self.profile.to_dict()
+        if hasattr(self, 'account_settings') and self.account_settings is not None:
+            if isinstance(self.account_settings, dict):
+                _dict['account_settings'] = self.account_settings
+            else:
+                _dict['account_settings'] = self.account_settings.to_dict()
+        if hasattr(self, 'policy_template_refs') and self.policy_template_refs is not None:
+            policy_template_refs_list = []
+            for v in self.policy_template_refs:
+                if isinstance(v, dict):
+                    policy_template_refs_list.append(v)
+                else:
+                    policy_template_refs_list.append(v.to_dict())
+            _dict['policy_template_refs'] = policy_template_refs_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TemplateAssignmentResponseResource object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TemplateAssignmentResponseResource') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TemplateAssignmentResponseResource') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class TemplateAssignmentResponseResourceDetail:
+    """
+    TemplateAssignmentResponseResourceDetail.
+
+    :attr str id: (optional) Policy Template Id, only returned for a profile
+          assignment with policy references.
+    :attr str version: (optional) Policy version, only returned for a profile
+          assignment with policy references.
+    :attr TemplateAssignmentResource resource_created: (optional) Body parameters
+          for created resource.
+    :attr TemplateAssignmentResourceError error_message: (optional) Body parameters
+          for assignment error.
+    :attr str status: Status for the target account's assignment.
+    """
+
+    def __init__(
+        self,
+        status: str,
+        *,
+        id: str = None,
+        version: str = None,
+        resource_created: 'TemplateAssignmentResource' = None,
+        error_message: 'TemplateAssignmentResourceError' = None,
+    ) -> None:
+        """
+        Initialize a TemplateAssignmentResponseResourceDetail object.
+
+        :param str status: Status for the target account's assignment.
+        :param str id: (optional) Policy Template Id, only returned for a profile
+               assignment with policy references.
+        :param str version: (optional) Policy version, only returned for a profile
+               assignment with policy references.
+        :param TemplateAssignmentResource resource_created: (optional) Body
+               parameters for created resource.
+        :param TemplateAssignmentResourceError error_message: (optional) Body
+               parameters for assignment error.
+        """
+        self.id = id
+        self.version = version
+        self.resource_created = resource_created
+        self.error_message = error_message
+        self.status = status
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TemplateAssignmentResponseResourceDetail':
+        """Initialize a TemplateAssignmentResponseResourceDetail object from a json dictionary."""
+        args = {}
+        if 'id' in _dict:
+            args['id'] = _dict.get('id')
+        if 'version' in _dict:
+            args['version'] = _dict.get('version')
+        if 'resource_created' in _dict:
+            args['resource_created'] = TemplateAssignmentResource.from_dict(_dict.get('resource_created'))
+        if 'error_message' in _dict:
+            args['error_message'] = TemplateAssignmentResourceError.from_dict(_dict.get('error_message'))
+        if 'status' in _dict:
+            args['status'] = _dict.get('status')
+        else:
+            raise ValueError('Required property \'status\' not present in TemplateAssignmentResponseResourceDetail JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TemplateAssignmentResponseResourceDetail object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'version') and self.version is not None:
+            _dict['version'] = self.version
+        if hasattr(self, 'resource_created') and self.resource_created is not None:
+            if isinstance(self.resource_created, dict):
+                _dict['resource_created'] = self.resource_created
+            else:
+                _dict['resource_created'] = self.resource_created.to_dict()
+        if hasattr(self, 'error_message') and self.error_message is not None:
+            if isinstance(self.error_message, dict):
+                _dict['error_message'] = self.error_message
+            else:
+                _dict['error_message'] = self.error_message.to_dict()
+        if hasattr(self, 'status') and self.status is not None:
+            _dict['status'] = self.status
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TemplateAssignmentResponseResourceDetail object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TemplateAssignmentResponseResourceDetail') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TemplateAssignmentResponseResourceDetail') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class TemplateProfileComponentRequest:
+    """
+    Input body parameters for the TemplateProfileComponent.
+
+    :attr str name: Name of the Profile.
+    :attr str description: (optional) Description of the Profile.
+    :attr List[TrustedProfileTemplateClaimRule] rules: (optional) Rules for the
+          Profile.
+    :attr List[ProfileIdentityRequest] identities: (optional) Identities for the
+          Profile.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        description: str = None,
+        rules: List['TrustedProfileTemplateClaimRule'] = None,
+        identities: List['ProfileIdentityRequest'] = None,
+    ) -> None:
+        """
+        Initialize a TemplateProfileComponentRequest object.
+
+        :param str name: Name of the Profile.
+        :param str description: (optional) Description of the Profile.
+        :param List[TrustedProfileTemplateClaimRule] rules: (optional) Rules for
+               the Profile.
+        :param List[ProfileIdentityRequest] identities: (optional) Identities for
+               the Profile.
+        """
+        self.name = name
+        self.description = description
+        self.rules = rules
+        self.identities = identities
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TemplateProfileComponentRequest':
+        """Initialize a TemplateProfileComponentRequest object from a json dictionary."""
+        args = {}
+        if 'name' in _dict:
+            args['name'] = _dict.get('name')
+        else:
+            raise ValueError('Required property \'name\' not present in TemplateProfileComponentRequest JSON')
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
+        if 'rules' in _dict:
+            args['rules'] = [TrustedProfileTemplateClaimRule.from_dict(v) for v in _dict.get('rules')]
+        if 'identities' in _dict:
+            args['identities'] = [ProfileIdentityRequest.from_dict(v) for v in _dict.get('identities')]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TemplateProfileComponentRequest object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'rules') and self.rules is not None:
+            rules_list = []
+            for v in self.rules:
+                if isinstance(v, dict):
+                    rules_list.append(v)
+                else:
+                    rules_list.append(v.to_dict())
+            _dict['rules'] = rules_list
+        if hasattr(self, 'identities') and self.identities is not None:
+            identities_list = []
+            for v in self.identities:
+                if isinstance(v, dict):
+                    identities_list.append(v)
+                else:
+                    identities_list.append(v.to_dict())
+            _dict['identities'] = identities_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TemplateProfileComponentRequest object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TemplateProfileComponentRequest') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TemplateProfileComponentRequest') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class TemplateProfileComponentResponse:
+    """
+    Input body parameters for the TemplateProfileComponent.
+
+    :attr str name: Name of the Profile.
+    :attr str description: (optional) Description of the Profile.
+    :attr List[TrustedProfileTemplateClaimRule] rules: (optional) Rules for the
+          Profile.
+    :attr List[ProfileIdentityResponse] identities: (optional) Identities for the
+          Profile.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        description: str = None,
+        rules: List['TrustedProfileTemplateClaimRule'] = None,
+        identities: List['ProfileIdentityResponse'] = None,
+    ) -> None:
+        """
+        Initialize a TemplateProfileComponentResponse object.
+
+        :param str name: Name of the Profile.
+        :param str description: (optional) Description of the Profile.
+        :param List[TrustedProfileTemplateClaimRule] rules: (optional) Rules for
+               the Profile.
+        :param List[ProfileIdentityResponse] identities: (optional) Identities for
+               the Profile.
+        """
+        self.name = name
+        self.description = description
+        self.rules = rules
+        self.identities = identities
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TemplateProfileComponentResponse':
+        """Initialize a TemplateProfileComponentResponse object from a json dictionary."""
+        args = {}
+        if 'name' in _dict:
+            args['name'] = _dict.get('name')
+        else:
+            raise ValueError('Required property \'name\' not present in TemplateProfileComponentResponse JSON')
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
+        if 'rules' in _dict:
+            args['rules'] = [TrustedProfileTemplateClaimRule.from_dict(v) for v in _dict.get('rules')]
+        if 'identities' in _dict:
+            args['identities'] = [ProfileIdentityResponse.from_dict(v) for v in _dict.get('identities')]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TemplateProfileComponentResponse object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'rules') and self.rules is not None:
+            rules_list = []
+            for v in self.rules:
+                if isinstance(v, dict):
+                    rules_list.append(v)
+                else:
+                    rules_list.append(v.to_dict())
+            _dict['rules'] = rules_list
+        if hasattr(self, 'identities') and self.identities is not None:
+            identities_list = []
+            for v in self.identities:
+                if isinstance(v, dict):
+                    identities_list.append(v)
+                else:
+                    identities_list.append(v.to_dict())
+            _dict['identities'] = identities_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TemplateProfileComponentResponse object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TemplateProfileComponentResponse') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TemplateProfileComponentResponse') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class TrustedProfile:
     """
     Response body format for trusted profile V1 REST requests.
@@ -6354,6 +10213,14 @@ class TrustedProfile:
           last modification date in ISO format.
     :attr str iam_id: The iam_id of this trusted profile.
     :attr str account_id: ID of the account that this trusted profile belong to.
+    :attr str template_id: (optional) ID of the IAM template that was used to create
+          an enterprise-managed trusted profile in your account. When returned, this
+          indicates that the trusted profile is created from and managed by a template in
+          the root enterprise account.
+    :attr str assignment_id: (optional) ID of the assignment that was used to create
+          an enterprise-managed trusted profile in your account. When returned, this
+          indicates that the trusted profile is created from and managed by a template in
+          the root enterprise account.
     :attr int ims_account_id: (optional) IMS acount ID of the trusted profile.
     :attr int ims_user_id: (optional) IMS user ID of the trusted profile.
     :attr List[EnityHistoryRecord] history: (optional) History of the trusted
@@ -6374,6 +10241,8 @@ class TrustedProfile:
         description: str = None,
         created_at: datetime = None,
         modified_at: datetime = None,
+        template_id: str = None,
+        assignment_id: str = None,
         ims_account_id: int = None,
         ims_user_id: int = None,
         history: List['EnityHistoryRecord'] = None,
@@ -6405,6 +10274,14 @@ class TrustedProfile:
                of the creation date in ISO format.
         :param datetime modified_at: (optional) If set contains a date time string
                of the last modification date in ISO format.
+        :param str template_id: (optional) ID of the IAM template that was used to
+               create an enterprise-managed trusted profile in your account. When
+               returned, this indicates that the trusted profile is created from and
+               managed by a template in the root enterprise account.
+        :param str assignment_id: (optional) ID of the assignment that was used to
+               create an enterprise-managed trusted profile in your account. When
+               returned, this indicates that the trusted profile is created from and
+               managed by a template in the root enterprise account.
         :param int ims_account_id: (optional) IMS acount ID of the trusted profile.
         :param int ims_user_id: (optional) IMS user ID of the trusted profile.
         :param List[EnityHistoryRecord] history: (optional) History of the trusted
@@ -6421,6 +10298,8 @@ class TrustedProfile:
         self.modified_at = modified_at
         self.iam_id = iam_id
         self.account_id = account_id
+        self.template_id = template_id
+        self.assignment_id = assignment_id
         self.ims_account_id = ims_account_id
         self.ims_user_id = ims_user_id
         self.history = history
@@ -6462,6 +10341,10 @@ class TrustedProfile:
             args['account_id'] = _dict.get('account_id')
         else:
             raise ValueError('Required property \'account_id\' not present in TrustedProfile JSON')
+        if 'template_id' in _dict:
+            args['template_id'] = _dict.get('template_id')
+        if 'assignment_id' in _dict:
+            args['assignment_id'] = _dict.get('assignment_id')
         if 'ims_account_id' in _dict:
             args['ims_account_id'] = _dict.get('ims_account_id')
         if 'ims_user_id' in _dict:
@@ -6503,6 +10386,10 @@ class TrustedProfile:
             _dict['iam_id'] = self.iam_id
         if hasattr(self, 'account_id') and self.account_id is not None:
             _dict['account_id'] = self.account_id
+        if hasattr(self, 'template_id') and self.template_id is not None:
+            _dict['template_id'] = self.template_id
+        if hasattr(self, 'assignment_id') and self.assignment_id is not None:
+            _dict['assignment_id'] = self.assignment_id
         if hasattr(self, 'ims_account_id') and self.ims_account_id is not None:
             _dict['ims_account_id'] = self.ims_account_id
         if hasattr(self, 'ims_user_id') and self.ims_user_id is not None:
@@ -6537,6 +10424,467 @@ class TrustedProfile:
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other: 'TrustedProfile') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class TrustedProfileTemplateClaimRule:
+    """
+    TrustedProfileTemplateClaimRule.
+
+    :attr str name: (optional) Name of the claim rule to be created or updated.
+    :attr str type: Type of the claim rule.
+    :attr str realm_name: (optional) The realm name of the Idp this claim rule
+          applies to. This field is required only if the type is specified as
+          'Profile-SAML'.
+    :attr int expiration: (optional) Session expiration in seconds, only required if
+          type is 'Profile-SAML'.
+    :attr List[ProfileClaimRuleConditions] conditions: Conditions of this claim
+          rule.
+    """
+
+    def __init__(
+        self,
+        type: str,
+        conditions: List['ProfileClaimRuleConditions'],
+        *,
+        name: str = None,
+        realm_name: str = None,
+        expiration: int = None,
+    ) -> None:
+        """
+        Initialize a TrustedProfileTemplateClaimRule object.
+
+        :param str type: Type of the claim rule.
+        :param List[ProfileClaimRuleConditions] conditions: Conditions of this
+               claim rule.
+        :param str name: (optional) Name of the claim rule to be created or
+               updated.
+        :param str realm_name: (optional) The realm name of the Idp this claim rule
+               applies to. This field is required only if the type is specified as
+               'Profile-SAML'.
+        :param int expiration: (optional) Session expiration in seconds, only
+               required if type is 'Profile-SAML'.
+        """
+        self.name = name
+        self.type = type
+        self.realm_name = realm_name
+        self.expiration = expiration
+        self.conditions = conditions
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TrustedProfileTemplateClaimRule':
+        """Initialize a TrustedProfileTemplateClaimRule object from a json dictionary."""
+        args = {}
+        if 'name' in _dict:
+            args['name'] = _dict.get('name')
+        if 'type' in _dict:
+            args['type'] = _dict.get('type')
+        else:
+            raise ValueError('Required property \'type\' not present in TrustedProfileTemplateClaimRule JSON')
+        if 'realm_name' in _dict:
+            args['realm_name'] = _dict.get('realm_name')
+        if 'expiration' in _dict:
+            args['expiration'] = _dict.get('expiration')
+        if 'conditions' in _dict:
+            args['conditions'] = [ProfileClaimRuleConditions.from_dict(v) for v in _dict.get('conditions')]
+        else:
+            raise ValueError('Required property \'conditions\' not present in TrustedProfileTemplateClaimRule JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TrustedProfileTemplateClaimRule object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'type') and self.type is not None:
+            _dict['type'] = self.type
+        if hasattr(self, 'realm_name') and self.realm_name is not None:
+            _dict['realm_name'] = self.realm_name
+        if hasattr(self, 'expiration') and self.expiration is not None:
+            _dict['expiration'] = self.expiration
+        if hasattr(self, 'conditions') and self.conditions is not None:
+            conditions_list = []
+            for v in self.conditions:
+                if isinstance(v, dict):
+                    conditions_list.append(v)
+                else:
+                    conditions_list.append(v.to_dict())
+            _dict['conditions'] = conditions_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TrustedProfileTemplateClaimRule object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TrustedProfileTemplateClaimRule') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TrustedProfileTemplateClaimRule') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class TypeEnum(str, Enum):
+        """
+        Type of the claim rule.
+        """
+
+        PROFILE_SAML = 'Profile-SAML'
+
+
+
+class TrustedProfileTemplateList:
+    """
+    TrustedProfileTemplateList.
+
+    :attr ResponseContext context: (optional) Context with key properties for
+          problem determination.
+    :attr int offset: (optional) The offset of the current page.
+    :attr int limit: (optional) Optional size of a single page.
+    :attr str first: (optional) Link to the first page.
+    :attr str previous: (optional) Link to the previous available page. If
+          'previous' property is not part of the response no previous page is available.
+    :attr str next: (optional) Link to the next available page. If 'next' property
+          is not part of the response no next page is available.
+    :attr List[TrustedProfileTemplateResponse] profile_templates: List of Profile
+          Templates based on the query paramters and the page size. The profile_templates
+          array is always part of the response but might be empty depending on the query
+          parameter values provided.
+    """
+
+    def __init__(
+        self,
+        profile_templates: List['TrustedProfileTemplateResponse'],
+        *,
+        context: 'ResponseContext' = None,
+        offset: int = None,
+        limit: int = None,
+        first: str = None,
+        previous: str = None,
+        next: str = None,
+    ) -> None:
+        """
+        Initialize a TrustedProfileTemplateList object.
+
+        :param List[TrustedProfileTemplateResponse] profile_templates: List of
+               Profile Templates based on the query paramters and the page size. The
+               profile_templates array is always part of the response but might be empty
+               depending on the query parameter values provided.
+        :param ResponseContext context: (optional) Context with key properties for
+               problem determination.
+        :param int offset: (optional) The offset of the current page.
+        :param int limit: (optional) Optional size of a single page.
+        :param str first: (optional) Link to the first page.
+        :param str previous: (optional) Link to the previous available page. If
+               'previous' property is not part of the response no previous page is
+               available.
+        :param str next: (optional) Link to the next available page. If 'next'
+               property is not part of the response no next page is available.
+        """
+        self.context = context
+        self.offset = offset
+        self.limit = limit
+        self.first = first
+        self.previous = previous
+        self.next = next
+        self.profile_templates = profile_templates
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TrustedProfileTemplateList':
+        """Initialize a TrustedProfileTemplateList object from a json dictionary."""
+        args = {}
+        if 'context' in _dict:
+            args['context'] = ResponseContext.from_dict(_dict.get('context'))
+        if 'offset' in _dict:
+            args['offset'] = _dict.get('offset')
+        if 'limit' in _dict:
+            args['limit'] = _dict.get('limit')
+        if 'first' in _dict:
+            args['first'] = _dict.get('first')
+        if 'previous' in _dict:
+            args['previous'] = _dict.get('previous')
+        if 'next' in _dict:
+            args['next'] = _dict.get('next')
+        if 'profile_templates' in _dict:
+            args['profile_templates'] = [TrustedProfileTemplateResponse.from_dict(v) for v in _dict.get('profile_templates')]
+        else:
+            raise ValueError('Required property \'profile_templates\' not present in TrustedProfileTemplateList JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TrustedProfileTemplateList object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'context') and self.context is not None:
+            if isinstance(self.context, dict):
+                _dict['context'] = self.context
+            else:
+                _dict['context'] = self.context.to_dict()
+        if hasattr(self, 'offset') and self.offset is not None:
+            _dict['offset'] = self.offset
+        if hasattr(self, 'limit') and self.limit is not None:
+            _dict['limit'] = self.limit
+        if hasattr(self, 'first') and self.first is not None:
+            _dict['first'] = self.first
+        if hasattr(self, 'previous') and self.previous is not None:
+            _dict['previous'] = self.previous
+        if hasattr(self, 'next') and self.next is not None:
+            _dict['next'] = self.next
+        if hasattr(self, 'profile_templates') and self.profile_templates is not None:
+            profile_templates_list = []
+            for v in self.profile_templates:
+                if isinstance(v, dict):
+                    profile_templates_list.append(v)
+                else:
+                    profile_templates_list.append(v.to_dict())
+            _dict['profile_templates'] = profile_templates_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TrustedProfileTemplateList object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TrustedProfileTemplateList') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TrustedProfileTemplateList') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class TrustedProfileTemplateResponse:
+    """
+    Response body format for Trusted Profile Template REST requests.
+
+    :attr str id: ID of the the template.
+    :attr int version: Version of the the template.
+    :attr str account_id: ID of the account where the template resides.
+    :attr str name: The name of the trusted profile template. This is visible only
+          in the enterprise account.
+    :attr str description: (optional) The description of the trusted profile
+          template. Describe the template for enterprise account users.
+    :attr bool committed: (optional) Committed flag determines if the template is
+          ready for assignment.
+    :attr TemplateProfileComponentResponse profile: (optional) Input body parameters
+          for the TemplateProfileComponent.
+    :attr List[PolicyTemplateReference] policy_template_references: (optional)
+          Existing policy templates that you can reference to assign access in the trusted
+          profile component.
+    :attr List[EnityHistoryRecord] history: (optional) History of the trusted
+          profile template.
+    :attr str entity_tag: (optional) Entity tag for this templateId-version
+          combination.
+    :attr str crn: (optional) Cloud resource name.
+    :attr str created_at: (optional) Timestamp of when the template was created.
+    :attr str created_by_id: (optional) IAMid of the creator.
+    :attr str last_modified_at: (optional) Timestamp of when the template was last
+          modified.
+    :attr str last_modified_by_id: (optional) IAMid of the identity that made the
+          latest modification.
+    """
+
+    def __init__(
+        self,
+        id: str,
+        version: int,
+        account_id: str,
+        name: str,
+        *,
+        description: str = None,
+        committed: bool = None,
+        profile: 'TemplateProfileComponentResponse' = None,
+        policy_template_references: List['PolicyTemplateReference'] = None,
+        history: List['EnityHistoryRecord'] = None,
+        entity_tag: str = None,
+        crn: str = None,
+        created_at: str = None,
+        created_by_id: str = None,
+        last_modified_at: str = None,
+        last_modified_by_id: str = None,
+    ) -> None:
+        """
+        Initialize a TrustedProfileTemplateResponse object.
+
+        :param str id: ID of the the template.
+        :param int version: Version of the the template.
+        :param str account_id: ID of the account where the template resides.
+        :param str name: The name of the trusted profile template. This is visible
+               only in the enterprise account.
+        :param str description: (optional) The description of the trusted profile
+               template. Describe the template for enterprise account users.
+        :param bool committed: (optional) Committed flag determines if the template
+               is ready for assignment.
+        :param TemplateProfileComponentResponse profile: (optional) Input body
+               parameters for the TemplateProfileComponent.
+        :param List[PolicyTemplateReference] policy_template_references: (optional)
+               Existing policy templates that you can reference to assign access in the
+               trusted profile component.
+        :param List[EnityHistoryRecord] history: (optional) History of the trusted
+               profile template.
+        :param str entity_tag: (optional) Entity tag for this templateId-version
+               combination.
+        :param str crn: (optional) Cloud resource name.
+        :param str created_at: (optional) Timestamp of when the template was
+               created.
+        :param str created_by_id: (optional) IAMid of the creator.
+        :param str last_modified_at: (optional) Timestamp of when the template was
+               last modified.
+        :param str last_modified_by_id: (optional) IAMid of the identity that made
+               the latest modification.
+        """
+        self.id = id
+        self.version = version
+        self.account_id = account_id
+        self.name = name
+        self.description = description
+        self.committed = committed
+        self.profile = profile
+        self.policy_template_references = policy_template_references
+        self.history = history
+        self.entity_tag = entity_tag
+        self.crn = crn
+        self.created_at = created_at
+        self.created_by_id = created_by_id
+        self.last_modified_at = last_modified_at
+        self.last_modified_by_id = last_modified_by_id
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TrustedProfileTemplateResponse':
+        """Initialize a TrustedProfileTemplateResponse object from a json dictionary."""
+        args = {}
+        if 'id' in _dict:
+            args['id'] = _dict.get('id')
+        else:
+            raise ValueError('Required property \'id\' not present in TrustedProfileTemplateResponse JSON')
+        if 'version' in _dict:
+            args['version'] = _dict.get('version')
+        else:
+            raise ValueError('Required property \'version\' not present in TrustedProfileTemplateResponse JSON')
+        if 'account_id' in _dict:
+            args['account_id'] = _dict.get('account_id')
+        else:
+            raise ValueError('Required property \'account_id\' not present in TrustedProfileTemplateResponse JSON')
+        if 'name' in _dict:
+            args['name'] = _dict.get('name')
+        else:
+            raise ValueError('Required property \'name\' not present in TrustedProfileTemplateResponse JSON')
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
+        if 'committed' in _dict:
+            args['committed'] = _dict.get('committed')
+        if 'profile' in _dict:
+            args['profile'] = TemplateProfileComponentResponse.from_dict(_dict.get('profile'))
+        if 'policy_template_references' in _dict:
+            args['policy_template_references'] = [PolicyTemplateReference.from_dict(v) for v in _dict.get('policy_template_references')]
+        if 'history' in _dict:
+            args['history'] = [EnityHistoryRecord.from_dict(v) for v in _dict.get('history')]
+        if 'entity_tag' in _dict:
+            args['entity_tag'] = _dict.get('entity_tag')
+        if 'crn' in _dict:
+            args['crn'] = _dict.get('crn')
+        if 'created_at' in _dict:
+            args['created_at'] = _dict.get('created_at')
+        if 'created_by_id' in _dict:
+            args['created_by_id'] = _dict.get('created_by_id')
+        if 'last_modified_at' in _dict:
+            args['last_modified_at'] = _dict.get('last_modified_at')
+        if 'last_modified_by_id' in _dict:
+            args['last_modified_by_id'] = _dict.get('last_modified_by_id')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TrustedProfileTemplateResponse object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'version') and self.version is not None:
+            _dict['version'] = self.version
+        if hasattr(self, 'account_id') and self.account_id is not None:
+            _dict['account_id'] = self.account_id
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'committed') and self.committed is not None:
+            _dict['committed'] = self.committed
+        if hasattr(self, 'profile') and self.profile is not None:
+            if isinstance(self.profile, dict):
+                _dict['profile'] = self.profile
+            else:
+                _dict['profile'] = self.profile.to_dict()
+        if hasattr(self, 'policy_template_references') and self.policy_template_references is not None:
+            policy_template_references_list = []
+            for v in self.policy_template_references:
+                if isinstance(v, dict):
+                    policy_template_references_list.append(v)
+                else:
+                    policy_template_references_list.append(v.to_dict())
+            _dict['policy_template_references'] = policy_template_references_list
+        if hasattr(self, 'history') and self.history is not None:
+            history_list = []
+            for v in self.history:
+                if isinstance(v, dict):
+                    history_list.append(v)
+                else:
+                    history_list.append(v.to_dict())
+            _dict['history'] = history_list
+        if hasattr(self, 'entity_tag') and self.entity_tag is not None:
+            _dict['entity_tag'] = self.entity_tag
+        if hasattr(self, 'crn') and self.crn is not None:
+            _dict['crn'] = self.crn
+        if hasattr(self, 'created_at') and self.created_at is not None:
+            _dict['created_at'] = self.created_at
+        if hasattr(self, 'created_by_id') and self.created_by_id is not None:
+            _dict['created_by_id'] = self.created_by_id
+        if hasattr(self, 'last_modified_at') and self.last_modified_at is not None:
+            _dict['last_modified_at'] = self.last_modified_at
+        if hasattr(self, 'last_modified_by_id') and self.last_modified_by_id is not None:
+            _dict['last_modified_by_id'] = self.last_modified_by_id
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TrustedProfileTemplateResponse object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TrustedProfileTemplateResponse') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TrustedProfileTemplateResponse') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 

--- a/ibm_platform_services/iam_identity_v1.py
+++ b/ibm_platform_services/iam_identity_v1.py
@@ -56,9 +56,7 @@ class IamIdentityV1(BaseService):
                parameters and external configuration.
         """
         authenticator = get_authenticator_from_environment(service_name)
-        service = cls(
-            authenticator
-            )
+        service = cls(authenticator)
         service.configure_service(service_name)
         return service
 
@@ -4512,6 +4510,7 @@ class ListApiKeysEnums:
 
         ENTITY = 'entity'
         ACCOUNT = 'account'
+
     class Type(str, Enum):
         """
         Optional parameter to filter the type of the queried API Keys. Can be 'user' or
@@ -4520,6 +4519,7 @@ class ListApiKeysEnums:
 
         USER = 'user'
         SERVICEID = 'serviceid'
+
     class Order(str, Enum):
         """
         Optional sort order, valid values are asc and desc. Default: asc.
@@ -4614,6 +4614,7 @@ class ListAccountSettingsAssignmentsEnums:
 
         ACCOUNT = 'Account'
         ACCOUNTGROUP = 'AccountGroup'
+
     class Sort(str, Enum):
         """
         If specified, the items are sorted by the value of this property.
@@ -4622,6 +4623,7 @@ class ListAccountSettingsAssignmentsEnums:
         TEMPLATE_ID = 'template_id'
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
+
     class Order(str, Enum):
         """
         Sort order.
@@ -4645,6 +4647,7 @@ class ListAccountSettingsTemplatesEnums:
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
         NAME = 'name'
+
     class Order(str, Enum):
         """
         Optional sort order.
@@ -4668,6 +4671,7 @@ class ListVersionsOfAccountSettingsTemplateEnums:
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
         NAME = 'name'
+
     class Order(str, Enum):
         """
         Optional sort order.
@@ -4689,6 +4693,7 @@ class ListTrustedProfileAssignmentsEnums:
 
         ACCOUNT = 'Account'
         ACCOUNTGROUP = 'AccountGroup'
+
     class Sort(str, Enum):
         """
         If specified, the items are sorted by the value of this property.
@@ -4697,6 +4702,7 @@ class ListTrustedProfileAssignmentsEnums:
         TEMPLATE_ID = 'template_id'
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
+
     class Order(str, Enum):
         """
         Sort order.
@@ -4720,6 +4726,7 @@ class ListProfileTemplatesEnums:
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
         NAME = 'name'
+
     class Order(str, Enum):
         """
         Optional sort order.
@@ -4743,6 +4750,7 @@ class ListVersionsOfProfileTemplateEnums:
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
         NAME = 'name'
+
     class Order(str, Enum):
         """
         Optional sort order.
@@ -5033,9 +5041,15 @@ class AccountSettingsComponent:
             _dict['session_invalidation_in_seconds'] = self.session_invalidation_in_seconds
         if hasattr(self, 'max_sessions_per_identity') and self.max_sessions_per_identity is not None:
             _dict['max_sessions_per_identity'] = self.max_sessions_per_identity
-        if hasattr(self, 'system_access_token_expiration_in_seconds') and self.system_access_token_expiration_in_seconds is not None:
+        if (
+            hasattr(self, 'system_access_token_expiration_in_seconds')
+            and self.system_access_token_expiration_in_seconds is not None
+        ):
             _dict['system_access_token_expiration_in_seconds'] = self.system_access_token_expiration_in_seconds
-        if hasattr(self, 'system_refresh_token_expiration_in_seconds') and self.system_refresh_token_expiration_in_seconds is not None:
+        if (
+            hasattr(self, 'system_refresh_token_expiration_in_seconds')
+            and self.system_refresh_token_expiration_in_seconds is not None
+        ):
             _dict['system_refresh_token_expiration_in_seconds'] = self.system_refresh_token_expiration_in_seconds
         return _dict
 
@@ -5070,7 +5084,6 @@ class AccountSettingsComponent:
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
 
-
     class RestrictCreatePlatformApikeyEnum(str, Enum):
         """
         Defines whether or not creating platform API keys is access controlled. Valid
@@ -5083,7 +5096,6 @@ class AccountSettingsComponent:
         RESTRICTED = 'RESTRICTED'
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
-
 
     class MfaEnum(str, Enum):
         """
@@ -5102,7 +5114,6 @@ class AccountSettingsComponent:
         LEVEL1 = 'LEVEL1'
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
-
 
 
 class AccountSettingsResponse:
@@ -5260,11 +5271,15 @@ class AccountSettingsResponse:
         if 'restrict_create_service_id' in _dict:
             args['restrict_create_service_id'] = _dict.get('restrict_create_service_id')
         else:
-            raise ValueError('Required property \'restrict_create_service_id\' not present in AccountSettingsResponse JSON')
+            raise ValueError(
+                'Required property \'restrict_create_service_id\' not present in AccountSettingsResponse JSON'
+            )
         if 'restrict_create_platform_apikey' in _dict:
             args['restrict_create_platform_apikey'] = _dict.get('restrict_create_platform_apikey')
         else:
-            raise ValueError('Required property \'restrict_create_platform_apikey\' not present in AccountSettingsResponse JSON')
+            raise ValueError(
+                'Required property \'restrict_create_platform_apikey\' not present in AccountSettingsResponse JSON'
+            )
         if 'allowed_ip_addresses' in _dict:
             args['allowed_ip_addresses'] = _dict.get('allowed_ip_addresses')
         else:
@@ -5286,23 +5301,33 @@ class AccountSettingsResponse:
         if 'session_expiration_in_seconds' in _dict:
             args['session_expiration_in_seconds'] = _dict.get('session_expiration_in_seconds')
         else:
-            raise ValueError('Required property \'session_expiration_in_seconds\' not present in AccountSettingsResponse JSON')
+            raise ValueError(
+                'Required property \'session_expiration_in_seconds\' not present in AccountSettingsResponse JSON'
+            )
         if 'session_invalidation_in_seconds' in _dict:
             args['session_invalidation_in_seconds'] = _dict.get('session_invalidation_in_seconds')
         else:
-            raise ValueError('Required property \'session_invalidation_in_seconds\' not present in AccountSettingsResponse JSON')
+            raise ValueError(
+                'Required property \'session_invalidation_in_seconds\' not present in AccountSettingsResponse JSON'
+            )
         if 'max_sessions_per_identity' in _dict:
             args['max_sessions_per_identity'] = _dict.get('max_sessions_per_identity')
         else:
-            raise ValueError('Required property \'max_sessions_per_identity\' not present in AccountSettingsResponse JSON')
+            raise ValueError(
+                'Required property \'max_sessions_per_identity\' not present in AccountSettingsResponse JSON'
+            )
         if 'system_access_token_expiration_in_seconds' in _dict:
             args['system_access_token_expiration_in_seconds'] = _dict.get('system_access_token_expiration_in_seconds')
         else:
-            raise ValueError('Required property \'system_access_token_expiration_in_seconds\' not present in AccountSettingsResponse JSON')
+            raise ValueError(
+                'Required property \'system_access_token_expiration_in_seconds\' not present in AccountSettingsResponse JSON'
+            )
         if 'system_refresh_token_expiration_in_seconds' in _dict:
             args['system_refresh_token_expiration_in_seconds'] = _dict.get('system_refresh_token_expiration_in_seconds')
         else:
-            raise ValueError('Required property \'system_refresh_token_expiration_in_seconds\' not present in AccountSettingsResponse JSON')
+            raise ValueError(
+                'Required property \'system_refresh_token_expiration_in_seconds\' not present in AccountSettingsResponse JSON'
+            )
         return cls(**args)
 
     @classmethod
@@ -5352,9 +5377,15 @@ class AccountSettingsResponse:
             _dict['session_invalidation_in_seconds'] = self.session_invalidation_in_seconds
         if hasattr(self, 'max_sessions_per_identity') and self.max_sessions_per_identity is not None:
             _dict['max_sessions_per_identity'] = self.max_sessions_per_identity
-        if hasattr(self, 'system_access_token_expiration_in_seconds') and self.system_access_token_expiration_in_seconds is not None:
+        if (
+            hasattr(self, 'system_access_token_expiration_in_seconds')
+            and self.system_access_token_expiration_in_seconds is not None
+        ):
             _dict['system_access_token_expiration_in_seconds'] = self.system_access_token_expiration_in_seconds
-        if hasattr(self, 'system_refresh_token_expiration_in_seconds') and self.system_refresh_token_expiration_in_seconds is not None:
+        if (
+            hasattr(self, 'system_refresh_token_expiration_in_seconds')
+            and self.system_refresh_token_expiration_in_seconds is not None
+        ):
             _dict['system_refresh_token_expiration_in_seconds'] = self.system_refresh_token_expiration_in_seconds
         return _dict
 
@@ -5389,7 +5420,6 @@ class AccountSettingsResponse:
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
 
-
     class RestrictCreatePlatformApikeyEnum(str, Enum):
         """
         Defines whether or not creating platform API keys is access controlled. Valid
@@ -5402,7 +5432,6 @@ class AccountSettingsResponse:
         RESTRICTED = 'RESTRICTED'
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
-
 
     class MfaEnum(str, Enum):
         """
@@ -5423,7 +5452,6 @@ class AccountSettingsResponse:
         LEVEL1 = 'LEVEL1'
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
-
 
 
 class AccountSettingsTemplateList:
@@ -5500,9 +5528,13 @@ class AccountSettingsTemplateList:
         if 'next' in _dict:
             args['next'] = _dict.get('next')
         if 'account_settings_templates' in _dict:
-            args['account_settings_templates'] = [AccountSettingsTemplateResponse.from_dict(v) for v in _dict.get('account_settings_templates')]
+            args['account_settings_templates'] = [
+                AccountSettingsTemplateResponse.from_dict(v) for v in _dict.get('account_settings_templates')
+            ]
         else:
-            raise ValueError('Required property \'account_settings_templates\' not present in AccountSettingsTemplateList JSON')
+            raise ValueError(
+                'Required property \'account_settings_templates\' not present in AccountSettingsTemplateList JSON'
+            )
         return cls(**args)
 
     @classmethod
@@ -5666,7 +5698,9 @@ class AccountSettingsTemplateResponse:
         if 'account_settings' in _dict:
             args['account_settings'] = AccountSettingsComponent.from_dict(_dict.get('account_settings'))
         else:
-            raise ValueError('Required property \'account_settings\' not present in AccountSettingsTemplateResponse JSON')
+            raise ValueError(
+                'Required property \'account_settings\' not present in AccountSettingsTemplateResponse JSON'
+            )
         if 'history' in _dict:
             args['history'] = [EnityHistoryRecord.from_dict(v) for v in _dict.get('history')]
         if 'entity_tag' in _dict:
@@ -5854,7 +5888,6 @@ class AccountSettingsUserMFA:
         LEVEL1 = 'LEVEL1'
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
-
 
 
 class Activity:
@@ -7271,7 +7304,6 @@ class IdBasedMfaEnrollment:
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
 
-
     class TraitUserSpecificEnum(str, Enum):
         """
         Defines the MFA trait for the account. Valid values:
@@ -7292,7 +7324,6 @@ class IdBasedMfaEnrollment:
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
 
-
     class TraitEffectiveEnum(str, Enum):
         """
         Defines the MFA trait for the account. Valid values:
@@ -7312,7 +7343,6 @@ class IdBasedMfaEnrollment:
         LEVEL1 = 'LEVEL1'
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
-
 
 
 class MfaEnrollmentTypeStatus:
@@ -8046,7 +8076,6 @@ class ProfileIdentityRequest:
         CRN = 'crn'
 
 
-
 class ProfileIdentityResponse:
     """
     ProfileIdentityResponse.
@@ -8168,7 +8197,6 @@ class ProfileIdentityResponse:
         USER = 'user'
         SERVICEID = 'serviceid'
         CRN = 'crn'
-
 
 
 class ProfileLink:
@@ -9831,7 +9859,9 @@ class TemplateAssignmentResponseResource:
         if 'account_settings' in _dict:
             args['account_settings'] = TemplateAssignmentResponseResourceDetail.from_dict(_dict.get('account_settings'))
         if 'policy_template_refs' in _dict:
-            args['policy_template_refs'] = [TemplateAssignmentResponseResourceDetail.from_dict(v) for v in _dict.get('policy_template_refs')]
+            args['policy_template_refs'] = [
+                TemplateAssignmentResponseResourceDetail.from_dict(v) for v in _dict.get('policy_template_refs')
+            ]
         return cls(**args)
 
     @classmethod
@@ -9941,7 +9971,9 @@ class TemplateAssignmentResponseResourceDetail:
         if 'status' in _dict:
             args['status'] = _dict.get('status')
         else:
-            raise ValueError('Required property \'status\' not present in TemplateAssignmentResponseResourceDetail JSON')
+            raise ValueError(
+                'Required property \'status\' not present in TemplateAssignmentResponseResourceDetail JSON'
+            )
         return cls(**args)
 
     @classmethod
@@ -10544,7 +10576,6 @@ class TrustedProfileTemplateClaimRule:
         PROFILE_SAML = 'Profile-SAML'
 
 
-
 class TrustedProfileTemplateList:
     """
     TrustedProfileTemplateList.
@@ -10618,7 +10649,9 @@ class TrustedProfileTemplateList:
         if 'next' in _dict:
             args['next'] = _dict.get('next')
         if 'profile_templates' in _dict:
-            args['profile_templates'] = [TrustedProfileTemplateResponse.from_dict(v) for v in _dict.get('profile_templates')]
+            args['profile_templates'] = [
+                TrustedProfileTemplateResponse.from_dict(v) for v in _dict.get('profile_templates')
+            ]
         else:
             raise ValueError('Required property \'profile_templates\' not present in TrustedProfileTemplateList JSON')
         return cls(**args)
@@ -10798,7 +10831,9 @@ class TrustedProfileTemplateResponse:
         if 'profile' in _dict:
             args['profile'] = TemplateProfileComponentResponse.from_dict(_dict.get('profile'))
         if 'policy_template_references' in _dict:
-            args['policy_template_references'] = [PolicyTemplateReference.from_dict(v) for v in _dict.get('policy_template_references')]
+            args['policy_template_references'] = [
+                PolicyTemplateReference.from_dict(v) for v in _dict.get('policy_template_references')
+            ]
         if 'history' in _dict:
             args['history'] = [EnityHistoryRecord.from_dict(v) for v in _dict.get('history')]
         if 'entity_tag' in _dict:

--- a/test/integration/test_iam_identity_v1.py
+++ b/test/integration/test_iam_identity_v1.py
@@ -66,6 +66,7 @@ account_settings_template_etag = None
 account_settings_template_assignment_id = None
 account_settings_template_assignment_etag = None
 
+
 class TestIamIdentityV1:
     """
     Integration Test Class for IamIdentityV1
@@ -168,17 +169,25 @@ class TestIamIdentityV1:
             for profile_template in profile_template_list['profile_templates']:
                 if profile_template['name'] == cls.profile_template_name:
                     print('>>> deleting profile template: ', profile_template['id'])
-                    list_response = cls.iam_identity_service.list_trusted_profile_assignments(account_id=cls.enterprise_account_id,template_id=profile_template['id'])
+                    list_response = cls.iam_identity_service.list_trusted_profile_assignments(
+                        account_id=cls.enterprise_account_id, template_id=profile_template['id']
+                    )
                     assert list_response.get_status_code() == 200
                     assignments_list = list_response.get_result()
                     if len(assignments_list['assignments']) > 0:
                         for assignment in assignments_list['assignments']:
                             if not cls.isFinished(assignment['status']):
-                                cls.waitUntilTrustedProfileAssignmentFinished(cls.iam_identity_service, assignment['id'])
-                            delete_assignment_response = cls.iam_identity_service.delete_trusted_profile_assignment(assignment_id=assignment['id'])
+                                cls.waitUntilTrustedProfileAssignmentFinished(
+                                    cls.iam_identity_service, assignment['id']
+                                )
+                            delete_assignment_response = cls.iam_identity_service.delete_trusted_profile_assignment(
+                                assignment_id=assignment['id']
+                            )
                             assert delete_assignment_response.get_status_code() == 202
                             cls.waitUntilTrustedProfileAssignmentFinished(cls.iam_identity_service, assignment['id'])
-                    delete_response = cls.iam_identity_service.delete_all_versions_of_profile_template(template_id=profile_template['id'])
+                    delete_response = cls.iam_identity_service.delete_all_versions_of_profile_template(
+                        template_id=profile_template['id']
+                    )
                     assert delete_response.get_status_code() == 204
 
         # list account settings templates
@@ -189,17 +198,25 @@ class TestIamIdentityV1:
             for account_settings_template in account_settings_template_list['account_settings_templates']:
                 if account_settings_template['name'] == cls.account_settings_template_name:
                     print('>>> deleting account settings template: ', account_settings_template['id'])
-                    list_response = cls.iam_identity_service.list_account_settings_assignments(account_id=cls.enterprise_account_id,template_id=account_settings_template['id'])
+                    list_response = cls.iam_identity_service.list_account_settings_assignments(
+                        account_id=cls.enterprise_account_id, template_id=account_settings_template['id']
+                    )
                     assert list_response.get_status_code() == 200
                     assignments_list = list_response.get_result()
                     if len(assignments_list['assignments']) > 0:
                         for assignment in assignments_list['assignments']:
                             if not cls.isFinished(assignment['status']):
-                                cls.waitUntilAccountSettingsAssignmentFinished(cls.iam_identity_service, assignment['id'])
-                            delete_assignment_response = cls.iam_identity_service.delete_account_settings_assignment(assignment_id=assignment['id'])
+                                cls.waitUntilAccountSettingsAssignmentFinished(
+                                    cls.iam_identity_service, assignment['id']
+                                )
+                            delete_assignment_response = cls.iam_identity_service.delete_account_settings_assignment(
+                                assignment_id=assignment['id']
+                            )
                             assert delete_assignment_response.get_status_code() == 202
                             cls.waitUntilAccountSettingsAssignmentFinished(cls.iam_identity_service, assignment['id'])
-                    delete_response = cls.iam_identity_service.delete_all_versions_of_account_settings_template(template_id=account_settings_template['id'])
+                    delete_response = cls.iam_identity_service.delete_all_versions_of_account_settings_template(
+                        template_id=account_settings_template['id']
+                    )
                     assert delete_response.get_status_code() == 204
 
         print('Finished cleaning up resources!')
@@ -1304,7 +1321,7 @@ class TestIamIdentityV1:
             name=self.profile_template_name,
             description='Python SDK test Profile Template',
             account_id=self.enterprise_account_id,
-            profile=profile
+            profile=profile,
         )
 
         assert create_response.get_status_code() == 201
@@ -1328,8 +1345,7 @@ class TestIamIdentityV1:
         assert profile_template_version is not None
 
         get_response = self.iam_identity_service.get_profile_template_version(
-            template_id=profile_template_id,
-            version=str(profile_template_version)
+            template_id=profile_template_id, version=str(profile_template_version)
         )
 
         assert get_response.get_status_code() == 200
@@ -1347,9 +1363,7 @@ class TestIamIdentityV1:
     @needscredentials
     def test_list_profile_templates(self):
 
-        list_response = self.iam_identity_service.list_profile_templates(
-            account_id=self.enterprise_account_id
-        )
+        list_response = self.iam_identity_service.list_profile_templates(account_id=self.enterprise_account_id)
 
         assert list_response.get_status_code() == 200
         profile_template_list = list_response.get_result()
@@ -1372,7 +1386,7 @@ class TestIamIdentityV1:
             version=str(profile_template_version),
             if_match=profile_template_etag,
             name=self.profile_template_name,
-            description='Python SDK test Profile Template - updated'
+            description='Python SDK test Profile Template - updated',
         )
 
         assert update_response.get_status_code() == 200
@@ -1392,8 +1406,7 @@ class TestIamIdentityV1:
         assert profile_template_version is not None
 
         commit_response = self.iam_identity_service.commit_profile_template(
-            template_id=profile_template_id,
-            version=str(profile_template_version)
+            template_id=profile_template_id, version=str(profile_template_version)
         )
         assert commit_response.get_status_code() == 204
 
@@ -1401,7 +1414,7 @@ class TestIamIdentityV1:
             template_id=profile_template_id,
             template_version=profile_template_version,
             target_type='Account',
-            target=self.enterprise_subaccount_id
+            target=self.enterprise_subaccount_id,
         )
         assert assign_response.get_status_code() == 202
         assignment = assign_response.get_result()
@@ -1418,8 +1431,7 @@ class TestIamIdentityV1:
         assert profile_template_id is not None
 
         list_response = self.iam_identity_service.list_trusted_profile_assignments(
-            account_id=self.enterprise_account_id,
-            template_id=profile_template_id
+            account_id=self.enterprise_account_id, template_id=profile_template_id
         )
         assert list_response.get_status_code() == 200
         assignment_list = list_response.get_result()
@@ -1460,7 +1472,7 @@ class TestIamIdentityV1:
             name=self.profile_template_name,
             description='Python SDK test Profile Template - new version',
             account_id=self.enterprise_account_id,
-            profile=profile
+            profile=profile,
         )
 
         assert create_response.get_status_code() == 201
@@ -1477,9 +1489,7 @@ class TestIamIdentityV1:
         global profile_template_id
         assert profile_template_id is not None
 
-        get_response = self.iam_identity_service.get_latest_profile_template_version(
-            template_id=profile_template_id
-        )
+        get_response = self.iam_identity_service.get_latest_profile_template_version(template_id=profile_template_id)
 
         assert get_response.get_status_code() == 200
         profile_template = get_response.get_result()
@@ -1491,9 +1501,7 @@ class TestIamIdentityV1:
         global profile_template_id
         assert profile_template_id is not None
 
-        list_response = self.iam_identity_service.list_versions_of_profile_template(
-            template_id=profile_template_id
-        )
+        list_response = self.iam_identity_service.list_versions_of_profile_template(template_id=profile_template_id)
 
         assert list_response.get_status_code() == 200
         profile_template_list = list_response.get_result()
@@ -1513,8 +1521,7 @@ class TestIamIdentityV1:
         assert profile_template_assignment_etag is not None
 
         commit_response = self.iam_identity_service.commit_profile_template(
-            template_id=profile_template_id,
-            version=str(profile_template_version)
+            template_id=profile_template_id, version=str(profile_template_version)
         )
         assert commit_response.get_status_code() == 204
 
@@ -1523,7 +1530,7 @@ class TestIamIdentityV1:
         assign_response = self.iam_identity_service.update_trusted_profile_assignment(
             assignment_id=profile_template_assignment_id,
             template_version=profile_template_version,
-            if_match=profile_template_assignment_etag
+            if_match=profile_template_assignment_etag,
         )
         assert assign_response.get_status_code() == 202
         assignment = assign_response.get_result()
@@ -1551,8 +1558,7 @@ class TestIamIdentityV1:
         assert profile_template_assignment_id is not None
 
         delete_response = self.iam_identity_service.delete_profile_template_version(
-            template_id=profile_template_id,
-            version='1'
+            template_id=profile_template_id, version='1'
         )
         assert delete_response.get_status_code() == 204
 
@@ -1578,7 +1584,7 @@ class TestIamIdentityV1:
             name=self.account_settings_template_name,
             description='Python SDK test Account Settings Template',
             account_id=self.enterprise_account_id,
-            account_settings=account_settings
+            account_settings=account_settings,
         )
 
         assert create_response.get_status_code() == 201
@@ -1602,8 +1608,7 @@ class TestIamIdentityV1:
         assert account_settings_template_version is not None
 
         get_response = self.iam_identity_service.get_account_settings_template_version(
-            template_id=account_settings_template_id,
-            version=str(account_settings_template_version)
+            template_id=account_settings_template_id, version=str(account_settings_template_version)
         )
 
         assert get_response.get_status_code() == 200
@@ -1621,9 +1626,7 @@ class TestIamIdentityV1:
     @needscredentials
     def test_list_account_settings_templates(self):
 
-        list_response = self.iam_identity_service.list_account_settings_templates(
-            account_id=self.enterprise_account_id
-        )
+        list_response = self.iam_identity_service.list_account_settings_templates(account_id=self.enterprise_account_id)
 
         assert list_response.get_status_code() == 200
         account_settings_template_list = list_response.get_result()
@@ -1651,7 +1654,7 @@ class TestIamIdentityV1:
             if_match=account_settings_template_etag,
             name=self.account_settings_template_name,
             description='Python SDK test Account Settings Template - updated',
-            account_settings=account_settings
+            account_settings=account_settings,
         )
 
         assert update_response.get_status_code() == 200
@@ -1671,8 +1674,7 @@ class TestIamIdentityV1:
         assert account_settings_template_version is not None
 
         commit_response = self.iam_identity_service.commit_account_settings_template(
-            template_id=account_settings_template_id,
-            version=str(account_settings_template_version)
+            template_id=account_settings_template_id, version=str(account_settings_template_version)
         )
         assert commit_response.get_status_code() == 204
 
@@ -1680,7 +1682,7 @@ class TestIamIdentityV1:
             template_id=account_settings_template_id,
             template_version=account_settings_template_version,
             target_type='Account',
-            target=self.enterprise_subaccount_id
+            target=self.enterprise_subaccount_id,
         )
         assert assign_response.get_status_code() == 202
         assignment = assign_response.get_result()
@@ -1697,8 +1699,7 @@ class TestIamIdentityV1:
         assert account_settings_template_id is not None
 
         list_response = self.iam_identity_service.list_account_settings_assignments(
-            account_id=self.enterprise_account_id,
-            template_id=account_settings_template_id
+            account_id=self.enterprise_account_id, template_id=account_settings_template_id
         )
         assert list_response.get_status_code() == 200
         assignment_list = list_response.get_result()
@@ -1721,13 +1722,15 @@ class TestIamIdentityV1:
             name=self.account_settings_template_name,
             description='Python SDK test Account Settings Template - new version',
             account_id=self.enterprise_account_id,
-            account_settings=account_settings
+            account_settings=account_settings,
         )
 
         assert create_response.get_status_code() == 201
         account_settings_template = create_response.get_result()
         assert account_settings_template is not None
-        print('\ncreate_account_settings_template_version() response: ', json.dumps(account_settings_template, indent=2))
+        print(
+            '\ncreate_account_settings_template_version() response: ', json.dumps(account_settings_template, indent=2)
+        )
 
         global account_settings_template_version
         assert account_settings_template['version'] is not None
@@ -1745,7 +1748,9 @@ class TestIamIdentityV1:
         assert get_response.get_status_code() == 200
         account_settings_template = get_response.get_result()
         assert account_settings_template is not None
-        print('\nget_latest_account_settings_template_version response: ', json.dumps(account_settings_template, indent=2))
+        print(
+            '\nget_latest_account_settings_template_version response: ', json.dumps(account_settings_template, indent=2)
+        )
 
     @needscredentials
     def test_list_account_settings_template_versions(self):
@@ -1759,7 +1764,9 @@ class TestIamIdentityV1:
         assert list_response.get_status_code() == 200
         account_settings_template_list = list_response.get_result()
         assert account_settings_template_list is not None
-        print('\nlist_account_settings_template_versions response: ', json.dumps(account_settings_template_list, indent=2))
+        print(
+            '\nlist_account_settings_template_versions response: ', json.dumps(account_settings_template_list, indent=2)
+        )
 
     @needscredentials
     def test_update_account_settings_template_assignment(self):
@@ -1774,17 +1781,18 @@ class TestIamIdentityV1:
         assert account_settings_template_assignment_etag is not None
 
         commit_response = self.iam_identity_service.commit_account_settings_template(
-            template_id=account_settings_template_id,
-            version=str(account_settings_template_version)
+            template_id=account_settings_template_id, version=str(account_settings_template_version)
         )
         assert commit_response.get_status_code() == 204
 
-        self.waitUntilAccountSettingsAssignmentFinished(self.iam_identity_service, account_settings_template_assignment_id)
+        self.waitUntilAccountSettingsAssignmentFinished(
+            self.iam_identity_service, account_settings_template_assignment_id
+        )
 
         assign_response = self.iam_identity_service.update_account_settings_assignment(
             assignment_id=account_settings_template_assignment_id,
             template_version=account_settings_template_version,
-            if_match=account_settings_template_assignment_etag
+            if_match=account_settings_template_assignment_etag,
         )
         assert assign_response.get_status_code() == 202
         assignment = assign_response.get_result()
@@ -1797,7 +1805,9 @@ class TestIamIdentityV1:
         global account_settings_template_assignment_id
         assert account_settings_template_assignment_id is not None
 
-        self.waitUntilAccountSettingsAssignmentFinished(self.iam_identity_service, account_settings_template_assignment_id)
+        self.waitUntilAccountSettingsAssignmentFinished(
+            self.iam_identity_service, account_settings_template_assignment_id
+        )
 
         delete_response = self.iam_identity_service.delete_account_settings_assignment(
             assignment_id=account_settings_template_assignment_id
@@ -1812,8 +1822,7 @@ class TestIamIdentityV1:
         assert account_settings_template_assignment_id is not None
 
         delete_response = self.iam_identity_service.delete_account_settings_template_version(
-            template_id=account_settings_template_id,
-            version='1'
+            template_id=account_settings_template_id, version='1'
         )
         assert delete_response.get_status_code() == 204
 
@@ -1822,7 +1831,9 @@ class TestIamIdentityV1:
         global account_settings_template_id
         assert account_settings_template_id is not None
 
-        self.waitUntilAccountSettingsAssignmentFinished(self.iam_identity_service, account_settings_template_assignment_id)
+        self.waitUntilAccountSettingsAssignmentFinished(
+            self.iam_identity_service, account_settings_template_assignment_id
+        )
 
         delete_response = self.iam_identity_service.delete_all_versions_of_account_settings_template(
             template_id=account_settings_template_id

--- a/test/unit/test_iam_identity_v1.py
+++ b/test/unit/test_iam_identity_v1.py
@@ -31,9 +31,11 @@ import urllib
 from ibm_platform_services.iam_identity_v1 import *
 
 
-_service = IamIdentityV1(authenticator=NoAuthAuthenticator())
+_service = IamIdentityV1(
+    authenticator=NoAuthAuthenticator()
+)
 
-_base_url = 'https://iam.test.cloud.ibm.com'
+_base_url = 'https://iam.cloud.ibm.com'
 _service.set_service_url(_base_url)
 
 
@@ -1711,7 +1713,7 @@ class TestCreateProfile:
         """
         # Set up mock
         url = preprocess_url('/v1/profiles')
-        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}'
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "template_id": "template_id", "assignment_id": "assignment_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}'
         responses.add(
             responses.POST,
             url,
@@ -1758,7 +1760,7 @@ class TestCreateProfile:
         """
         # Set up mock
         url = preprocess_url('/v1/profiles')
-        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}'
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "template_id": "template_id", "assignment_id": "assignment_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}'
         responses.add(
             responses.POST,
             url,
@@ -1804,7 +1806,7 @@ class TestListProfiles:
         """
         # Set up mock
         url = preprocess_url('/v1/profiles')
-        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 5, "first": "first", "previous": "previous", "next": "next", "profiles": [{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}]}'
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 5, "first": "first", "previous": "previous", "next": "next", "profiles": [{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "template_id": "template_id", "assignment_id": "assignment_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}]}'
         responses.add(
             responses.GET,
             url,
@@ -1864,7 +1866,7 @@ class TestListProfiles:
         """
         # Set up mock
         url = preprocess_url('/v1/profiles')
-        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 5, "first": "first", "previous": "previous", "next": "next", "profiles": [{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}]}'
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 5, "first": "first", "previous": "previous", "next": "next", "profiles": [{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "template_id": "template_id", "assignment_id": "assignment_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}]}'
         responses.add(
             responses.GET,
             url,
@@ -1906,7 +1908,7 @@ class TestListProfiles:
         """
         # Set up mock
         url = preprocess_url('/v1/profiles')
-        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 5, "first": "first", "previous": "previous", "next": "next", "profiles": [{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}]}'
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 5, "first": "first", "previous": "previous", "next": "next", "profiles": [{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "template_id": "template_id", "assignment_id": "assignment_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}]}'
         responses.add(
             responses.GET,
             url,
@@ -1949,7 +1951,7 @@ class TestGetProfile:
         """
         # Set up mock
         url = preprocess_url('/v1/profiles/testString')
-        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}'
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "template_id": "template_id", "assignment_id": "assignment_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}'
         responses.add(
             responses.GET,
             url,
@@ -1993,7 +1995,7 @@ class TestGetProfile:
         """
         # Set up mock
         url = preprocess_url('/v1/profiles/testString')
-        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}'
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "template_id": "template_id", "assignment_id": "assignment_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}'
         responses.add(
             responses.GET,
             url,
@@ -2031,7 +2033,7 @@ class TestGetProfile:
         """
         # Set up mock
         url = preprocess_url('/v1/profiles/testString')
-        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}'
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "template_id": "template_id", "assignment_id": "assignment_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}'
         responses.add(
             responses.GET,
             url,
@@ -2074,7 +2076,7 @@ class TestUpdateProfile:
         """
         # Set up mock
         url = preprocess_url('/v1/profiles/testString')
-        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}'
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "template_id": "template_id", "assignment_id": "assignment_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}'
         responses.add(
             responses.PUT,
             url,
@@ -2122,7 +2124,7 @@ class TestUpdateProfile:
         """
         # Set up mock
         url = preprocess_url('/v1/profiles/testString')
-        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}'
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "entity_tag": "entity_tag", "crn": "crn", "name": "name", "description": "description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "iam_id", "account_id": "account_id", "template_id": "template_id", "assignment_id": "assignment_id", "ims_account_id": 14, "ims_user_id": 11, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "activity": {"last_authn": "last_authn", "authn_count": 11}}'
         responses.add(
             responses.PUT,
             url,
@@ -3247,18 +3249,17 @@ class TestSetProfileIdentities:
             status=200,
         )
 
-        # Construct a dict representation of a ProfileIdentity model
-        profile_identity_model = {}
-        profile_identity_model['iam_id'] = 'testString'
-        profile_identity_model['identifier'] = 'testString'
-        profile_identity_model['type'] = 'user'
-        profile_identity_model['accounts'] = ['testString']
-        profile_identity_model['description'] = 'testString'
+        # Construct a dict representation of a ProfileIdentityRequest model
+        profile_identity_request_model = {}
+        profile_identity_request_model['identifier'] = 'testString'
+        profile_identity_request_model['type'] = 'user'
+        profile_identity_request_model['accounts'] = ['testString']
+        profile_identity_request_model['description'] = 'testString'
 
         # Set up parameter values
         profile_id = 'testString'
         if_match = 'testString'
-        identities = [profile_identity_model]
+        identities = [profile_identity_request_model]
 
         # Invoke method
         response = _service.set_profile_identities(
@@ -3273,7 +3274,7 @@ class TestSetProfileIdentities:
         assert response.status_code == 200
         # Validate body params
         req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
-        assert req_body['identities'] == [profile_identity_model]
+        assert req_body['identities'] == [profile_identity_request_model]
 
     def test_set_profile_identities_all_params_with_retries(self):
         # Enable retries and run test_set_profile_identities_all_params.
@@ -3300,18 +3301,17 @@ class TestSetProfileIdentities:
             status=200,
         )
 
-        # Construct a dict representation of a ProfileIdentity model
-        profile_identity_model = {}
-        profile_identity_model['iam_id'] = 'testString'
-        profile_identity_model['identifier'] = 'testString'
-        profile_identity_model['type'] = 'user'
-        profile_identity_model['accounts'] = ['testString']
-        profile_identity_model['description'] = 'testString'
+        # Construct a dict representation of a ProfileIdentityRequest model
+        profile_identity_request_model = {}
+        profile_identity_request_model['identifier'] = 'testString'
+        profile_identity_request_model['type'] = 'user'
+        profile_identity_request_model['accounts'] = ['testString']
+        profile_identity_request_model['description'] = 'testString'
 
         # Set up parameter values
         profile_id = 'testString'
         if_match = 'testString'
-        identities = [profile_identity_model]
+        identities = [profile_identity_request_model]
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
@@ -3359,7 +3359,6 @@ class TestSetProfileIdentity:
         identity_type = 'user'
         identifier = 'testString'
         type = 'user'
-        iam_id = 'testString'
         accounts = ['testString']
         description = 'testString'
 
@@ -3369,7 +3368,6 @@ class TestSetProfileIdentity:
             identity_type,
             identifier,
             type,
-            iam_id=iam_id,
             accounts=accounts,
             description=description,
             headers={},
@@ -3382,7 +3380,6 @@ class TestSetProfileIdentity:
         req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
         assert req_body['identifier'] == 'testString'
         assert req_body['type'] == 'user'
-        assert req_body['iam_id'] == 'testString'
         assert req_body['accounts'] == ['testString']
         assert req_body['description'] == 'testString'
 
@@ -3416,7 +3413,6 @@ class TestSetProfileIdentity:
         identity_type = 'user'
         identifier = 'testString'
         type = 'user'
-        iam_id = 'testString'
         accounts = ['testString']
         description = 'testString'
 
@@ -4259,6 +4255,1661 @@ class TestGetMfaReport:
 ##############################################################################
 
 ##############################################################################
+# Start of Service: AccountSettingsAssignments
+##############################################################################
+# region
+
+
+class TestNewInstance:
+    """
+    Test Class for new_instance
+    """
+
+    def test_new_instance(self):
+        """
+        new_instance()
+        """
+        os.environ['TEST_SERVICE_AUTH_TYPE'] = 'noAuth'
+
+        service = IamIdentityV1.new_instance(
+            service_name='TEST_SERVICE',
+        )
+
+        assert service is not None
+        assert isinstance(service, IamIdentityV1)
+
+    def test_new_instance_without_authenticator(self):
+        """
+        new_instance_without_authenticator()
+        """
+        with pytest.raises(ValueError, match='authenticator must be provided'):
+            service = IamIdentityV1.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
+
+
+class TestListAccountSettingsAssignments:
+    """
+    Test Class for list_account_settings_assignments
+    """
+
+    @responses.activate
+    def test_list_account_settings_assignments_all_params(self):
+        """
+        list_account_settings_assignments()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_assignments/')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 5, "first": "first", "previous": "previous", "next": "next", "assignments": [{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        account_id = 'testString'
+        template_id = 'testString'
+        template_version = 'testString'
+        target = 'testString'
+        target_type = 'Account'
+        limit = 20
+        pagetoken = 'testString'
+        sort = 'created_at'
+        order = 'asc'
+        include_history = False
+
+        # Invoke method
+        response = _service.list_account_settings_assignments(
+            account_id=account_id,
+            template_id=template_id,
+            template_version=template_version,
+            target=target,
+            target_type=target_type,
+            limit=limit,
+            pagetoken=pagetoken,
+            sort=sort,
+            order=order,
+            include_history=include_history,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'account_id={}'.format(account_id) in query_string
+        assert 'template_id={}'.format(template_id) in query_string
+        assert 'template_version={}'.format(template_version) in query_string
+        assert 'target={}'.format(target) in query_string
+        assert 'target_type={}'.format(target_type) in query_string
+        assert 'limit={}'.format(limit) in query_string
+        assert 'pagetoken={}'.format(pagetoken) in query_string
+        assert 'sort={}'.format(sort) in query_string
+        assert 'order={}'.format(order) in query_string
+        assert 'include_history={}'.format('true' if include_history else 'false') in query_string
+
+    def test_list_account_settings_assignments_all_params_with_retries(self):
+        # Enable retries and run test_list_account_settings_assignments_all_params.
+        _service.enable_retries()
+        self.test_list_account_settings_assignments_all_params()
+
+        # Disable retries and run test_list_account_settings_assignments_all_params.
+        _service.disable_retries()
+        self.test_list_account_settings_assignments_all_params()
+
+    @responses.activate
+    def test_list_account_settings_assignments_required_params(self):
+        """
+        test_list_account_settings_assignments_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_assignments/')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 5, "first": "first", "previous": "previous", "next": "next", "assignments": [{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Invoke method
+        response = _service.list_account_settings_assignments()
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_list_account_settings_assignments_required_params_with_retries(self):
+        # Enable retries and run test_list_account_settings_assignments_required_params.
+        _service.enable_retries()
+        self.test_list_account_settings_assignments_required_params()
+
+        # Disable retries and run test_list_account_settings_assignments_required_params.
+        _service.disable_retries()
+        self.test_list_account_settings_assignments_required_params()
+
+
+class TestCreateAccountSettingsAssignment:
+    """
+    Test Class for create_account_settings_assignment
+    """
+
+    @responses.activate
+    def test_create_account_settings_assignment_all_params(self):
+        """
+        create_account_settings_assignment()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_assignments/')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}'
+        responses.add(
+            responses.POST,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=202,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        template_version = 1
+        target_type = 'Account'
+        target = 'testString'
+
+        # Invoke method
+        response = _service.create_account_settings_assignment(
+            template_id,
+            template_version,
+            target_type,
+            target,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 202
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['template_id'] == 'testString'
+        assert req_body['template_version'] == 1
+        assert req_body['target_type'] == 'Account'
+        assert req_body['target'] == 'testString'
+
+    def test_create_account_settings_assignment_all_params_with_retries(self):
+        # Enable retries and run test_create_account_settings_assignment_all_params.
+        _service.enable_retries()
+        self.test_create_account_settings_assignment_all_params()
+
+        # Disable retries and run test_create_account_settings_assignment_all_params.
+        _service.disable_retries()
+        self.test_create_account_settings_assignment_all_params()
+
+    @responses.activate
+    def test_create_account_settings_assignment_value_error(self):
+        """
+        test_create_account_settings_assignment_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_assignments/')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}'
+        responses.add(
+            responses.POST,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=202,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        template_version = 1
+        target_type = 'Account'
+        target = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "template_id": template_id,
+            "template_version": template_version,
+            "target_type": target_type,
+            "target": target,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.create_account_settings_assignment(**req_copy)
+
+    def test_create_account_settings_assignment_value_error_with_retries(self):
+        # Enable retries and run test_create_account_settings_assignment_value_error.
+        _service.enable_retries()
+        self.test_create_account_settings_assignment_value_error()
+
+        # Disable retries and run test_create_account_settings_assignment_value_error.
+        _service.disable_retries()
+        self.test_create_account_settings_assignment_value_error()
+
+
+class TestGetAccountSettingsAssignment:
+    """
+    Test Class for get_account_settings_assignment
+    """
+
+    @responses.activate
+    def test_get_account_settings_assignment_all_params(self):
+        """
+        get_account_settings_assignment()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_assignments/testString')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+        include_history = False
+
+        # Invoke method
+        response = _service.get_account_settings_assignment(
+            assignment_id,
+            include_history=include_history,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'include_history={}'.format('true' if include_history else 'false') in query_string
+
+    def test_get_account_settings_assignment_all_params_with_retries(self):
+        # Enable retries and run test_get_account_settings_assignment_all_params.
+        _service.enable_retries()
+        self.test_get_account_settings_assignment_all_params()
+
+        # Disable retries and run test_get_account_settings_assignment_all_params.
+        _service.disable_retries()
+        self.test_get_account_settings_assignment_all_params()
+
+    @responses.activate
+    def test_get_account_settings_assignment_required_params(self):
+        """
+        test_get_account_settings_assignment_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_assignments/testString')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+
+        # Invoke method
+        response = _service.get_account_settings_assignment(
+            assignment_id,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_account_settings_assignment_required_params_with_retries(self):
+        # Enable retries and run test_get_account_settings_assignment_required_params.
+        _service.enable_retries()
+        self.test_get_account_settings_assignment_required_params()
+
+        # Disable retries and run test_get_account_settings_assignment_required_params.
+        _service.disable_retries()
+        self.test_get_account_settings_assignment_required_params()
+
+    @responses.activate
+    def test_get_account_settings_assignment_value_error(self):
+        """
+        test_get_account_settings_assignment_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_assignments/testString')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "assignment_id": assignment_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_account_settings_assignment(**req_copy)
+
+    def test_get_account_settings_assignment_value_error_with_retries(self):
+        # Enable retries and run test_get_account_settings_assignment_value_error.
+        _service.enable_retries()
+        self.test_get_account_settings_assignment_value_error()
+
+        # Disable retries and run test_get_account_settings_assignment_value_error.
+        _service.disable_retries()
+        self.test_get_account_settings_assignment_value_error()
+
+
+class TestDeleteAccountSettingsAssignment:
+    """
+    Test Class for delete_account_settings_assignment
+    """
+
+    @responses.activate
+    def test_delete_account_settings_assignment_all_params(self):
+        """
+        delete_account_settings_assignment()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_assignments/testString')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "status_code": "status_code", "errors": [{"code": "code", "message_code": "message_code", "message": "message", "details": "details"}], "trace": "trace"}'
+        responses.add(
+            responses.DELETE,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=202,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+
+        # Invoke method
+        response = _service.delete_account_settings_assignment(
+            assignment_id,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 202
+
+    def test_delete_account_settings_assignment_all_params_with_retries(self):
+        # Enable retries and run test_delete_account_settings_assignment_all_params.
+        _service.enable_retries()
+        self.test_delete_account_settings_assignment_all_params()
+
+        # Disable retries and run test_delete_account_settings_assignment_all_params.
+        _service.disable_retries()
+        self.test_delete_account_settings_assignment_all_params()
+
+    @responses.activate
+    def test_delete_account_settings_assignment_value_error(self):
+        """
+        test_delete_account_settings_assignment_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_assignments/testString')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "status_code": "status_code", "errors": [{"code": "code", "message_code": "message_code", "message": "message", "details": "details"}], "trace": "trace"}'
+        responses.add(
+            responses.DELETE,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=202,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "assignment_id": assignment_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_account_settings_assignment(**req_copy)
+
+    def test_delete_account_settings_assignment_value_error_with_retries(self):
+        # Enable retries and run test_delete_account_settings_assignment_value_error.
+        _service.enable_retries()
+        self.test_delete_account_settings_assignment_value_error()
+
+        # Disable retries and run test_delete_account_settings_assignment_value_error.
+        _service.disable_retries()
+        self.test_delete_account_settings_assignment_value_error()
+
+
+class TestUpdateAccountSettingsAssignment:
+    """
+    Test Class for update_account_settings_assignment
+    """
+
+    @responses.activate
+    def test_update_account_settings_assignment_all_params(self):
+        """
+        update_account_settings_assignment()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_assignments/testString')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}'
+        responses.add(
+            responses.PATCH,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+        if_match = 'testString'
+        template_version = 1
+
+        # Invoke method
+        response = _service.update_account_settings_assignment(
+            assignment_id,
+            if_match,
+            template_version,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['template_version'] == 1
+
+    def test_update_account_settings_assignment_all_params_with_retries(self):
+        # Enable retries and run test_update_account_settings_assignment_all_params.
+        _service.enable_retries()
+        self.test_update_account_settings_assignment_all_params()
+
+        # Disable retries and run test_update_account_settings_assignment_all_params.
+        _service.disable_retries()
+        self.test_update_account_settings_assignment_all_params()
+
+    @responses.activate
+    def test_update_account_settings_assignment_value_error(self):
+        """
+        test_update_account_settings_assignment_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_assignments/testString')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}'
+        responses.add(
+            responses.PATCH,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+        if_match = 'testString'
+        template_version = 1
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "assignment_id": assignment_id,
+            "if_match": if_match,
+            "template_version": template_version,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.update_account_settings_assignment(**req_copy)
+
+    def test_update_account_settings_assignment_value_error_with_retries(self):
+        # Enable retries and run test_update_account_settings_assignment_value_error.
+        _service.enable_retries()
+        self.test_update_account_settings_assignment_value_error()
+
+        # Disable retries and run test_update_account_settings_assignment_value_error.
+        _service.disable_retries()
+        self.test_update_account_settings_assignment_value_error()
+
+
+# endregion
+##############################################################################
+# End of Service: AccountSettingsAssignments
+##############################################################################
+
+##############################################################################
+# Start of Service: AccountSettingsTemplate
+##############################################################################
+# region
+
+
+class TestNewInstance:
+    """
+    Test Class for new_instance
+    """
+
+    def test_new_instance(self):
+        """
+        new_instance()
+        """
+        os.environ['TEST_SERVICE_AUTH_TYPE'] = 'noAuth'
+
+        service = IamIdentityV1.new_instance(
+            service_name='TEST_SERVICE',
+        )
+
+        assert service is not None
+        assert isinstance(service, IamIdentityV1)
+
+    def test_new_instance_without_authenticator(self):
+        """
+        new_instance_without_authenticator()
+        """
+        with pytest.raises(ValueError, match='authenticator must be provided'):
+            service = IamIdentityV1.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
+
+
+class TestListAccountSettingsTemplates:
+    """
+    Test Class for list_account_settings_templates
+    """
+
+    @responses.activate
+    def test_list_account_settings_templates_all_params(self):
+        """
+        list_account_settings_templates()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 20, "first": "first", "previous": "previous", "next": "next", "account_settings_templates": [{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "allowed_ip_addresses", "mfa": "NONE", "user_mfa": [{"iam_id": "iam_id", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "max_sessions_per_identity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        account_id = 'testString'
+        limit = '20'
+        pagetoken = 'testString'
+        sort = 'created_at'
+        order = 'asc'
+        include_history = 'false'
+
+        # Invoke method
+        response = _service.list_account_settings_templates(
+            account_id=account_id,
+            limit=limit,
+            pagetoken=pagetoken,
+            sort=sort,
+            order=order,
+            include_history=include_history,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'account_id={}'.format(account_id) in query_string
+        assert 'limit={}'.format(limit) in query_string
+        assert 'pagetoken={}'.format(pagetoken) in query_string
+        assert 'sort={}'.format(sort) in query_string
+        assert 'order={}'.format(order) in query_string
+        assert 'include_history={}'.format(include_history) in query_string
+
+    def test_list_account_settings_templates_all_params_with_retries(self):
+        # Enable retries and run test_list_account_settings_templates_all_params.
+        _service.enable_retries()
+        self.test_list_account_settings_templates_all_params()
+
+        # Disable retries and run test_list_account_settings_templates_all_params.
+        _service.disable_retries()
+        self.test_list_account_settings_templates_all_params()
+
+    @responses.activate
+    def test_list_account_settings_templates_required_params(self):
+        """
+        test_list_account_settings_templates_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 20, "first": "first", "previous": "previous", "next": "next", "account_settings_templates": [{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "allowed_ip_addresses", "mfa": "NONE", "user_mfa": [{"iam_id": "iam_id", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "max_sessions_per_identity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Invoke method
+        response = _service.list_account_settings_templates()
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_list_account_settings_templates_required_params_with_retries(self):
+        # Enable retries and run test_list_account_settings_templates_required_params.
+        _service.enable_retries()
+        self.test_list_account_settings_templates_required_params()
+
+        # Disable retries and run test_list_account_settings_templates_required_params.
+        _service.disable_retries()
+        self.test_list_account_settings_templates_required_params()
+
+
+class TestCreateAccountSettingsTemplate:
+    """
+    Test Class for create_account_settings_template
+    """
+
+    @responses.activate
+    def test_create_account_settings_template_all_params(self):
+        """
+        create_account_settings_template()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "allowed_ip_addresses", "mfa": "NONE", "user_mfa": [{"iam_id": "iam_id", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "max_sessions_per_identity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.POST,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=201,
+        )
+
+        # Construct a dict representation of a AccountSettingsUserMFA model
+        account_settings_user_mfa_model = {}
+        account_settings_user_mfa_model['iam_id'] = 'testString'
+        account_settings_user_mfa_model['mfa'] = 'NONE'
+
+        # Construct a dict representation of a AccountSettingsComponent model
+        account_settings_component_model = {}
+        account_settings_component_model['restrict_create_service_id'] = 'NOT_SET'
+        account_settings_component_model['restrict_create_platform_apikey'] = 'NOT_SET'
+        account_settings_component_model['allowed_ip_addresses'] = 'testString'
+        account_settings_component_model['mfa'] = 'NONE'
+        account_settings_component_model['user_mfa'] = [account_settings_user_mfa_model]
+        account_settings_component_model['session_expiration_in_seconds'] = '86400'
+        account_settings_component_model['session_invalidation_in_seconds'] = '7200'
+        account_settings_component_model['max_sessions_per_identity'] = 'testString'
+        account_settings_component_model['system_access_token_expiration_in_seconds'] = '3600'
+        account_settings_component_model['system_refresh_token_expiration_in_seconds'] = '259200'
+
+        # Set up parameter values
+        account_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+        account_settings = account_settings_component_model
+
+        # Invoke method
+        response = _service.create_account_settings_template(
+            account_id=account_id,
+            name=name,
+            description=description,
+            account_settings=account_settings,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['account_id'] == 'testString'
+        assert req_body['name'] == 'testString'
+        assert req_body['description'] == 'testString'
+        assert req_body['account_settings'] == account_settings_component_model
+
+    def test_create_account_settings_template_all_params_with_retries(self):
+        # Enable retries and run test_create_account_settings_template_all_params.
+        _service.enable_retries()
+        self.test_create_account_settings_template_all_params()
+
+        # Disable retries and run test_create_account_settings_template_all_params.
+        _service.disable_retries()
+        self.test_create_account_settings_template_all_params()
+
+
+class TestGetLatestAccountSettingsTemplateVersion:
+    """
+    Test Class for get_latest_account_settings_template_version
+    """
+
+    @responses.activate
+    def test_get_latest_account_settings_template_version_all_params(self):
+        """
+        get_latest_account_settings_template_version()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "allowed_ip_addresses", "mfa": "NONE", "user_mfa": [{"iam_id": "iam_id", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "max_sessions_per_identity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        include_history = False
+
+        # Invoke method
+        response = _service.get_latest_account_settings_template_version(
+            template_id,
+            include_history=include_history,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'include_history={}'.format('true' if include_history else 'false') in query_string
+
+    def test_get_latest_account_settings_template_version_all_params_with_retries(self):
+        # Enable retries and run test_get_latest_account_settings_template_version_all_params.
+        _service.enable_retries()
+        self.test_get_latest_account_settings_template_version_all_params()
+
+        # Disable retries and run test_get_latest_account_settings_template_version_all_params.
+        _service.disable_retries()
+        self.test_get_latest_account_settings_template_version_all_params()
+
+    @responses.activate
+    def test_get_latest_account_settings_template_version_required_params(self):
+        """
+        test_get_latest_account_settings_template_version_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "allowed_ip_addresses", "mfa": "NONE", "user_mfa": [{"iam_id": "iam_id", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "max_sessions_per_identity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+
+        # Invoke method
+        response = _service.get_latest_account_settings_template_version(
+            template_id,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_latest_account_settings_template_version_required_params_with_retries(self):
+        # Enable retries and run test_get_latest_account_settings_template_version_required_params.
+        _service.enable_retries()
+        self.test_get_latest_account_settings_template_version_required_params()
+
+        # Disable retries and run test_get_latest_account_settings_template_version_required_params.
+        _service.disable_retries()
+        self.test_get_latest_account_settings_template_version_required_params()
+
+    @responses.activate
+    def test_get_latest_account_settings_template_version_value_error(self):
+        """
+        test_get_latest_account_settings_template_version_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "allowed_ip_addresses", "mfa": "NONE", "user_mfa": [{"iam_id": "iam_id", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "max_sessions_per_identity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "template_id": template_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_latest_account_settings_template_version(**req_copy)
+
+    def test_get_latest_account_settings_template_version_value_error_with_retries(self):
+        # Enable retries and run test_get_latest_account_settings_template_version_value_error.
+        _service.enable_retries()
+        self.test_get_latest_account_settings_template_version_value_error()
+
+        # Disable retries and run test_get_latest_account_settings_template_version_value_error.
+        _service.disable_retries()
+        self.test_get_latest_account_settings_template_version_value_error()
+
+
+class TestDeleteAllVersionsOfAccountSettingsTemplate:
+    """
+    Test Class for delete_all_versions_of_account_settings_template
+    """
+
+    @responses.activate
+    def test_delete_all_versions_of_account_settings_template_all_params(self):
+        """
+        delete_all_versions_of_account_settings_template()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString')
+        responses.add(
+            responses.DELETE,
+            url,
+            status=204,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+
+        # Invoke method
+        response = _service.delete_all_versions_of_account_settings_template(
+            template_id,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_delete_all_versions_of_account_settings_template_all_params_with_retries(self):
+        # Enable retries and run test_delete_all_versions_of_account_settings_template_all_params.
+        _service.enable_retries()
+        self.test_delete_all_versions_of_account_settings_template_all_params()
+
+        # Disable retries and run test_delete_all_versions_of_account_settings_template_all_params.
+        _service.disable_retries()
+        self.test_delete_all_versions_of_account_settings_template_all_params()
+
+    @responses.activate
+    def test_delete_all_versions_of_account_settings_template_value_error(self):
+        """
+        test_delete_all_versions_of_account_settings_template_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString')
+        responses.add(
+            responses.DELETE,
+            url,
+            status=204,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "template_id": template_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_all_versions_of_account_settings_template(**req_copy)
+
+    def test_delete_all_versions_of_account_settings_template_value_error_with_retries(self):
+        # Enable retries and run test_delete_all_versions_of_account_settings_template_value_error.
+        _service.enable_retries()
+        self.test_delete_all_versions_of_account_settings_template_value_error()
+
+        # Disable retries and run test_delete_all_versions_of_account_settings_template_value_error.
+        _service.disable_retries()
+        self.test_delete_all_versions_of_account_settings_template_value_error()
+
+
+class TestListVersionsOfAccountSettingsTemplate:
+    """
+    Test Class for list_versions_of_account_settings_template
+    """
+
+    @responses.activate
+    def test_list_versions_of_account_settings_template_all_params(self):
+        """
+        list_versions_of_account_settings_template()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString/versions')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 20, "first": "first", "previous": "previous", "next": "next", "account_settings_templates": [{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "allowed_ip_addresses", "mfa": "NONE", "user_mfa": [{"iam_id": "iam_id", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "max_sessions_per_identity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        limit = '20'
+        pagetoken = 'testString'
+        sort = 'created_at'
+        order = 'asc'
+        include_history = 'false'
+
+        # Invoke method
+        response = _service.list_versions_of_account_settings_template(
+            template_id,
+            limit=limit,
+            pagetoken=pagetoken,
+            sort=sort,
+            order=order,
+            include_history=include_history,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'limit={}'.format(limit) in query_string
+        assert 'pagetoken={}'.format(pagetoken) in query_string
+        assert 'sort={}'.format(sort) in query_string
+        assert 'order={}'.format(order) in query_string
+        assert 'include_history={}'.format(include_history) in query_string
+
+    def test_list_versions_of_account_settings_template_all_params_with_retries(self):
+        # Enable retries and run test_list_versions_of_account_settings_template_all_params.
+        _service.enable_retries()
+        self.test_list_versions_of_account_settings_template_all_params()
+
+        # Disable retries and run test_list_versions_of_account_settings_template_all_params.
+        _service.disable_retries()
+        self.test_list_versions_of_account_settings_template_all_params()
+
+    @responses.activate
+    def test_list_versions_of_account_settings_template_required_params(self):
+        """
+        test_list_versions_of_account_settings_template_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString/versions')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 20, "first": "first", "previous": "previous", "next": "next", "account_settings_templates": [{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "allowed_ip_addresses", "mfa": "NONE", "user_mfa": [{"iam_id": "iam_id", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "max_sessions_per_identity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+
+        # Invoke method
+        response = _service.list_versions_of_account_settings_template(
+            template_id,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_list_versions_of_account_settings_template_required_params_with_retries(self):
+        # Enable retries and run test_list_versions_of_account_settings_template_required_params.
+        _service.enable_retries()
+        self.test_list_versions_of_account_settings_template_required_params()
+
+        # Disable retries and run test_list_versions_of_account_settings_template_required_params.
+        _service.disable_retries()
+        self.test_list_versions_of_account_settings_template_required_params()
+
+    @responses.activate
+    def test_list_versions_of_account_settings_template_value_error(self):
+        """
+        test_list_versions_of_account_settings_template_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString/versions')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 20, "first": "first", "previous": "previous", "next": "next", "account_settings_templates": [{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "allowed_ip_addresses", "mfa": "NONE", "user_mfa": [{"iam_id": "iam_id", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "max_sessions_per_identity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "template_id": template_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.list_versions_of_account_settings_template(**req_copy)
+
+    def test_list_versions_of_account_settings_template_value_error_with_retries(self):
+        # Enable retries and run test_list_versions_of_account_settings_template_value_error.
+        _service.enable_retries()
+        self.test_list_versions_of_account_settings_template_value_error()
+
+        # Disable retries and run test_list_versions_of_account_settings_template_value_error.
+        _service.disable_retries()
+        self.test_list_versions_of_account_settings_template_value_error()
+
+
+class TestCreateAccountSettingsTemplateVersion:
+    """
+    Test Class for create_account_settings_template_version
+    """
+
+    @responses.activate
+    def test_create_account_settings_template_version_all_params(self):
+        """
+        create_account_settings_template_version()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString/versions')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "allowed_ip_addresses", "mfa": "NONE", "user_mfa": [{"iam_id": "iam_id", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "max_sessions_per_identity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.POST,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=201,
+        )
+
+        # Construct a dict representation of a AccountSettingsUserMFA model
+        account_settings_user_mfa_model = {}
+        account_settings_user_mfa_model['iam_id'] = 'testString'
+        account_settings_user_mfa_model['mfa'] = 'NONE'
+
+        # Construct a dict representation of a AccountSettingsComponent model
+        account_settings_component_model = {}
+        account_settings_component_model['restrict_create_service_id'] = 'NOT_SET'
+        account_settings_component_model['restrict_create_platform_apikey'] = 'NOT_SET'
+        account_settings_component_model['allowed_ip_addresses'] = 'testString'
+        account_settings_component_model['mfa'] = 'NONE'
+        account_settings_component_model['user_mfa'] = [account_settings_user_mfa_model]
+        account_settings_component_model['session_expiration_in_seconds'] = '86400'
+        account_settings_component_model['session_invalidation_in_seconds'] = '7200'
+        account_settings_component_model['max_sessions_per_identity'] = 'testString'
+        account_settings_component_model['system_access_token_expiration_in_seconds'] = '3600'
+        account_settings_component_model['system_refresh_token_expiration_in_seconds'] = '259200'
+
+        # Set up parameter values
+        template_id = 'testString'
+        account_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+        account_settings = account_settings_component_model
+
+        # Invoke method
+        response = _service.create_account_settings_template_version(
+            template_id,
+            account_id=account_id,
+            name=name,
+            description=description,
+            account_settings=account_settings,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['account_id'] == 'testString'
+        assert req_body['name'] == 'testString'
+        assert req_body['description'] == 'testString'
+        assert req_body['account_settings'] == account_settings_component_model
+
+    def test_create_account_settings_template_version_all_params_with_retries(self):
+        # Enable retries and run test_create_account_settings_template_version_all_params.
+        _service.enable_retries()
+        self.test_create_account_settings_template_version_all_params()
+
+        # Disable retries and run test_create_account_settings_template_version_all_params.
+        _service.disable_retries()
+        self.test_create_account_settings_template_version_all_params()
+
+    @responses.activate
+    def test_create_account_settings_template_version_value_error(self):
+        """
+        test_create_account_settings_template_version_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString/versions')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "allowed_ip_addresses", "mfa": "NONE", "user_mfa": [{"iam_id": "iam_id", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "max_sessions_per_identity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.POST,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=201,
+        )
+
+        # Construct a dict representation of a AccountSettingsUserMFA model
+        account_settings_user_mfa_model = {}
+        account_settings_user_mfa_model['iam_id'] = 'testString'
+        account_settings_user_mfa_model['mfa'] = 'NONE'
+
+        # Construct a dict representation of a AccountSettingsComponent model
+        account_settings_component_model = {}
+        account_settings_component_model['restrict_create_service_id'] = 'NOT_SET'
+        account_settings_component_model['restrict_create_platform_apikey'] = 'NOT_SET'
+        account_settings_component_model['allowed_ip_addresses'] = 'testString'
+        account_settings_component_model['mfa'] = 'NONE'
+        account_settings_component_model['user_mfa'] = [account_settings_user_mfa_model]
+        account_settings_component_model['session_expiration_in_seconds'] = '86400'
+        account_settings_component_model['session_invalidation_in_seconds'] = '7200'
+        account_settings_component_model['max_sessions_per_identity'] = 'testString'
+        account_settings_component_model['system_access_token_expiration_in_seconds'] = '3600'
+        account_settings_component_model['system_refresh_token_expiration_in_seconds'] = '259200'
+
+        # Set up parameter values
+        template_id = 'testString'
+        account_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+        account_settings = account_settings_component_model
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "template_id": template_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.create_account_settings_template_version(**req_copy)
+
+    def test_create_account_settings_template_version_value_error_with_retries(self):
+        # Enable retries and run test_create_account_settings_template_version_value_error.
+        _service.enable_retries()
+        self.test_create_account_settings_template_version_value_error()
+
+        # Disable retries and run test_create_account_settings_template_version_value_error.
+        _service.disable_retries()
+        self.test_create_account_settings_template_version_value_error()
+
+
+class TestGetAccountSettingsTemplateVersion:
+    """
+    Test Class for get_account_settings_template_version
+    """
+
+    @responses.activate
+    def test_get_account_settings_template_version_all_params(self):
+        """
+        get_account_settings_template_version()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString/versions/testString')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "allowed_ip_addresses", "mfa": "NONE", "user_mfa": [{"iam_id": "iam_id", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "max_sessions_per_identity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        version = 'testString'
+        include_history = False
+
+        # Invoke method
+        response = _service.get_account_settings_template_version(
+            template_id,
+            version,
+            include_history=include_history,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'include_history={}'.format('true' if include_history else 'false') in query_string
+
+    def test_get_account_settings_template_version_all_params_with_retries(self):
+        # Enable retries and run test_get_account_settings_template_version_all_params.
+        _service.enable_retries()
+        self.test_get_account_settings_template_version_all_params()
+
+        # Disable retries and run test_get_account_settings_template_version_all_params.
+        _service.disable_retries()
+        self.test_get_account_settings_template_version_all_params()
+
+    @responses.activate
+    def test_get_account_settings_template_version_required_params(self):
+        """
+        test_get_account_settings_template_version_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString/versions/testString')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "allowed_ip_addresses", "mfa": "NONE", "user_mfa": [{"iam_id": "iam_id", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "max_sessions_per_identity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        version = 'testString'
+
+        # Invoke method
+        response = _service.get_account_settings_template_version(
+            template_id,
+            version,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_account_settings_template_version_required_params_with_retries(self):
+        # Enable retries and run test_get_account_settings_template_version_required_params.
+        _service.enable_retries()
+        self.test_get_account_settings_template_version_required_params()
+
+        # Disable retries and run test_get_account_settings_template_version_required_params.
+        _service.disable_retries()
+        self.test_get_account_settings_template_version_required_params()
+
+    @responses.activate
+    def test_get_account_settings_template_version_value_error(self):
+        """
+        test_get_account_settings_template_version_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString/versions/testString')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "allowed_ip_addresses", "mfa": "NONE", "user_mfa": [{"iam_id": "iam_id", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "max_sessions_per_identity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        version = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "template_id": template_id,
+            "version": version,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_account_settings_template_version(**req_copy)
+
+    def test_get_account_settings_template_version_value_error_with_retries(self):
+        # Enable retries and run test_get_account_settings_template_version_value_error.
+        _service.enable_retries()
+        self.test_get_account_settings_template_version_value_error()
+
+        # Disable retries and run test_get_account_settings_template_version_value_error.
+        _service.disable_retries()
+        self.test_get_account_settings_template_version_value_error()
+
+
+class TestUpdateAccountSettingsTemplateVersion:
+    """
+    Test Class for update_account_settings_template_version
+    """
+
+    @responses.activate
+    def test_update_account_settings_template_version_all_params(self):
+        """
+        update_account_settings_template_version()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString/versions/testString')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "allowed_ip_addresses", "mfa": "NONE", "user_mfa": [{"iam_id": "iam_id", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "max_sessions_per_identity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.PUT,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Construct a dict representation of a AccountSettingsUserMFA model
+        account_settings_user_mfa_model = {}
+        account_settings_user_mfa_model['iam_id'] = 'testString'
+        account_settings_user_mfa_model['mfa'] = 'NONE'
+
+        # Construct a dict representation of a AccountSettingsComponent model
+        account_settings_component_model = {}
+        account_settings_component_model['restrict_create_service_id'] = 'NOT_SET'
+        account_settings_component_model['restrict_create_platform_apikey'] = 'NOT_SET'
+        account_settings_component_model['allowed_ip_addresses'] = 'testString'
+        account_settings_component_model['mfa'] = 'NONE'
+        account_settings_component_model['user_mfa'] = [account_settings_user_mfa_model]
+        account_settings_component_model['session_expiration_in_seconds'] = '86400'
+        account_settings_component_model['session_invalidation_in_seconds'] = '7200'
+        account_settings_component_model['max_sessions_per_identity'] = 'testString'
+        account_settings_component_model['system_access_token_expiration_in_seconds'] = '3600'
+        account_settings_component_model['system_refresh_token_expiration_in_seconds'] = '259200'
+
+        # Set up parameter values
+        if_match = 'testString'
+        template_id = 'testString'
+        version = 'testString'
+        account_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+        account_settings = account_settings_component_model
+
+        # Invoke method
+        response = _service.update_account_settings_template_version(
+            if_match,
+            template_id,
+            version,
+            account_id=account_id,
+            name=name,
+            description=description,
+            account_settings=account_settings,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['account_id'] == 'testString'
+        assert req_body['name'] == 'testString'
+        assert req_body['description'] == 'testString'
+        assert req_body['account_settings'] == account_settings_component_model
+
+    def test_update_account_settings_template_version_all_params_with_retries(self):
+        # Enable retries and run test_update_account_settings_template_version_all_params.
+        _service.enable_retries()
+        self.test_update_account_settings_template_version_all_params()
+
+        # Disable retries and run test_update_account_settings_template_version_all_params.
+        _service.disable_retries()
+        self.test_update_account_settings_template_version_all_params()
+
+    @responses.activate
+    def test_update_account_settings_template_version_value_error(self):
+        """
+        test_update_account_settings_template_version_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString/versions/testString')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "allowed_ip_addresses", "mfa": "NONE", "user_mfa": [{"iam_id": "iam_id", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "max_sessions_per_identity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.PUT,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Construct a dict representation of a AccountSettingsUserMFA model
+        account_settings_user_mfa_model = {}
+        account_settings_user_mfa_model['iam_id'] = 'testString'
+        account_settings_user_mfa_model['mfa'] = 'NONE'
+
+        # Construct a dict representation of a AccountSettingsComponent model
+        account_settings_component_model = {}
+        account_settings_component_model['restrict_create_service_id'] = 'NOT_SET'
+        account_settings_component_model['restrict_create_platform_apikey'] = 'NOT_SET'
+        account_settings_component_model['allowed_ip_addresses'] = 'testString'
+        account_settings_component_model['mfa'] = 'NONE'
+        account_settings_component_model['user_mfa'] = [account_settings_user_mfa_model]
+        account_settings_component_model['session_expiration_in_seconds'] = '86400'
+        account_settings_component_model['session_invalidation_in_seconds'] = '7200'
+        account_settings_component_model['max_sessions_per_identity'] = 'testString'
+        account_settings_component_model['system_access_token_expiration_in_seconds'] = '3600'
+        account_settings_component_model['system_refresh_token_expiration_in_seconds'] = '259200'
+
+        # Set up parameter values
+        if_match = 'testString'
+        template_id = 'testString'
+        version = 'testString'
+        account_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+        account_settings = account_settings_component_model
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "if_match": if_match,
+            "template_id": template_id,
+            "version": version,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.update_account_settings_template_version(**req_copy)
+
+    def test_update_account_settings_template_version_value_error_with_retries(self):
+        # Enable retries and run test_update_account_settings_template_version_value_error.
+        _service.enable_retries()
+        self.test_update_account_settings_template_version_value_error()
+
+        # Disable retries and run test_update_account_settings_template_version_value_error.
+        _service.disable_retries()
+        self.test_update_account_settings_template_version_value_error()
+
+
+class TestDeleteAccountSettingsTemplateVersion:
+    """
+    Test Class for delete_account_settings_template_version
+    """
+
+    @responses.activate
+    def test_delete_account_settings_template_version_all_params(self):
+        """
+        delete_account_settings_template_version()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString/versions/testString')
+        responses.add(
+            responses.DELETE,
+            url,
+            status=204,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        version = 'testString'
+
+        # Invoke method
+        response = _service.delete_account_settings_template_version(
+            template_id,
+            version,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_delete_account_settings_template_version_all_params_with_retries(self):
+        # Enable retries and run test_delete_account_settings_template_version_all_params.
+        _service.enable_retries()
+        self.test_delete_account_settings_template_version_all_params()
+
+        # Disable retries and run test_delete_account_settings_template_version_all_params.
+        _service.disable_retries()
+        self.test_delete_account_settings_template_version_all_params()
+
+    @responses.activate
+    def test_delete_account_settings_template_version_value_error(self):
+        """
+        test_delete_account_settings_template_version_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString/versions/testString')
+        responses.add(
+            responses.DELETE,
+            url,
+            status=204,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        version = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "template_id": template_id,
+            "version": version,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_account_settings_template_version(**req_copy)
+
+    def test_delete_account_settings_template_version_value_error_with_retries(self):
+        # Enable retries and run test_delete_account_settings_template_version_value_error.
+        _service.enable_retries()
+        self.test_delete_account_settings_template_version_value_error()
+
+        # Disable retries and run test_delete_account_settings_template_version_value_error.
+        _service.disable_retries()
+        self.test_delete_account_settings_template_version_value_error()
+
+
+class TestCommitAccountSettingsTemplate:
+    """
+    Test Class for commit_account_settings_template
+    """
+
+    @responses.activate
+    def test_commit_account_settings_template_all_params(self):
+        """
+        commit_account_settings_template()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString/versions/testString/commit')
+        responses.add(
+            responses.POST,
+            url,
+            status=204,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        version = 'testString'
+
+        # Invoke method
+        response = _service.commit_account_settings_template(
+            template_id,
+            version,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_commit_account_settings_template_all_params_with_retries(self):
+        # Enable retries and run test_commit_account_settings_template_all_params.
+        _service.enable_retries()
+        self.test_commit_account_settings_template_all_params()
+
+        # Disable retries and run test_commit_account_settings_template_all_params.
+        _service.disable_retries()
+        self.test_commit_account_settings_template_all_params()
+
+    @responses.activate
+    def test_commit_account_settings_template_value_error(self):
+        """
+        test_commit_account_settings_template_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/account_settings_templates/testString/versions/testString/commit')
+        responses.add(
+            responses.POST,
+            url,
+            status=204,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        version = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "template_id": template_id,
+            "version": version,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.commit_account_settings_template(**req_copy)
+
+    def test_commit_account_settings_template_value_error_with_retries(self):
+        # Enable retries and run test_commit_account_settings_template_value_error.
+        _service.enable_retries()
+        self.test_commit_account_settings_template_value_error()
+
+        # Disable retries and run test_commit_account_settings_template_value_error.
+        _service.disable_retries()
+        self.test_commit_account_settings_template_value_error()
+
+
+# endregion
+##############################################################################
+# End of Service: AccountSettingsTemplate
+##############################################################################
+
+##############################################################################
 # Start of Service: ActivityOperations
 ##############################################################################
 # region
@@ -4510,6 +6161,1747 @@ class TestGetReport:
 # End of Service: ActivityOperations
 ##############################################################################
 
+##############################################################################
+# Start of Service: TrustedProfileAssignments
+##############################################################################
+# region
+
+
+class TestNewInstance:
+    """
+    Test Class for new_instance
+    """
+
+    def test_new_instance(self):
+        """
+        new_instance()
+        """
+        os.environ['TEST_SERVICE_AUTH_TYPE'] = 'noAuth'
+
+        service = IamIdentityV1.new_instance(
+            service_name='TEST_SERVICE',
+        )
+
+        assert service is not None
+        assert isinstance(service, IamIdentityV1)
+
+    def test_new_instance_without_authenticator(self):
+        """
+        new_instance_without_authenticator()
+        """
+        with pytest.raises(ValueError, match='authenticator must be provided'):
+            service = IamIdentityV1.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
+
+
+class TestListTrustedProfileAssignments:
+    """
+    Test Class for list_trusted_profile_assignments
+    """
+
+    @responses.activate
+    def test_list_trusted_profile_assignments_all_params(self):
+        """
+        list_trusted_profile_assignments()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_assignments/')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 5, "first": "first", "previous": "previous", "next": "next", "assignments": [{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        account_id = 'testString'
+        template_id = 'testString'
+        template_version = 'testString'
+        target = 'testString'
+        target_type = 'Account'
+        limit = 20
+        pagetoken = 'testString'
+        sort = 'created_at'
+        order = 'asc'
+        include_history = False
+
+        # Invoke method
+        response = _service.list_trusted_profile_assignments(
+            account_id=account_id,
+            template_id=template_id,
+            template_version=template_version,
+            target=target,
+            target_type=target_type,
+            limit=limit,
+            pagetoken=pagetoken,
+            sort=sort,
+            order=order,
+            include_history=include_history,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'account_id={}'.format(account_id) in query_string
+        assert 'template_id={}'.format(template_id) in query_string
+        assert 'template_version={}'.format(template_version) in query_string
+        assert 'target={}'.format(target) in query_string
+        assert 'target_type={}'.format(target_type) in query_string
+        assert 'limit={}'.format(limit) in query_string
+        assert 'pagetoken={}'.format(pagetoken) in query_string
+        assert 'sort={}'.format(sort) in query_string
+        assert 'order={}'.format(order) in query_string
+        assert 'include_history={}'.format('true' if include_history else 'false') in query_string
+
+    def test_list_trusted_profile_assignments_all_params_with_retries(self):
+        # Enable retries and run test_list_trusted_profile_assignments_all_params.
+        _service.enable_retries()
+        self.test_list_trusted_profile_assignments_all_params()
+
+        # Disable retries and run test_list_trusted_profile_assignments_all_params.
+        _service.disable_retries()
+        self.test_list_trusted_profile_assignments_all_params()
+
+    @responses.activate
+    def test_list_trusted_profile_assignments_required_params(self):
+        """
+        test_list_trusted_profile_assignments_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_assignments/')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 5, "first": "first", "previous": "previous", "next": "next", "assignments": [{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Invoke method
+        response = _service.list_trusted_profile_assignments()
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_list_trusted_profile_assignments_required_params_with_retries(self):
+        # Enable retries and run test_list_trusted_profile_assignments_required_params.
+        _service.enable_retries()
+        self.test_list_trusted_profile_assignments_required_params()
+
+        # Disable retries and run test_list_trusted_profile_assignments_required_params.
+        _service.disable_retries()
+        self.test_list_trusted_profile_assignments_required_params()
+
+
+class TestCreateTrustedProfileAssignment:
+    """
+    Test Class for create_trusted_profile_assignment
+    """
+
+    @responses.activate
+    def test_create_trusted_profile_assignment_all_params(self):
+        """
+        create_trusted_profile_assignment()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_assignments/')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}'
+        responses.add(
+            responses.POST,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=202,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        template_version = 1
+        target_type = 'Account'
+        target = 'testString'
+
+        # Invoke method
+        response = _service.create_trusted_profile_assignment(
+            template_id,
+            template_version,
+            target_type,
+            target,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 202
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['template_id'] == 'testString'
+        assert req_body['template_version'] == 1
+        assert req_body['target_type'] == 'Account'
+        assert req_body['target'] == 'testString'
+
+    def test_create_trusted_profile_assignment_all_params_with_retries(self):
+        # Enable retries and run test_create_trusted_profile_assignment_all_params.
+        _service.enable_retries()
+        self.test_create_trusted_profile_assignment_all_params()
+
+        # Disable retries and run test_create_trusted_profile_assignment_all_params.
+        _service.disable_retries()
+        self.test_create_trusted_profile_assignment_all_params()
+
+    @responses.activate
+    def test_create_trusted_profile_assignment_value_error(self):
+        """
+        test_create_trusted_profile_assignment_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_assignments/')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}'
+        responses.add(
+            responses.POST,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=202,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        template_version = 1
+        target_type = 'Account'
+        target = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "template_id": template_id,
+            "template_version": template_version,
+            "target_type": target_type,
+            "target": target,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.create_trusted_profile_assignment(**req_copy)
+
+    def test_create_trusted_profile_assignment_value_error_with_retries(self):
+        # Enable retries and run test_create_trusted_profile_assignment_value_error.
+        _service.enable_retries()
+        self.test_create_trusted_profile_assignment_value_error()
+
+        # Disable retries and run test_create_trusted_profile_assignment_value_error.
+        _service.disable_retries()
+        self.test_create_trusted_profile_assignment_value_error()
+
+
+class TestGetTrustedProfileAssignment:
+    """
+    Test Class for get_trusted_profile_assignment
+    """
+
+    @responses.activate
+    def test_get_trusted_profile_assignment_all_params(self):
+        """
+        get_trusted_profile_assignment()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_assignments/testString')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+        include_history = False
+
+        # Invoke method
+        response = _service.get_trusted_profile_assignment(
+            assignment_id,
+            include_history=include_history,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'include_history={}'.format('true' if include_history else 'false') in query_string
+
+    def test_get_trusted_profile_assignment_all_params_with_retries(self):
+        # Enable retries and run test_get_trusted_profile_assignment_all_params.
+        _service.enable_retries()
+        self.test_get_trusted_profile_assignment_all_params()
+
+        # Disable retries and run test_get_trusted_profile_assignment_all_params.
+        _service.disable_retries()
+        self.test_get_trusted_profile_assignment_all_params()
+
+    @responses.activate
+    def test_get_trusted_profile_assignment_required_params(self):
+        """
+        test_get_trusted_profile_assignment_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_assignments/testString')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+
+        # Invoke method
+        response = _service.get_trusted_profile_assignment(
+            assignment_id,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_trusted_profile_assignment_required_params_with_retries(self):
+        # Enable retries and run test_get_trusted_profile_assignment_required_params.
+        _service.enable_retries()
+        self.test_get_trusted_profile_assignment_required_params()
+
+        # Disable retries and run test_get_trusted_profile_assignment_required_params.
+        _service.disable_retries()
+        self.test_get_trusted_profile_assignment_required_params()
+
+    @responses.activate
+    def test_get_trusted_profile_assignment_value_error(self):
+        """
+        test_get_trusted_profile_assignment_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_assignments/testString')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "assignment_id": assignment_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_trusted_profile_assignment(**req_copy)
+
+    def test_get_trusted_profile_assignment_value_error_with_retries(self):
+        # Enable retries and run test_get_trusted_profile_assignment_value_error.
+        _service.enable_retries()
+        self.test_get_trusted_profile_assignment_value_error()
+
+        # Disable retries and run test_get_trusted_profile_assignment_value_error.
+        _service.disable_retries()
+        self.test_get_trusted_profile_assignment_value_error()
+
+
+class TestDeleteTrustedProfileAssignment:
+    """
+    Test Class for delete_trusted_profile_assignment
+    """
+
+    @responses.activate
+    def test_delete_trusted_profile_assignment_all_params(self):
+        """
+        delete_trusted_profile_assignment()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_assignments/testString')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "status_code": "status_code", "errors": [{"code": "code", "message_code": "message_code", "message": "message", "details": "details"}], "trace": "trace"}'
+        responses.add(
+            responses.DELETE,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=202,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+
+        # Invoke method
+        response = _service.delete_trusted_profile_assignment(
+            assignment_id,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 202
+
+    def test_delete_trusted_profile_assignment_all_params_with_retries(self):
+        # Enable retries and run test_delete_trusted_profile_assignment_all_params.
+        _service.enable_retries()
+        self.test_delete_trusted_profile_assignment_all_params()
+
+        # Disable retries and run test_delete_trusted_profile_assignment_all_params.
+        _service.disable_retries()
+        self.test_delete_trusted_profile_assignment_all_params()
+
+    @responses.activate
+    def test_delete_trusted_profile_assignment_value_error(self):
+        """
+        test_delete_trusted_profile_assignment_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_assignments/testString')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "status_code": "status_code", "errors": [{"code": "code", "message_code": "message_code", "message": "message", "details": "details"}], "trace": "trace"}'
+        responses.add(
+            responses.DELETE,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=202,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "assignment_id": assignment_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_trusted_profile_assignment(**req_copy)
+
+    def test_delete_trusted_profile_assignment_value_error_with_retries(self):
+        # Enable retries and run test_delete_trusted_profile_assignment_value_error.
+        _service.enable_retries()
+        self.test_delete_trusted_profile_assignment_value_error()
+
+        # Disable retries and run test_delete_trusted_profile_assignment_value_error.
+        _service.disable_retries()
+        self.test_delete_trusted_profile_assignment_value_error()
+
+
+class TestUpdateTrustedProfileAssignment:
+    """
+    Test Class for update_trusted_profile_assignment
+    """
+
+    @responses.activate
+    def test_update_trusted_profile_assignment_all_params(self):
+        """
+        update_trusted_profile_assignment()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_assignments/testString')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}'
+        responses.add(
+            responses.PATCH,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+        if_match = 'testString'
+        template_version = 1
+
+        # Invoke method
+        response = _service.update_trusted_profile_assignment(
+            assignment_id,
+            if_match,
+            template_version,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['template_version'] == 1
+
+    def test_update_trusted_profile_assignment_all_params_with_retries(self):
+        # Enable retries and run test_update_trusted_profile_assignment_all_params.
+        _service.enable_retries()
+        self.test_update_trusted_profile_assignment_all_params()
+
+        # Disable retries and run test_update_trusted_profile_assignment_all_params.
+        _service.disable_retries()
+        self.test_update_trusted_profile_assignment_all_params()
+
+    @responses.activate
+    def test_update_trusted_profile_assignment_value_error(self):
+        """
+        test_update_trusted_profile_assignment_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_assignments/testString')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "id": "id", "account_id": "account_id", "template_id": "template_id", "template_version": 16, "target_type": "target_type", "target": "target", "status": "status", "resources": [{"target": "target", "profile": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "account_settings": {"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}, "policy_template_refs": [{"id": "id", "version": "version", "resource_created": {"id": "id"}, "error_message": {"name": "name", "errorCode": "error_code", "message": "message", "statusCode": "status_code"}, "status": "status"}]}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "href": "href", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id", "entity_tag": "entity_tag"}'
+        responses.add(
+            responses.PATCH,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+        if_match = 'testString'
+        template_version = 1
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "assignment_id": assignment_id,
+            "if_match": if_match,
+            "template_version": template_version,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.update_trusted_profile_assignment(**req_copy)
+
+    def test_update_trusted_profile_assignment_value_error_with_retries(self):
+        # Enable retries and run test_update_trusted_profile_assignment_value_error.
+        _service.enable_retries()
+        self.test_update_trusted_profile_assignment_value_error()
+
+        # Disable retries and run test_update_trusted_profile_assignment_value_error.
+        _service.disable_retries()
+        self.test_update_trusted_profile_assignment_value_error()
+
+
+# endregion
+##############################################################################
+# End of Service: TrustedProfileAssignments
+##############################################################################
+
+##############################################################################
+# Start of Service: TrustedProfileTemplate
+##############################################################################
+# region
+
+
+class TestNewInstance:
+    """
+    Test Class for new_instance
+    """
+
+    def test_new_instance(self):
+        """
+        new_instance()
+        """
+        os.environ['TEST_SERVICE_AUTH_TYPE'] = 'noAuth'
+
+        service = IamIdentityV1.new_instance(
+            service_name='TEST_SERVICE',
+        )
+
+        assert service is not None
+        assert isinstance(service, IamIdentityV1)
+
+    def test_new_instance_without_authenticator(self):
+        """
+        new_instance_without_authenticator()
+        """
+        with pytest.raises(ValueError, match='authenticator must be provided'):
+            service = IamIdentityV1.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
+
+
+class TestListProfileTemplates:
+    """
+    Test Class for list_profile_templates
+    """
+
+    @responses.activate
+    def test_list_profile_templates_all_params(self):
+        """
+        list_profile_templates()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 20, "first": "first", "previous": "previous", "next": "next", "profile_templates": [{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "profile": {"name": "name", "description": "description", "rules": [{"name": "name", "type": "Profile-SAML", "realm_name": "realm_name", "expiration": 10, "conditions": [{"claim": "claim", "operator": "operator", "value": "value"}]}], "identities": [{"iam_id": "iam_id", "identifier": "identifier", "type": "user", "accounts": ["accounts"], "description": "description"}]}, "policy_template_references": [{"id": "id", "version": "version"}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        account_id = 'testString'
+        limit = '20'
+        pagetoken = 'testString'
+        sort = 'created_at'
+        order = 'asc'
+        include_history = 'false'
+
+        # Invoke method
+        response = _service.list_profile_templates(
+            account_id=account_id,
+            limit=limit,
+            pagetoken=pagetoken,
+            sort=sort,
+            order=order,
+            include_history=include_history,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'account_id={}'.format(account_id) in query_string
+        assert 'limit={}'.format(limit) in query_string
+        assert 'pagetoken={}'.format(pagetoken) in query_string
+        assert 'sort={}'.format(sort) in query_string
+        assert 'order={}'.format(order) in query_string
+        assert 'include_history={}'.format(include_history) in query_string
+
+    def test_list_profile_templates_all_params_with_retries(self):
+        # Enable retries and run test_list_profile_templates_all_params.
+        _service.enable_retries()
+        self.test_list_profile_templates_all_params()
+
+        # Disable retries and run test_list_profile_templates_all_params.
+        _service.disable_retries()
+        self.test_list_profile_templates_all_params()
+
+    @responses.activate
+    def test_list_profile_templates_required_params(self):
+        """
+        test_list_profile_templates_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 20, "first": "first", "previous": "previous", "next": "next", "profile_templates": [{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "profile": {"name": "name", "description": "description", "rules": [{"name": "name", "type": "Profile-SAML", "realm_name": "realm_name", "expiration": 10, "conditions": [{"claim": "claim", "operator": "operator", "value": "value"}]}], "identities": [{"iam_id": "iam_id", "identifier": "identifier", "type": "user", "accounts": ["accounts"], "description": "description"}]}, "policy_template_references": [{"id": "id", "version": "version"}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Invoke method
+        response = _service.list_profile_templates()
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_list_profile_templates_required_params_with_retries(self):
+        # Enable retries and run test_list_profile_templates_required_params.
+        _service.enable_retries()
+        self.test_list_profile_templates_required_params()
+
+        # Disable retries and run test_list_profile_templates_required_params.
+        _service.disable_retries()
+        self.test_list_profile_templates_required_params()
+
+
+class TestCreateProfileTemplate:
+    """
+    Test Class for create_profile_template
+    """
+
+    @responses.activate
+    def test_create_profile_template_all_params(self):
+        """
+        create_profile_template()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "profile": {"name": "name", "description": "description", "rules": [{"name": "name", "type": "Profile-SAML", "realm_name": "realm_name", "expiration": 10, "conditions": [{"claim": "claim", "operator": "operator", "value": "value"}]}], "identities": [{"iam_id": "iam_id", "identifier": "identifier", "type": "user", "accounts": ["accounts"], "description": "description"}]}, "policy_template_references": [{"id": "id", "version": "version"}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.POST,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=201,
+        )
+
+        # Construct a dict representation of a ProfileClaimRuleConditions model
+        profile_claim_rule_conditions_model = {}
+        profile_claim_rule_conditions_model['claim'] = 'testString'
+        profile_claim_rule_conditions_model['operator'] = 'testString'
+        profile_claim_rule_conditions_model['value'] = 'testString'
+
+        # Construct a dict representation of a TrustedProfileTemplateClaimRule model
+        trusted_profile_template_claim_rule_model = {}
+        trusted_profile_template_claim_rule_model['name'] = 'testString'
+        trusted_profile_template_claim_rule_model['type'] = 'Profile-SAML'
+        trusted_profile_template_claim_rule_model['realm_name'] = 'testString'
+        trusted_profile_template_claim_rule_model['expiration'] = 38
+        trusted_profile_template_claim_rule_model['conditions'] = [profile_claim_rule_conditions_model]
+
+        # Construct a dict representation of a ProfileIdentityRequest model
+        profile_identity_request_model = {}
+        profile_identity_request_model['identifier'] = 'testString'
+        profile_identity_request_model['type'] = 'user'
+        profile_identity_request_model['accounts'] = ['testString']
+        profile_identity_request_model['description'] = 'testString'
+
+        # Construct a dict representation of a TemplateProfileComponentRequest model
+        template_profile_component_request_model = {}
+        template_profile_component_request_model['name'] = 'testString'
+        template_profile_component_request_model['description'] = 'testString'
+        template_profile_component_request_model['rules'] = [trusted_profile_template_claim_rule_model]
+        template_profile_component_request_model['identities'] = [profile_identity_request_model]
+
+        # Construct a dict representation of a PolicyTemplateReference model
+        policy_template_reference_model = {}
+        policy_template_reference_model['id'] = 'testString'
+        policy_template_reference_model['version'] = 'testString'
+
+        # Set up parameter values
+        account_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+        profile = template_profile_component_request_model
+        policy_template_references = [policy_template_reference_model]
+
+        # Invoke method
+        response = _service.create_profile_template(
+            account_id=account_id,
+            name=name,
+            description=description,
+            profile=profile,
+            policy_template_references=policy_template_references,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['account_id'] == 'testString'
+        assert req_body['name'] == 'testString'
+        assert req_body['description'] == 'testString'
+        assert req_body['profile'] == template_profile_component_request_model
+        assert req_body['policy_template_references'] == [policy_template_reference_model]
+
+    def test_create_profile_template_all_params_with_retries(self):
+        # Enable retries and run test_create_profile_template_all_params.
+        _service.enable_retries()
+        self.test_create_profile_template_all_params()
+
+        # Disable retries and run test_create_profile_template_all_params.
+        _service.disable_retries()
+        self.test_create_profile_template_all_params()
+
+
+class TestGetLatestProfileTemplateVersion:
+    """
+    Test Class for get_latest_profile_template_version
+    """
+
+    @responses.activate
+    def test_get_latest_profile_template_version_all_params(self):
+        """
+        get_latest_profile_template_version()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "profile": {"name": "name", "description": "description", "rules": [{"name": "name", "type": "Profile-SAML", "realm_name": "realm_name", "expiration": 10, "conditions": [{"claim": "claim", "operator": "operator", "value": "value"}]}], "identities": [{"iam_id": "iam_id", "identifier": "identifier", "type": "user", "accounts": ["accounts"], "description": "description"}]}, "policy_template_references": [{"id": "id", "version": "version"}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        include_history = False
+
+        # Invoke method
+        response = _service.get_latest_profile_template_version(
+            template_id,
+            include_history=include_history,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'include_history={}'.format('true' if include_history else 'false') in query_string
+
+    def test_get_latest_profile_template_version_all_params_with_retries(self):
+        # Enable retries and run test_get_latest_profile_template_version_all_params.
+        _service.enable_retries()
+        self.test_get_latest_profile_template_version_all_params()
+
+        # Disable retries and run test_get_latest_profile_template_version_all_params.
+        _service.disable_retries()
+        self.test_get_latest_profile_template_version_all_params()
+
+    @responses.activate
+    def test_get_latest_profile_template_version_required_params(self):
+        """
+        test_get_latest_profile_template_version_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "profile": {"name": "name", "description": "description", "rules": [{"name": "name", "type": "Profile-SAML", "realm_name": "realm_name", "expiration": 10, "conditions": [{"claim": "claim", "operator": "operator", "value": "value"}]}], "identities": [{"iam_id": "iam_id", "identifier": "identifier", "type": "user", "accounts": ["accounts"], "description": "description"}]}, "policy_template_references": [{"id": "id", "version": "version"}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+
+        # Invoke method
+        response = _service.get_latest_profile_template_version(
+            template_id,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_latest_profile_template_version_required_params_with_retries(self):
+        # Enable retries and run test_get_latest_profile_template_version_required_params.
+        _service.enable_retries()
+        self.test_get_latest_profile_template_version_required_params()
+
+        # Disable retries and run test_get_latest_profile_template_version_required_params.
+        _service.disable_retries()
+        self.test_get_latest_profile_template_version_required_params()
+
+    @responses.activate
+    def test_get_latest_profile_template_version_value_error(self):
+        """
+        test_get_latest_profile_template_version_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "profile": {"name": "name", "description": "description", "rules": [{"name": "name", "type": "Profile-SAML", "realm_name": "realm_name", "expiration": 10, "conditions": [{"claim": "claim", "operator": "operator", "value": "value"}]}], "identities": [{"iam_id": "iam_id", "identifier": "identifier", "type": "user", "accounts": ["accounts"], "description": "description"}]}, "policy_template_references": [{"id": "id", "version": "version"}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "template_id": template_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_latest_profile_template_version(**req_copy)
+
+    def test_get_latest_profile_template_version_value_error_with_retries(self):
+        # Enable retries and run test_get_latest_profile_template_version_value_error.
+        _service.enable_retries()
+        self.test_get_latest_profile_template_version_value_error()
+
+        # Disable retries and run test_get_latest_profile_template_version_value_error.
+        _service.disable_retries()
+        self.test_get_latest_profile_template_version_value_error()
+
+
+class TestDeleteAllVersionsOfProfileTemplate:
+    """
+    Test Class for delete_all_versions_of_profile_template
+    """
+
+    @responses.activate
+    def test_delete_all_versions_of_profile_template_all_params(self):
+        """
+        delete_all_versions_of_profile_template()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString')
+        responses.add(
+            responses.DELETE,
+            url,
+            status=204,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+
+        # Invoke method
+        response = _service.delete_all_versions_of_profile_template(
+            template_id,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_delete_all_versions_of_profile_template_all_params_with_retries(self):
+        # Enable retries and run test_delete_all_versions_of_profile_template_all_params.
+        _service.enable_retries()
+        self.test_delete_all_versions_of_profile_template_all_params()
+
+        # Disable retries and run test_delete_all_versions_of_profile_template_all_params.
+        _service.disable_retries()
+        self.test_delete_all_versions_of_profile_template_all_params()
+
+    @responses.activate
+    def test_delete_all_versions_of_profile_template_value_error(self):
+        """
+        test_delete_all_versions_of_profile_template_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString')
+        responses.add(
+            responses.DELETE,
+            url,
+            status=204,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "template_id": template_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_all_versions_of_profile_template(**req_copy)
+
+    def test_delete_all_versions_of_profile_template_value_error_with_retries(self):
+        # Enable retries and run test_delete_all_versions_of_profile_template_value_error.
+        _service.enable_retries()
+        self.test_delete_all_versions_of_profile_template_value_error()
+
+        # Disable retries and run test_delete_all_versions_of_profile_template_value_error.
+        _service.disable_retries()
+        self.test_delete_all_versions_of_profile_template_value_error()
+
+
+class TestListVersionsOfProfileTemplate:
+    """
+    Test Class for list_versions_of_profile_template
+    """
+
+    @responses.activate
+    def test_list_versions_of_profile_template_all_params(self):
+        """
+        list_versions_of_profile_template()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString/versions')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 20, "first": "first", "previous": "previous", "next": "next", "profile_templates": [{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "profile": {"name": "name", "description": "description", "rules": [{"name": "name", "type": "Profile-SAML", "realm_name": "realm_name", "expiration": 10, "conditions": [{"claim": "claim", "operator": "operator", "value": "value"}]}], "identities": [{"iam_id": "iam_id", "identifier": "identifier", "type": "user", "accounts": ["accounts"], "description": "description"}]}, "policy_template_references": [{"id": "id", "version": "version"}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        limit = '20'
+        pagetoken = 'testString'
+        sort = 'created_at'
+        order = 'asc'
+        include_history = 'false'
+
+        # Invoke method
+        response = _service.list_versions_of_profile_template(
+            template_id,
+            limit=limit,
+            pagetoken=pagetoken,
+            sort=sort,
+            order=order,
+            include_history=include_history,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'limit={}'.format(limit) in query_string
+        assert 'pagetoken={}'.format(pagetoken) in query_string
+        assert 'sort={}'.format(sort) in query_string
+        assert 'order={}'.format(order) in query_string
+        assert 'include_history={}'.format(include_history) in query_string
+
+    def test_list_versions_of_profile_template_all_params_with_retries(self):
+        # Enable retries and run test_list_versions_of_profile_template_all_params.
+        _service.enable_retries()
+        self.test_list_versions_of_profile_template_all_params()
+
+        # Disable retries and run test_list_versions_of_profile_template_all_params.
+        _service.disable_retries()
+        self.test_list_versions_of_profile_template_all_params()
+
+    @responses.activate
+    def test_list_versions_of_profile_template_required_params(self):
+        """
+        test_list_versions_of_profile_template_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString/versions')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 20, "first": "first", "previous": "previous", "next": "next", "profile_templates": [{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "profile": {"name": "name", "description": "description", "rules": [{"name": "name", "type": "Profile-SAML", "realm_name": "realm_name", "expiration": 10, "conditions": [{"claim": "claim", "operator": "operator", "value": "value"}]}], "identities": [{"iam_id": "iam_id", "identifier": "identifier", "type": "user", "accounts": ["accounts"], "description": "description"}]}, "policy_template_references": [{"id": "id", "version": "version"}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+
+        # Invoke method
+        response = _service.list_versions_of_profile_template(
+            template_id,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_list_versions_of_profile_template_required_params_with_retries(self):
+        # Enable retries and run test_list_versions_of_profile_template_required_params.
+        _service.enable_retries()
+        self.test_list_versions_of_profile_template_required_params()
+
+        # Disable retries and run test_list_versions_of_profile_template_required_params.
+        _service.disable_retries()
+        self.test_list_versions_of_profile_template_required_params()
+
+    @responses.activate
+    def test_list_versions_of_profile_template_value_error(self):
+        """
+        test_list_versions_of_profile_template_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString/versions')
+        mock_response = '{"context": {"transaction_id": "transaction_id", "operation": "operation", "user_agent": "user_agent", "url": "url", "instance_id": "instance_id", "thread_id": "thread_id", "host": "host", "start_time": "start_time", "end_time": "end_time", "elapsed_time": "elapsed_time", "cluster_name": "cluster_name"}, "offset": 6, "limit": 20, "first": "first", "previous": "previous", "next": "next", "profile_templates": [{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "profile": {"name": "name", "description": "description", "rules": [{"name": "name", "type": "Profile-SAML", "realm_name": "realm_name", "expiration": 10, "conditions": [{"claim": "claim", "operator": "operator", "value": "value"}]}], "identities": [{"iam_id": "iam_id", "identifier": "identifier", "type": "user", "accounts": ["accounts"], "description": "description"}]}, "policy_template_references": [{"id": "id", "version": "version"}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "template_id": template_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.list_versions_of_profile_template(**req_copy)
+
+    def test_list_versions_of_profile_template_value_error_with_retries(self):
+        # Enable retries and run test_list_versions_of_profile_template_value_error.
+        _service.enable_retries()
+        self.test_list_versions_of_profile_template_value_error()
+
+        # Disable retries and run test_list_versions_of_profile_template_value_error.
+        _service.disable_retries()
+        self.test_list_versions_of_profile_template_value_error()
+
+
+class TestCreateProfileTemplateVersion:
+    """
+    Test Class for create_profile_template_version
+    """
+
+    @responses.activate
+    def test_create_profile_template_version_all_params(self):
+        """
+        create_profile_template_version()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString/versions')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "profile": {"name": "name", "description": "description", "rules": [{"name": "name", "type": "Profile-SAML", "realm_name": "realm_name", "expiration": 10, "conditions": [{"claim": "claim", "operator": "operator", "value": "value"}]}], "identities": [{"iam_id": "iam_id", "identifier": "identifier", "type": "user", "accounts": ["accounts"], "description": "description"}]}, "policy_template_references": [{"id": "id", "version": "version"}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.POST,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=201,
+        )
+
+        # Construct a dict representation of a ProfileClaimRuleConditions model
+        profile_claim_rule_conditions_model = {}
+        profile_claim_rule_conditions_model['claim'] = 'testString'
+        profile_claim_rule_conditions_model['operator'] = 'testString'
+        profile_claim_rule_conditions_model['value'] = 'testString'
+
+        # Construct a dict representation of a TrustedProfileTemplateClaimRule model
+        trusted_profile_template_claim_rule_model = {}
+        trusted_profile_template_claim_rule_model['name'] = 'testString'
+        trusted_profile_template_claim_rule_model['type'] = 'Profile-SAML'
+        trusted_profile_template_claim_rule_model['realm_name'] = 'testString'
+        trusted_profile_template_claim_rule_model['expiration'] = 38
+        trusted_profile_template_claim_rule_model['conditions'] = [profile_claim_rule_conditions_model]
+
+        # Construct a dict representation of a ProfileIdentityRequest model
+        profile_identity_request_model = {}
+        profile_identity_request_model['identifier'] = 'testString'
+        profile_identity_request_model['type'] = 'user'
+        profile_identity_request_model['accounts'] = ['testString']
+        profile_identity_request_model['description'] = 'testString'
+
+        # Construct a dict representation of a TemplateProfileComponentRequest model
+        template_profile_component_request_model = {}
+        template_profile_component_request_model['name'] = 'testString'
+        template_profile_component_request_model['description'] = 'testString'
+        template_profile_component_request_model['rules'] = [trusted_profile_template_claim_rule_model]
+        template_profile_component_request_model['identities'] = [profile_identity_request_model]
+
+        # Construct a dict representation of a PolicyTemplateReference model
+        policy_template_reference_model = {}
+        policy_template_reference_model['id'] = 'testString'
+        policy_template_reference_model['version'] = 'testString'
+
+        # Set up parameter values
+        template_id = 'testString'
+        account_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+        profile = template_profile_component_request_model
+        policy_template_references = [policy_template_reference_model]
+
+        # Invoke method
+        response = _service.create_profile_template_version(
+            template_id,
+            account_id=account_id,
+            name=name,
+            description=description,
+            profile=profile,
+            policy_template_references=policy_template_references,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['account_id'] == 'testString'
+        assert req_body['name'] == 'testString'
+        assert req_body['description'] == 'testString'
+        assert req_body['profile'] == template_profile_component_request_model
+        assert req_body['policy_template_references'] == [policy_template_reference_model]
+
+    def test_create_profile_template_version_all_params_with_retries(self):
+        # Enable retries and run test_create_profile_template_version_all_params.
+        _service.enable_retries()
+        self.test_create_profile_template_version_all_params()
+
+        # Disable retries and run test_create_profile_template_version_all_params.
+        _service.disable_retries()
+        self.test_create_profile_template_version_all_params()
+
+    @responses.activate
+    def test_create_profile_template_version_value_error(self):
+        """
+        test_create_profile_template_version_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString/versions')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "profile": {"name": "name", "description": "description", "rules": [{"name": "name", "type": "Profile-SAML", "realm_name": "realm_name", "expiration": 10, "conditions": [{"claim": "claim", "operator": "operator", "value": "value"}]}], "identities": [{"iam_id": "iam_id", "identifier": "identifier", "type": "user", "accounts": ["accounts"], "description": "description"}]}, "policy_template_references": [{"id": "id", "version": "version"}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.POST,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=201,
+        )
+
+        # Construct a dict representation of a ProfileClaimRuleConditions model
+        profile_claim_rule_conditions_model = {}
+        profile_claim_rule_conditions_model['claim'] = 'testString'
+        profile_claim_rule_conditions_model['operator'] = 'testString'
+        profile_claim_rule_conditions_model['value'] = 'testString'
+
+        # Construct a dict representation of a TrustedProfileTemplateClaimRule model
+        trusted_profile_template_claim_rule_model = {}
+        trusted_profile_template_claim_rule_model['name'] = 'testString'
+        trusted_profile_template_claim_rule_model['type'] = 'Profile-SAML'
+        trusted_profile_template_claim_rule_model['realm_name'] = 'testString'
+        trusted_profile_template_claim_rule_model['expiration'] = 38
+        trusted_profile_template_claim_rule_model['conditions'] = [profile_claim_rule_conditions_model]
+
+        # Construct a dict representation of a ProfileIdentityRequest model
+        profile_identity_request_model = {}
+        profile_identity_request_model['identifier'] = 'testString'
+        profile_identity_request_model['type'] = 'user'
+        profile_identity_request_model['accounts'] = ['testString']
+        profile_identity_request_model['description'] = 'testString'
+
+        # Construct a dict representation of a TemplateProfileComponentRequest model
+        template_profile_component_request_model = {}
+        template_profile_component_request_model['name'] = 'testString'
+        template_profile_component_request_model['description'] = 'testString'
+        template_profile_component_request_model['rules'] = [trusted_profile_template_claim_rule_model]
+        template_profile_component_request_model['identities'] = [profile_identity_request_model]
+
+        # Construct a dict representation of a PolicyTemplateReference model
+        policy_template_reference_model = {}
+        policy_template_reference_model['id'] = 'testString'
+        policy_template_reference_model['version'] = 'testString'
+
+        # Set up parameter values
+        template_id = 'testString'
+        account_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+        profile = template_profile_component_request_model
+        policy_template_references = [policy_template_reference_model]
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "template_id": template_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.create_profile_template_version(**req_copy)
+
+    def test_create_profile_template_version_value_error_with_retries(self):
+        # Enable retries and run test_create_profile_template_version_value_error.
+        _service.enable_retries()
+        self.test_create_profile_template_version_value_error()
+
+        # Disable retries and run test_create_profile_template_version_value_error.
+        _service.disable_retries()
+        self.test_create_profile_template_version_value_error()
+
+
+class TestGetProfileTemplateVersion:
+    """
+    Test Class for get_profile_template_version
+    """
+
+    @responses.activate
+    def test_get_profile_template_version_all_params(self):
+        """
+        get_profile_template_version()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString/versions/testString')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "profile": {"name": "name", "description": "description", "rules": [{"name": "name", "type": "Profile-SAML", "realm_name": "realm_name", "expiration": 10, "conditions": [{"claim": "claim", "operator": "operator", "value": "value"}]}], "identities": [{"iam_id": "iam_id", "identifier": "identifier", "type": "user", "accounts": ["accounts"], "description": "description"}]}, "policy_template_references": [{"id": "id", "version": "version"}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        version = 'testString'
+        include_history = False
+
+        # Invoke method
+        response = _service.get_profile_template_version(
+            template_id,
+            version,
+            include_history=include_history,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'include_history={}'.format('true' if include_history else 'false') in query_string
+
+    def test_get_profile_template_version_all_params_with_retries(self):
+        # Enable retries and run test_get_profile_template_version_all_params.
+        _service.enable_retries()
+        self.test_get_profile_template_version_all_params()
+
+        # Disable retries and run test_get_profile_template_version_all_params.
+        _service.disable_retries()
+        self.test_get_profile_template_version_all_params()
+
+    @responses.activate
+    def test_get_profile_template_version_required_params(self):
+        """
+        test_get_profile_template_version_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString/versions/testString')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "profile": {"name": "name", "description": "description", "rules": [{"name": "name", "type": "Profile-SAML", "realm_name": "realm_name", "expiration": 10, "conditions": [{"claim": "claim", "operator": "operator", "value": "value"}]}], "identities": [{"iam_id": "iam_id", "identifier": "identifier", "type": "user", "accounts": ["accounts"], "description": "description"}]}, "policy_template_references": [{"id": "id", "version": "version"}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        version = 'testString'
+
+        # Invoke method
+        response = _service.get_profile_template_version(
+            template_id,
+            version,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_profile_template_version_required_params_with_retries(self):
+        # Enable retries and run test_get_profile_template_version_required_params.
+        _service.enable_retries()
+        self.test_get_profile_template_version_required_params()
+
+        # Disable retries and run test_get_profile_template_version_required_params.
+        _service.disable_retries()
+        self.test_get_profile_template_version_required_params()
+
+    @responses.activate
+    def test_get_profile_template_version_value_error(self):
+        """
+        test_get_profile_template_version_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString/versions/testString')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "profile": {"name": "name", "description": "description", "rules": [{"name": "name", "type": "Profile-SAML", "realm_name": "realm_name", "expiration": 10, "conditions": [{"claim": "claim", "operator": "operator", "value": "value"}]}], "identities": [{"iam_id": "iam_id", "identifier": "identifier", "type": "user", "accounts": ["accounts"], "description": "description"}]}, "policy_template_references": [{"id": "id", "version": "version"}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        version = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "template_id": template_id,
+            "version": version,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_profile_template_version(**req_copy)
+
+    def test_get_profile_template_version_value_error_with_retries(self):
+        # Enable retries and run test_get_profile_template_version_value_error.
+        _service.enable_retries()
+        self.test_get_profile_template_version_value_error()
+
+        # Disable retries and run test_get_profile_template_version_value_error.
+        _service.disable_retries()
+        self.test_get_profile_template_version_value_error()
+
+
+class TestUpdateProfileTemplateVersion:
+    """
+    Test Class for update_profile_template_version
+    """
+
+    @responses.activate
+    def test_update_profile_template_version_all_params(self):
+        """
+        update_profile_template_version()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString/versions/testString')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "profile": {"name": "name", "description": "description", "rules": [{"name": "name", "type": "Profile-SAML", "realm_name": "realm_name", "expiration": 10, "conditions": [{"claim": "claim", "operator": "operator", "value": "value"}]}], "identities": [{"iam_id": "iam_id", "identifier": "identifier", "type": "user", "accounts": ["accounts"], "description": "description"}]}, "policy_template_references": [{"id": "id", "version": "version"}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.PUT,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Construct a dict representation of a ProfileClaimRuleConditions model
+        profile_claim_rule_conditions_model = {}
+        profile_claim_rule_conditions_model['claim'] = 'testString'
+        profile_claim_rule_conditions_model['operator'] = 'testString'
+        profile_claim_rule_conditions_model['value'] = 'testString'
+
+        # Construct a dict representation of a TrustedProfileTemplateClaimRule model
+        trusted_profile_template_claim_rule_model = {}
+        trusted_profile_template_claim_rule_model['name'] = 'testString'
+        trusted_profile_template_claim_rule_model['type'] = 'Profile-SAML'
+        trusted_profile_template_claim_rule_model['realm_name'] = 'testString'
+        trusted_profile_template_claim_rule_model['expiration'] = 38
+        trusted_profile_template_claim_rule_model['conditions'] = [profile_claim_rule_conditions_model]
+
+        # Construct a dict representation of a ProfileIdentityRequest model
+        profile_identity_request_model = {}
+        profile_identity_request_model['identifier'] = 'testString'
+        profile_identity_request_model['type'] = 'user'
+        profile_identity_request_model['accounts'] = ['testString']
+        profile_identity_request_model['description'] = 'testString'
+
+        # Construct a dict representation of a TemplateProfileComponentRequest model
+        template_profile_component_request_model = {}
+        template_profile_component_request_model['name'] = 'testString'
+        template_profile_component_request_model['description'] = 'testString'
+        template_profile_component_request_model['rules'] = [trusted_profile_template_claim_rule_model]
+        template_profile_component_request_model['identities'] = [profile_identity_request_model]
+
+        # Construct a dict representation of a PolicyTemplateReference model
+        policy_template_reference_model = {}
+        policy_template_reference_model['id'] = 'testString'
+        policy_template_reference_model['version'] = 'testString'
+
+        # Set up parameter values
+        if_match = 'testString'
+        template_id = 'testString'
+        version = 'testString'
+        account_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+        profile = template_profile_component_request_model
+        policy_template_references = [policy_template_reference_model]
+
+        # Invoke method
+        response = _service.update_profile_template_version(
+            if_match,
+            template_id,
+            version,
+            account_id=account_id,
+            name=name,
+            description=description,
+            profile=profile,
+            policy_template_references=policy_template_references,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['account_id'] == 'testString'
+        assert req_body['name'] == 'testString'
+        assert req_body['description'] == 'testString'
+        assert req_body['profile'] == template_profile_component_request_model
+        assert req_body['policy_template_references'] == [policy_template_reference_model]
+
+    def test_update_profile_template_version_all_params_with_retries(self):
+        # Enable retries and run test_update_profile_template_version_all_params.
+        _service.enable_retries()
+        self.test_update_profile_template_version_all_params()
+
+        # Disable retries and run test_update_profile_template_version_all_params.
+        _service.disable_retries()
+        self.test_update_profile_template_version_all_params()
+
+    @responses.activate
+    def test_update_profile_template_version_value_error(self):
+        """
+        test_update_profile_template_version_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString/versions/testString')
+        mock_response = '{"id": "id", "version": 7, "account_id": "account_id", "name": "name", "description": "description", "committed": false, "profile": {"name": "name", "description": "description", "rules": [{"name": "name", "type": "Profile-SAML", "realm_name": "realm_name", "expiration": 10, "conditions": [{"claim": "claim", "operator": "operator", "value": "value"}]}], "identities": [{"iam_id": "iam_id", "identifier": "identifier", "type": "user", "accounts": ["accounts"], "description": "description"}]}, "policy_template_references": [{"id": "id", "version": "version"}], "history": [{"timestamp": "timestamp", "iam_id": "iam_id", "iam_id_account": "iam_id_account", "action": "action", "params": ["params"], "message": "message"}], "entity_tag": "entity_tag", "crn": "crn", "created_at": "created_at", "created_by_id": "created_by_id", "last_modified_at": "last_modified_at", "last_modified_by_id": "last_modified_by_id"}'
+        responses.add(
+            responses.PUT,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Construct a dict representation of a ProfileClaimRuleConditions model
+        profile_claim_rule_conditions_model = {}
+        profile_claim_rule_conditions_model['claim'] = 'testString'
+        profile_claim_rule_conditions_model['operator'] = 'testString'
+        profile_claim_rule_conditions_model['value'] = 'testString'
+
+        # Construct a dict representation of a TrustedProfileTemplateClaimRule model
+        trusted_profile_template_claim_rule_model = {}
+        trusted_profile_template_claim_rule_model['name'] = 'testString'
+        trusted_profile_template_claim_rule_model['type'] = 'Profile-SAML'
+        trusted_profile_template_claim_rule_model['realm_name'] = 'testString'
+        trusted_profile_template_claim_rule_model['expiration'] = 38
+        trusted_profile_template_claim_rule_model['conditions'] = [profile_claim_rule_conditions_model]
+
+        # Construct a dict representation of a ProfileIdentityRequest model
+        profile_identity_request_model = {}
+        profile_identity_request_model['identifier'] = 'testString'
+        profile_identity_request_model['type'] = 'user'
+        profile_identity_request_model['accounts'] = ['testString']
+        profile_identity_request_model['description'] = 'testString'
+
+        # Construct a dict representation of a TemplateProfileComponentRequest model
+        template_profile_component_request_model = {}
+        template_profile_component_request_model['name'] = 'testString'
+        template_profile_component_request_model['description'] = 'testString'
+        template_profile_component_request_model['rules'] = [trusted_profile_template_claim_rule_model]
+        template_profile_component_request_model['identities'] = [profile_identity_request_model]
+
+        # Construct a dict representation of a PolicyTemplateReference model
+        policy_template_reference_model = {}
+        policy_template_reference_model['id'] = 'testString'
+        policy_template_reference_model['version'] = 'testString'
+
+        # Set up parameter values
+        if_match = 'testString'
+        template_id = 'testString'
+        version = 'testString'
+        account_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+        profile = template_profile_component_request_model
+        policy_template_references = [policy_template_reference_model]
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "if_match": if_match,
+            "template_id": template_id,
+            "version": version,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.update_profile_template_version(**req_copy)
+
+    def test_update_profile_template_version_value_error_with_retries(self):
+        # Enable retries and run test_update_profile_template_version_value_error.
+        _service.enable_retries()
+        self.test_update_profile_template_version_value_error()
+
+        # Disable retries and run test_update_profile_template_version_value_error.
+        _service.disable_retries()
+        self.test_update_profile_template_version_value_error()
+
+
+class TestDeleteProfileTemplateVersion:
+    """
+    Test Class for delete_profile_template_version
+    """
+
+    @responses.activate
+    def test_delete_profile_template_version_all_params(self):
+        """
+        delete_profile_template_version()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString/versions/testString')
+        responses.add(
+            responses.DELETE,
+            url,
+            status=204,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        version = 'testString'
+
+        # Invoke method
+        response = _service.delete_profile_template_version(
+            template_id,
+            version,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_delete_profile_template_version_all_params_with_retries(self):
+        # Enable retries and run test_delete_profile_template_version_all_params.
+        _service.enable_retries()
+        self.test_delete_profile_template_version_all_params()
+
+        # Disable retries and run test_delete_profile_template_version_all_params.
+        _service.disable_retries()
+        self.test_delete_profile_template_version_all_params()
+
+    @responses.activate
+    def test_delete_profile_template_version_value_error(self):
+        """
+        test_delete_profile_template_version_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString/versions/testString')
+        responses.add(
+            responses.DELETE,
+            url,
+            status=204,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        version = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "template_id": template_id,
+            "version": version,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_profile_template_version(**req_copy)
+
+    def test_delete_profile_template_version_value_error_with_retries(self):
+        # Enable retries and run test_delete_profile_template_version_value_error.
+        _service.enable_retries()
+        self.test_delete_profile_template_version_value_error()
+
+        # Disable retries and run test_delete_profile_template_version_value_error.
+        _service.disable_retries()
+        self.test_delete_profile_template_version_value_error()
+
+
+class TestCommitProfileTemplate:
+    """
+    Test Class for commit_profile_template
+    """
+
+    @responses.activate
+    def test_commit_profile_template_all_params(self):
+        """
+        commit_profile_template()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString/versions/testString/commit')
+        responses.add(
+            responses.POST,
+            url,
+            status=204,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        version = 'testString'
+
+        # Invoke method
+        response = _service.commit_profile_template(
+            template_id,
+            version,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_commit_profile_template_all_params_with_retries(self):
+        # Enable retries and run test_commit_profile_template_all_params.
+        _service.enable_retries()
+        self.test_commit_profile_template_all_params()
+
+        # Disable retries and run test_commit_profile_template_all_params.
+        _service.disable_retries()
+        self.test_commit_profile_template_all_params()
+
+    @responses.activate
+    def test_commit_profile_template_value_error(self):
+        """
+        test_commit_profile_template_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/profile_templates/testString/versions/testString/commit')
+        responses.add(
+            responses.POST,
+            url,
+            status=204,
+        )
+
+        # Set up parameter values
+        template_id = 'testString'
+        version = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "template_id": template_id,
+            "version": version,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.commit_profile_template(**req_copy)
+
+    def test_commit_profile_template_value_error_with_retries(self):
+        # Enable retries and run test_commit_profile_template_value_error.
+        _service.enable_retries()
+        self.test_commit_profile_template_value_error()
+
+        # Disable retries and run test_commit_profile_template_value_error.
+        _service.disable_retries()
+        self.test_commit_profile_template_value_error()
+
+
+# endregion
+##############################################################################
+# End of Service: TrustedProfileTemplate
+##############################################################################
+
 
 ##############################################################################
 # Start of Model Tests
@@ -4541,15 +7933,11 @@ class TestModel_AccountBasedMfaEnrollment:
         account_based_mfa_enrollment_model_json['complies'] = True
 
         # Construct a model instance of AccountBasedMfaEnrollment by calling from_dict on the json representation
-        account_based_mfa_enrollment_model = AccountBasedMfaEnrollment.from_dict(
-            account_based_mfa_enrollment_model_json
-        )
+        account_based_mfa_enrollment_model = AccountBasedMfaEnrollment.from_dict(account_based_mfa_enrollment_model_json)
         assert account_based_mfa_enrollment_model != False
 
         # Construct a model instance of AccountBasedMfaEnrollment by calling from_dict on the json representation
-        account_based_mfa_enrollment_model_dict = AccountBasedMfaEnrollment.from_dict(
-            account_based_mfa_enrollment_model_json
-        ).__dict__
+        account_based_mfa_enrollment_model_dict = AccountBasedMfaEnrollment.from_dict(account_based_mfa_enrollment_model_json).__dict__
         account_based_mfa_enrollment_model2 = AccountBasedMfaEnrollment(**account_based_mfa_enrollment_model_dict)
 
         # Verify the model instances are equivalent
@@ -4558,6 +7946,51 @@ class TestModel_AccountBasedMfaEnrollment:
         # Convert model instance back to dict and verify no loss of data
         account_based_mfa_enrollment_model_json2 = account_based_mfa_enrollment_model.to_dict()
         assert account_based_mfa_enrollment_model_json2 == account_based_mfa_enrollment_model_json
+
+
+class TestModel_AccountSettingsComponent:
+    """
+    Test Class for AccountSettingsComponent
+    """
+
+    def test_account_settings_component_serialization(self):
+        """
+        Test serialization/deserialization for AccountSettingsComponent
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        account_settings_user_mfa_model = {}  # AccountSettingsUserMFA
+        account_settings_user_mfa_model['iam_id'] = 'testString'
+        account_settings_user_mfa_model['mfa'] = 'NONE'
+
+        # Construct a json representation of a AccountSettingsComponent model
+        account_settings_component_model_json = {}
+        account_settings_component_model_json['restrict_create_service_id'] = 'NOT_SET'
+        account_settings_component_model_json['restrict_create_platform_apikey'] = 'NOT_SET'
+        account_settings_component_model_json['allowed_ip_addresses'] = 'testString'
+        account_settings_component_model_json['mfa'] = 'NONE'
+        account_settings_component_model_json['user_mfa'] = [account_settings_user_mfa_model]
+        account_settings_component_model_json['session_expiration_in_seconds'] = '86400'
+        account_settings_component_model_json['session_invalidation_in_seconds'] = '7200'
+        account_settings_component_model_json['max_sessions_per_identity'] = 'testString'
+        account_settings_component_model_json['system_access_token_expiration_in_seconds'] = '3600'
+        account_settings_component_model_json['system_refresh_token_expiration_in_seconds'] = '259200'
+
+        # Construct a model instance of AccountSettingsComponent by calling from_dict on the json representation
+        account_settings_component_model = AccountSettingsComponent.from_dict(account_settings_component_model_json)
+        assert account_settings_component_model != False
+
+        # Construct a model instance of AccountSettingsComponent by calling from_dict on the json representation
+        account_settings_component_model_dict = AccountSettingsComponent.from_dict(account_settings_component_model_json).__dict__
+        account_settings_component_model2 = AccountSettingsComponent(**account_settings_component_model_dict)
+
+        # Verify the model instances are equivalent
+        assert account_settings_component_model == account_settings_component_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        account_settings_component_model_json2 = account_settings_component_model.to_dict()
+        assert account_settings_component_model_json2 == account_settings_component_model_json
 
 
 class TestModel_AccountSettingsResponse:
@@ -4619,9 +8052,7 @@ class TestModel_AccountSettingsResponse:
         assert account_settings_response_model != False
 
         # Construct a model instance of AccountSettingsResponse by calling from_dict on the json representation
-        account_settings_response_model_dict = AccountSettingsResponse.from_dict(
-            account_settings_response_model_json
-        ).__dict__
+        account_settings_response_model_dict = AccountSettingsResponse.from_dict(account_settings_response_model_json).__dict__
         account_settings_response_model2 = AccountSettingsResponse(**account_settings_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -4630,6 +8061,166 @@ class TestModel_AccountSettingsResponse:
         # Convert model instance back to dict and verify no loss of data
         account_settings_response_model_json2 = account_settings_response_model.to_dict()
         assert account_settings_response_model_json2 == account_settings_response_model_json
+
+
+class TestModel_AccountSettingsTemplateList:
+    """
+    Test Class for AccountSettingsTemplateList
+    """
+
+    def test_account_settings_template_list_serialization(self):
+        """
+        Test serialization/deserialization for AccountSettingsTemplateList
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        response_context_model = {}  # ResponseContext
+        response_context_model['transaction_id'] = 'testString'
+        response_context_model['operation'] = 'testString'
+        response_context_model['user_agent'] = 'testString'
+        response_context_model['url'] = 'testString'
+        response_context_model['instance_id'] = 'testString'
+        response_context_model['thread_id'] = 'testString'
+        response_context_model['host'] = 'testString'
+        response_context_model['start_time'] = 'testString'
+        response_context_model['end_time'] = 'testString'
+        response_context_model['elapsed_time'] = 'testString'
+        response_context_model['cluster_name'] = 'testString'
+
+        account_settings_user_mfa_model = {}  # AccountSettingsUserMFA
+        account_settings_user_mfa_model['iam_id'] = 'testString'
+        account_settings_user_mfa_model['mfa'] = 'NONE'
+
+        account_settings_component_model = {}  # AccountSettingsComponent
+        account_settings_component_model['restrict_create_service_id'] = 'NOT_SET'
+        account_settings_component_model['restrict_create_platform_apikey'] = 'NOT_SET'
+        account_settings_component_model['allowed_ip_addresses'] = 'testString'
+        account_settings_component_model['mfa'] = 'NONE'
+        account_settings_component_model['user_mfa'] = [account_settings_user_mfa_model]
+        account_settings_component_model['session_expiration_in_seconds'] = '86400'
+        account_settings_component_model['session_invalidation_in_seconds'] = '7200'
+        account_settings_component_model['max_sessions_per_identity'] = 'testString'
+        account_settings_component_model['system_access_token_expiration_in_seconds'] = '3600'
+        account_settings_component_model['system_refresh_token_expiration_in_seconds'] = '259200'
+
+        enity_history_record_model = {}  # EnityHistoryRecord
+        enity_history_record_model['timestamp'] = 'testString'
+        enity_history_record_model['iam_id'] = 'testString'
+        enity_history_record_model['iam_id_account'] = 'testString'
+        enity_history_record_model['action'] = 'testString'
+        enity_history_record_model['params'] = ['testString']
+        enity_history_record_model['message'] = 'testString'
+
+        account_settings_template_response_model = {}  # AccountSettingsTemplateResponse
+        account_settings_template_response_model['id'] = 'testString'
+        account_settings_template_response_model['version'] = 26
+        account_settings_template_response_model['account_id'] = 'testString'
+        account_settings_template_response_model['name'] = 'testString'
+        account_settings_template_response_model['description'] = 'testString'
+        account_settings_template_response_model['committed'] = True
+        account_settings_template_response_model['account_settings'] = account_settings_component_model
+        account_settings_template_response_model['history'] = [enity_history_record_model]
+        account_settings_template_response_model['entity_tag'] = 'testString'
+        account_settings_template_response_model['crn'] = 'testString'
+        account_settings_template_response_model['created_at'] = 'testString'
+        account_settings_template_response_model['created_by_id'] = 'testString'
+        account_settings_template_response_model['last_modified_at'] = 'testString'
+        account_settings_template_response_model['last_modified_by_id'] = 'testString'
+
+        # Construct a json representation of a AccountSettingsTemplateList model
+        account_settings_template_list_model_json = {}
+        account_settings_template_list_model_json['context'] = response_context_model
+        account_settings_template_list_model_json['offset'] = 26
+        account_settings_template_list_model_json['limit'] = 20
+        account_settings_template_list_model_json['first'] = 'testString'
+        account_settings_template_list_model_json['previous'] = 'testString'
+        account_settings_template_list_model_json['next'] = 'testString'
+        account_settings_template_list_model_json['account_settings_templates'] = [account_settings_template_response_model]
+
+        # Construct a model instance of AccountSettingsTemplateList by calling from_dict on the json representation
+        account_settings_template_list_model = AccountSettingsTemplateList.from_dict(account_settings_template_list_model_json)
+        assert account_settings_template_list_model != False
+
+        # Construct a model instance of AccountSettingsTemplateList by calling from_dict on the json representation
+        account_settings_template_list_model_dict = AccountSettingsTemplateList.from_dict(account_settings_template_list_model_json).__dict__
+        account_settings_template_list_model2 = AccountSettingsTemplateList(**account_settings_template_list_model_dict)
+
+        # Verify the model instances are equivalent
+        assert account_settings_template_list_model == account_settings_template_list_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        account_settings_template_list_model_json2 = account_settings_template_list_model.to_dict()
+        assert account_settings_template_list_model_json2 == account_settings_template_list_model_json
+
+
+class TestModel_AccountSettingsTemplateResponse:
+    """
+    Test Class for AccountSettingsTemplateResponse
+    """
+
+    def test_account_settings_template_response_serialization(self):
+        """
+        Test serialization/deserialization for AccountSettingsTemplateResponse
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        account_settings_user_mfa_model = {}  # AccountSettingsUserMFA
+        account_settings_user_mfa_model['iam_id'] = 'testString'
+        account_settings_user_mfa_model['mfa'] = 'NONE'
+
+        account_settings_component_model = {}  # AccountSettingsComponent
+        account_settings_component_model['restrict_create_service_id'] = 'NOT_SET'
+        account_settings_component_model['restrict_create_platform_apikey'] = 'NOT_SET'
+        account_settings_component_model['allowed_ip_addresses'] = 'testString'
+        account_settings_component_model['mfa'] = 'NONE'
+        account_settings_component_model['user_mfa'] = [account_settings_user_mfa_model]
+        account_settings_component_model['session_expiration_in_seconds'] = '86400'
+        account_settings_component_model['session_invalidation_in_seconds'] = '7200'
+        account_settings_component_model['max_sessions_per_identity'] = 'testString'
+        account_settings_component_model['system_access_token_expiration_in_seconds'] = '3600'
+        account_settings_component_model['system_refresh_token_expiration_in_seconds'] = '259200'
+
+        enity_history_record_model = {}  # EnityHistoryRecord
+        enity_history_record_model['timestamp'] = 'testString'
+        enity_history_record_model['iam_id'] = 'testString'
+        enity_history_record_model['iam_id_account'] = 'testString'
+        enity_history_record_model['action'] = 'testString'
+        enity_history_record_model['params'] = ['testString']
+        enity_history_record_model['message'] = 'testString'
+
+        # Construct a json representation of a AccountSettingsTemplateResponse model
+        account_settings_template_response_model_json = {}
+        account_settings_template_response_model_json['id'] = 'testString'
+        account_settings_template_response_model_json['version'] = 26
+        account_settings_template_response_model_json['account_id'] = 'testString'
+        account_settings_template_response_model_json['name'] = 'testString'
+        account_settings_template_response_model_json['description'] = 'testString'
+        account_settings_template_response_model_json['committed'] = True
+        account_settings_template_response_model_json['account_settings'] = account_settings_component_model
+        account_settings_template_response_model_json['history'] = [enity_history_record_model]
+        account_settings_template_response_model_json['entity_tag'] = 'testString'
+        account_settings_template_response_model_json['crn'] = 'testString'
+        account_settings_template_response_model_json['created_at'] = 'testString'
+        account_settings_template_response_model_json['created_by_id'] = 'testString'
+        account_settings_template_response_model_json['last_modified_at'] = 'testString'
+        account_settings_template_response_model_json['last_modified_by_id'] = 'testString'
+
+        # Construct a model instance of AccountSettingsTemplateResponse by calling from_dict on the json representation
+        account_settings_template_response_model = AccountSettingsTemplateResponse.from_dict(account_settings_template_response_model_json)
+        assert account_settings_template_response_model != False
+
+        # Construct a model instance of AccountSettingsTemplateResponse by calling from_dict on the json representation
+        account_settings_template_response_model_dict = AccountSettingsTemplateResponse.from_dict(account_settings_template_response_model_json).__dict__
+        account_settings_template_response_model2 = AccountSettingsTemplateResponse(**account_settings_template_response_model_dict)
+
+        # Verify the model instances are equivalent
+        assert account_settings_template_response_model == account_settings_template_response_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        account_settings_template_response_model_json2 = account_settings_template_response_model.to_dict()
+        assert account_settings_template_response_model_json2 == account_settings_template_response_model_json
 
 
 class TestModel_AccountSettingsUserMFA:
@@ -4652,9 +8243,7 @@ class TestModel_AccountSettingsUserMFA:
         assert account_settings_user_mfa_model != False
 
         # Construct a model instance of AccountSettingsUserMFA by calling from_dict on the json representation
-        account_settings_user_mfa_model_dict = AccountSettingsUserMFA.from_dict(
-            account_settings_user_mfa_model_json
-        ).__dict__
+        account_settings_user_mfa_model_dict = AccountSettingsUserMFA.from_dict(account_settings_user_mfa_model_json).__dict__
         account_settings_user_mfa_model2 = AccountSettingsUserMFA(**account_settings_user_mfa_model_dict)
 
         # Verify the model instances are equivalent
@@ -4785,27 +8374,19 @@ class TestModel_ApiKeyInsideCreateServiceIdRequest:
         api_key_inside_create_service_id_request_model_json['store_value'] = True
 
         # Construct a model instance of ApiKeyInsideCreateServiceIdRequest by calling from_dict on the json representation
-        api_key_inside_create_service_id_request_model = ApiKeyInsideCreateServiceIdRequest.from_dict(
-            api_key_inside_create_service_id_request_model_json
-        )
+        api_key_inside_create_service_id_request_model = ApiKeyInsideCreateServiceIdRequest.from_dict(api_key_inside_create_service_id_request_model_json)
         assert api_key_inside_create_service_id_request_model != False
 
         # Construct a model instance of ApiKeyInsideCreateServiceIdRequest by calling from_dict on the json representation
-        api_key_inside_create_service_id_request_model_dict = ApiKeyInsideCreateServiceIdRequest.from_dict(
-            api_key_inside_create_service_id_request_model_json
-        ).__dict__
-        api_key_inside_create_service_id_request_model2 = ApiKeyInsideCreateServiceIdRequest(
-            **api_key_inside_create_service_id_request_model_dict
-        )
+        api_key_inside_create_service_id_request_model_dict = ApiKeyInsideCreateServiceIdRequest.from_dict(api_key_inside_create_service_id_request_model_json).__dict__
+        api_key_inside_create_service_id_request_model2 = ApiKeyInsideCreateServiceIdRequest(**api_key_inside_create_service_id_request_model_dict)
 
         # Verify the model instances are equivalent
         assert api_key_inside_create_service_id_request_model == api_key_inside_create_service_id_request_model2
 
         # Convert model instance back to dict and verify no loss of data
         api_key_inside_create_service_id_request_model_json2 = api_key_inside_create_service_id_request_model.to_dict()
-        assert (
-            api_key_inside_create_service_id_request_model_json2 == api_key_inside_create_service_id_request_model_json
-        )
+        assert api_key_inside_create_service_id_request_model_json2 == api_key_inside_create_service_id_request_model_json
 
 
 class TestModel_ApiKeyList:
@@ -4955,9 +8536,7 @@ class TestModel_ApikeyActivityServiceid:
         assert apikey_activity_serviceid_model != False
 
         # Construct a model instance of ApikeyActivityServiceid by calling from_dict on the json representation
-        apikey_activity_serviceid_model_dict = ApikeyActivityServiceid.from_dict(
-            apikey_activity_serviceid_model_json
-        ).__dict__
+        apikey_activity_serviceid_model_dict = ApikeyActivityServiceid.from_dict(apikey_activity_serviceid_model_json).__dict__
         apikey_activity_serviceid_model2 = ApikeyActivityServiceid(**apikey_activity_serviceid_model_dict)
 
         # Verify the model instances are equivalent
@@ -5018,18 +8597,12 @@ class TestModel_CreateProfileLinkRequestLink:
         create_profile_link_request_link_model_json['name'] = 'testString'
 
         # Construct a model instance of CreateProfileLinkRequestLink by calling from_dict on the json representation
-        create_profile_link_request_link_model = CreateProfileLinkRequestLink.from_dict(
-            create_profile_link_request_link_model_json
-        )
+        create_profile_link_request_link_model = CreateProfileLinkRequestLink.from_dict(create_profile_link_request_link_model_json)
         assert create_profile_link_request_link_model != False
 
         # Construct a model instance of CreateProfileLinkRequestLink by calling from_dict on the json representation
-        create_profile_link_request_link_model_dict = CreateProfileLinkRequestLink.from_dict(
-            create_profile_link_request_link_model_json
-        ).__dict__
-        create_profile_link_request_link_model2 = CreateProfileLinkRequestLink(
-            **create_profile_link_request_link_model_dict
-        )
+        create_profile_link_request_link_model_dict = CreateProfileLinkRequestLink.from_dict(create_profile_link_request_link_model_json).__dict__
+        create_profile_link_request_link_model2 = CreateProfileLinkRequestLink(**create_profile_link_request_link_model_dict)
 
         # Verify the model instances are equivalent
         assert create_profile_link_request_link_model == create_profile_link_request_link_model2
@@ -5106,6 +8679,93 @@ class TestModel_EntityActivity:
         assert entity_activity_model_json2 == entity_activity_model_json
 
 
+class TestModel_Error:
+    """
+    Test Class for Error
+    """
+
+    def test_error_serialization(self):
+        """
+        Test serialization/deserialization for Error
+        """
+
+        # Construct a json representation of a Error model
+        error_model_json = {}
+        error_model_json['code'] = 'testString'
+        error_model_json['message_code'] = 'testString'
+        error_model_json['message'] = 'testString'
+        error_model_json['details'] = 'testString'
+
+        # Construct a model instance of Error by calling from_dict on the json representation
+        error_model = Error.from_dict(error_model_json)
+        assert error_model != False
+
+        # Construct a model instance of Error by calling from_dict on the json representation
+        error_model_dict = Error.from_dict(error_model_json).__dict__
+        error_model2 = Error(**error_model_dict)
+
+        # Verify the model instances are equivalent
+        assert error_model == error_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        error_model_json2 = error_model.to_dict()
+        assert error_model_json2 == error_model_json
+
+
+class TestModel_ExceptionResponse:
+    """
+    Test Class for ExceptionResponse
+    """
+
+    def test_exception_response_serialization(self):
+        """
+        Test serialization/deserialization for ExceptionResponse
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        response_context_model = {}  # ResponseContext
+        response_context_model['transaction_id'] = 'testString'
+        response_context_model['operation'] = 'testString'
+        response_context_model['user_agent'] = 'testString'
+        response_context_model['url'] = 'testString'
+        response_context_model['instance_id'] = 'testString'
+        response_context_model['thread_id'] = 'testString'
+        response_context_model['host'] = 'testString'
+        response_context_model['start_time'] = 'testString'
+        response_context_model['end_time'] = 'testString'
+        response_context_model['elapsed_time'] = 'testString'
+        response_context_model['cluster_name'] = 'testString'
+
+        error_model = {}  # Error
+        error_model['code'] = 'testString'
+        error_model['message_code'] = 'testString'
+        error_model['message'] = 'testString'
+        error_model['details'] = 'testString'
+
+        # Construct a json representation of a ExceptionResponse model
+        exception_response_model_json = {}
+        exception_response_model_json['context'] = response_context_model
+        exception_response_model_json['status_code'] = 'testString'
+        exception_response_model_json['errors'] = [error_model]
+        exception_response_model_json['trace'] = 'testString'
+
+        # Construct a model instance of ExceptionResponse by calling from_dict on the json representation
+        exception_response_model = ExceptionResponse.from_dict(exception_response_model_json)
+        assert exception_response_model != False
+
+        # Construct a model instance of ExceptionResponse by calling from_dict on the json representation
+        exception_response_model_dict = ExceptionResponse.from_dict(exception_response_model_json).__dict__
+        exception_response_model2 = ExceptionResponse(**exception_response_model_dict)
+
+        # Verify the model instances are equivalent
+        assert exception_response_model == exception_response_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        exception_response_model_json2 = exception_response_model.to_dict()
+        assert exception_response_model_json2 == exception_response_model_json
+
+
 class TestModel_IdBasedMfaEnrollment:
     """
     Test Class for IdBasedMfaEnrollment
@@ -5159,9 +8819,7 @@ class TestModel_MfaEnrollmentTypeStatus:
         assert mfa_enrollment_type_status_model != False
 
         # Construct a model instance of MfaEnrollmentTypeStatus by calling from_dict on the json representation
-        mfa_enrollment_type_status_model_dict = MfaEnrollmentTypeStatus.from_dict(
-            mfa_enrollment_type_status_model_json
-        ).__dict__
+        mfa_enrollment_type_status_model_dict = MfaEnrollmentTypeStatus.from_dict(mfa_enrollment_type_status_model_json).__dict__
         mfa_enrollment_type_status_model2 = MfaEnrollmentTypeStatus(**mfa_enrollment_type_status_model_dict)
 
         # Verify the model instances are equivalent
@@ -5220,6 +8878,37 @@ class TestModel_MfaEnrollments:
         # Convert model instance back to dict and verify no loss of data
         mfa_enrollments_model_json2 = mfa_enrollments_model.to_dict()
         assert mfa_enrollments_model_json2 == mfa_enrollments_model_json
+
+
+class TestModel_PolicyTemplateReference:
+    """
+    Test Class for PolicyTemplateReference
+    """
+
+    def test_policy_template_reference_serialization(self):
+        """
+        Test serialization/deserialization for PolicyTemplateReference
+        """
+
+        # Construct a json representation of a PolicyTemplateReference model
+        policy_template_reference_model_json = {}
+        policy_template_reference_model_json['id'] = 'testString'
+        policy_template_reference_model_json['version'] = 'testString'
+
+        # Construct a model instance of PolicyTemplateReference by calling from_dict on the json representation
+        policy_template_reference_model = PolicyTemplateReference.from_dict(policy_template_reference_model_json)
+        assert policy_template_reference_model != False
+
+        # Construct a model instance of PolicyTemplateReference by calling from_dict on the json representation
+        policy_template_reference_model_dict = PolicyTemplateReference.from_dict(policy_template_reference_model_json).__dict__
+        policy_template_reference_model2 = PolicyTemplateReference(**policy_template_reference_model_dict)
+
+        # Verify the model instances are equivalent
+        assert policy_template_reference_model == policy_template_reference_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_template_reference_model_json2 = policy_template_reference_model.to_dict()
+        assert policy_template_reference_model_json2 == policy_template_reference_model_json
 
 
 class TestModel_ProfileClaimRule:
@@ -5285,15 +8974,11 @@ class TestModel_ProfileClaimRuleConditions:
         profile_claim_rule_conditions_model_json['value'] = 'testString'
 
         # Construct a model instance of ProfileClaimRuleConditions by calling from_dict on the json representation
-        profile_claim_rule_conditions_model = ProfileClaimRuleConditions.from_dict(
-            profile_claim_rule_conditions_model_json
-        )
+        profile_claim_rule_conditions_model = ProfileClaimRuleConditions.from_dict(profile_claim_rule_conditions_model_json)
         assert profile_claim_rule_conditions_model != False
 
         # Construct a model instance of ProfileClaimRuleConditions by calling from_dict on the json representation
-        profile_claim_rule_conditions_model_dict = ProfileClaimRuleConditions.from_dict(
-            profile_claim_rule_conditions_model_json
-        ).__dict__
+        profile_claim_rule_conditions_model_dict = ProfileClaimRuleConditions.from_dict(profile_claim_rule_conditions_model_json).__dict__
         profile_claim_rule_conditions_model2 = ProfileClaimRuleConditions(**profile_claim_rule_conditions_model_dict)
 
         # Verify the model instances are equivalent
@@ -5379,26 +9064,24 @@ class TestModel_ProfileIdentitiesResponse:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        profile_identity_model = {}  # ProfileIdentity
-        profile_identity_model['iam_id'] = 'testString'
-        profile_identity_model['identifier'] = 'testString'
-        profile_identity_model['type'] = 'user'
-        profile_identity_model['accounts'] = ['testString']
-        profile_identity_model['description'] = 'testString'
+        profile_identity_response_model = {}  # ProfileIdentityResponse
+        profile_identity_response_model['iam_id'] = 'testString'
+        profile_identity_response_model['identifier'] = 'testString'
+        profile_identity_response_model['type'] = 'user'
+        profile_identity_response_model['accounts'] = ['testString']
+        profile_identity_response_model['description'] = 'testString'
 
         # Construct a json representation of a ProfileIdentitiesResponse model
         profile_identities_response_model_json = {}
         profile_identities_response_model_json['entity_tag'] = 'testString'
-        profile_identities_response_model_json['identities'] = [profile_identity_model]
+        profile_identities_response_model_json['identities'] = [profile_identity_response_model]
 
         # Construct a model instance of ProfileIdentitiesResponse by calling from_dict on the json representation
         profile_identities_response_model = ProfileIdentitiesResponse.from_dict(profile_identities_response_model_json)
         assert profile_identities_response_model != False
 
         # Construct a model instance of ProfileIdentitiesResponse by calling from_dict on the json representation
-        profile_identities_response_model_dict = ProfileIdentitiesResponse.from_dict(
-            profile_identities_response_model_json
-        ).__dict__
+        profile_identities_response_model_dict = ProfileIdentitiesResponse.from_dict(profile_identities_response_model_json).__dict__
         profile_identities_response_model2 = ProfileIdentitiesResponse(**profile_identities_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -5409,38 +9092,71 @@ class TestModel_ProfileIdentitiesResponse:
         assert profile_identities_response_model_json2 == profile_identities_response_model_json
 
 
-class TestModel_ProfileIdentity:
+class TestModel_ProfileIdentityRequest:
     """
-    Test Class for ProfileIdentity
+    Test Class for ProfileIdentityRequest
     """
 
-    def test_profile_identity_serialization(self):
+    def test_profile_identity_request_serialization(self):
         """
-        Test serialization/deserialization for ProfileIdentity
+        Test serialization/deserialization for ProfileIdentityRequest
         """
 
-        # Construct a json representation of a ProfileIdentity model
-        profile_identity_model_json = {}
-        profile_identity_model_json['iam_id'] = 'testString'
-        profile_identity_model_json['identifier'] = 'testString'
-        profile_identity_model_json['type'] = 'user'
-        profile_identity_model_json['accounts'] = ['testString']
-        profile_identity_model_json['description'] = 'testString'
+        # Construct a json representation of a ProfileIdentityRequest model
+        profile_identity_request_model_json = {}
+        profile_identity_request_model_json['identifier'] = 'testString'
+        profile_identity_request_model_json['type'] = 'user'
+        profile_identity_request_model_json['accounts'] = ['testString']
+        profile_identity_request_model_json['description'] = 'testString'
 
-        # Construct a model instance of ProfileIdentity by calling from_dict on the json representation
-        profile_identity_model = ProfileIdentity.from_dict(profile_identity_model_json)
-        assert profile_identity_model != False
+        # Construct a model instance of ProfileIdentityRequest by calling from_dict on the json representation
+        profile_identity_request_model = ProfileIdentityRequest.from_dict(profile_identity_request_model_json)
+        assert profile_identity_request_model != False
 
-        # Construct a model instance of ProfileIdentity by calling from_dict on the json representation
-        profile_identity_model_dict = ProfileIdentity.from_dict(profile_identity_model_json).__dict__
-        profile_identity_model2 = ProfileIdentity(**profile_identity_model_dict)
+        # Construct a model instance of ProfileIdentityRequest by calling from_dict on the json representation
+        profile_identity_request_model_dict = ProfileIdentityRequest.from_dict(profile_identity_request_model_json).__dict__
+        profile_identity_request_model2 = ProfileIdentityRequest(**profile_identity_request_model_dict)
 
         # Verify the model instances are equivalent
-        assert profile_identity_model == profile_identity_model2
+        assert profile_identity_request_model == profile_identity_request_model2
 
         # Convert model instance back to dict and verify no loss of data
-        profile_identity_model_json2 = profile_identity_model.to_dict()
-        assert profile_identity_model_json2 == profile_identity_model_json
+        profile_identity_request_model_json2 = profile_identity_request_model.to_dict()
+        assert profile_identity_request_model_json2 == profile_identity_request_model_json
+
+
+class TestModel_ProfileIdentityResponse:
+    """
+    Test Class for ProfileIdentityResponse
+    """
+
+    def test_profile_identity_response_serialization(self):
+        """
+        Test serialization/deserialization for ProfileIdentityResponse
+        """
+
+        # Construct a json representation of a ProfileIdentityResponse model
+        profile_identity_response_model_json = {}
+        profile_identity_response_model_json['iam_id'] = 'testString'
+        profile_identity_response_model_json['identifier'] = 'testString'
+        profile_identity_response_model_json['type'] = 'user'
+        profile_identity_response_model_json['accounts'] = ['testString']
+        profile_identity_response_model_json['description'] = 'testString'
+
+        # Construct a model instance of ProfileIdentityResponse by calling from_dict on the json representation
+        profile_identity_response_model = ProfileIdentityResponse.from_dict(profile_identity_response_model_json)
+        assert profile_identity_response_model != False
+
+        # Construct a model instance of ProfileIdentityResponse by calling from_dict on the json representation
+        profile_identity_response_model_dict = ProfileIdentityResponse.from_dict(profile_identity_response_model_json).__dict__
+        profile_identity_response_model2 = ProfileIdentityResponse(**profile_identity_response_model_dict)
+
+        # Verify the model instances are equivalent
+        assert profile_identity_response_model == profile_identity_response_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        profile_identity_response_model_json2 = profile_identity_response_model.to_dict()
+        assert profile_identity_response_model_json2 == profile_identity_response_model_json
 
 
 class TestModel_ProfileLink:
@@ -5684,15 +9400,11 @@ class TestModel_ReportMfaEnrollmentStatus:
         report_mfa_enrollment_status_model_json['users'] = [user_report_mfa_enrollment_status_model]
 
         # Construct a model instance of ReportMfaEnrollmentStatus by calling from_dict on the json representation
-        report_mfa_enrollment_status_model = ReportMfaEnrollmentStatus.from_dict(
-            report_mfa_enrollment_status_model_json
-        )
+        report_mfa_enrollment_status_model = ReportMfaEnrollmentStatus.from_dict(report_mfa_enrollment_status_model_json)
         assert report_mfa_enrollment_status_model != False
 
         # Construct a model instance of ReportMfaEnrollmentStatus by calling from_dict on the json representation
-        report_mfa_enrollment_status_model_dict = ReportMfaEnrollmentStatus.from_dict(
-            report_mfa_enrollment_status_model_json
-        ).__dict__
+        report_mfa_enrollment_status_model_dict = ReportMfaEnrollmentStatus.from_dict(report_mfa_enrollment_status_model_json).__dict__
         report_mfa_enrollment_status_model2 = ReportMfaEnrollmentStatus(**report_mfa_enrollment_status_model_dict)
 
         # Verify the model instances are equivalent
@@ -5958,6 +9670,461 @@ class TestModel_ServiceIdList:
         assert service_id_list_model_json2 == service_id_list_model_json
 
 
+class TestModel_TemplateAssignmentListResponse:
+    """
+    Test Class for TemplateAssignmentListResponse
+    """
+
+    def test_template_assignment_list_response_serialization(self):
+        """
+        Test serialization/deserialization for TemplateAssignmentListResponse
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        response_context_model = {}  # ResponseContext
+        response_context_model['transaction_id'] = 'testString'
+        response_context_model['operation'] = 'testString'
+        response_context_model['user_agent'] = 'testString'
+        response_context_model['url'] = 'testString'
+        response_context_model['instance_id'] = 'testString'
+        response_context_model['thread_id'] = 'testString'
+        response_context_model['host'] = 'testString'
+        response_context_model['start_time'] = 'testString'
+        response_context_model['end_time'] = 'testString'
+        response_context_model['elapsed_time'] = 'testString'
+        response_context_model['cluster_name'] = 'testString'
+
+        template_assignment_resource_model = {}  # TemplateAssignmentResource
+        template_assignment_resource_model['id'] = 'testString'
+
+        template_assignment_resource_error_model = {}  # TemplateAssignmentResourceError
+        template_assignment_resource_error_model['name'] = 'testString'
+        template_assignment_resource_error_model['errorCode'] = 'testString'
+        template_assignment_resource_error_model['message'] = 'testString'
+        template_assignment_resource_error_model['statusCode'] = 'testString'
+
+        template_assignment_response_resource_detail_model = {}  # TemplateAssignmentResponseResourceDetail
+        template_assignment_response_resource_detail_model['id'] = 'testString'
+        template_assignment_response_resource_detail_model['version'] = 'testString'
+        template_assignment_response_resource_detail_model['resource_created'] = template_assignment_resource_model
+        template_assignment_response_resource_detail_model['error_message'] = template_assignment_resource_error_model
+        template_assignment_response_resource_detail_model['status'] = 'testString'
+
+        template_assignment_response_resource_model = {}  # TemplateAssignmentResponseResource
+        template_assignment_response_resource_model['target'] = 'testString'
+        template_assignment_response_resource_model['profile'] = template_assignment_response_resource_detail_model
+        template_assignment_response_resource_model['account_settings'] = template_assignment_response_resource_detail_model
+        template_assignment_response_resource_model['policy_template_refs'] = [template_assignment_response_resource_detail_model]
+
+        enity_history_record_model = {}  # EnityHistoryRecord
+        enity_history_record_model['timestamp'] = 'testString'
+        enity_history_record_model['iam_id'] = 'testString'
+        enity_history_record_model['iam_id_account'] = 'testString'
+        enity_history_record_model['action'] = 'testString'
+        enity_history_record_model['params'] = ['testString']
+        enity_history_record_model['message'] = 'testString'
+
+        template_assignment_response_model = {}  # TemplateAssignmentResponse
+        template_assignment_response_model['context'] = response_context_model
+        template_assignment_response_model['id'] = 'testString'
+        template_assignment_response_model['account_id'] = 'testString'
+        template_assignment_response_model['template_id'] = 'testString'
+        template_assignment_response_model['template_version'] = 26
+        template_assignment_response_model['target_type'] = 'testString'
+        template_assignment_response_model['target'] = 'testString'
+        template_assignment_response_model['status'] = 'testString'
+        template_assignment_response_model['resources'] = [template_assignment_response_resource_model]
+        template_assignment_response_model['history'] = [enity_history_record_model]
+        template_assignment_response_model['href'] = 'testString'
+        template_assignment_response_model['created_at'] = 'testString'
+        template_assignment_response_model['created_by_id'] = 'testString'
+        template_assignment_response_model['last_modified_at'] = 'testString'
+        template_assignment_response_model['last_modified_by_id'] = 'testString'
+        template_assignment_response_model['entity_tag'] = 'testString'
+
+        # Construct a json representation of a TemplateAssignmentListResponse model
+        template_assignment_list_response_model_json = {}
+        template_assignment_list_response_model_json['context'] = response_context_model
+        template_assignment_list_response_model_json['offset'] = 26
+        template_assignment_list_response_model_json['limit'] = 26
+        template_assignment_list_response_model_json['first'] = 'testString'
+        template_assignment_list_response_model_json['previous'] = 'testString'
+        template_assignment_list_response_model_json['next'] = 'testString'
+        template_assignment_list_response_model_json['assignments'] = [template_assignment_response_model]
+
+        # Construct a model instance of TemplateAssignmentListResponse by calling from_dict on the json representation
+        template_assignment_list_response_model = TemplateAssignmentListResponse.from_dict(template_assignment_list_response_model_json)
+        assert template_assignment_list_response_model != False
+
+        # Construct a model instance of TemplateAssignmentListResponse by calling from_dict on the json representation
+        template_assignment_list_response_model_dict = TemplateAssignmentListResponse.from_dict(template_assignment_list_response_model_json).__dict__
+        template_assignment_list_response_model2 = TemplateAssignmentListResponse(**template_assignment_list_response_model_dict)
+
+        # Verify the model instances are equivalent
+        assert template_assignment_list_response_model == template_assignment_list_response_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        template_assignment_list_response_model_json2 = template_assignment_list_response_model.to_dict()
+        assert template_assignment_list_response_model_json2 == template_assignment_list_response_model_json
+
+
+class TestModel_TemplateAssignmentResource:
+    """
+    Test Class for TemplateAssignmentResource
+    """
+
+    def test_template_assignment_resource_serialization(self):
+        """
+        Test serialization/deserialization for TemplateAssignmentResource
+        """
+
+        # Construct a json representation of a TemplateAssignmentResource model
+        template_assignment_resource_model_json = {}
+        template_assignment_resource_model_json['id'] = 'testString'
+
+        # Construct a model instance of TemplateAssignmentResource by calling from_dict on the json representation
+        template_assignment_resource_model = TemplateAssignmentResource.from_dict(template_assignment_resource_model_json)
+        assert template_assignment_resource_model != False
+
+        # Construct a model instance of TemplateAssignmentResource by calling from_dict on the json representation
+        template_assignment_resource_model_dict = TemplateAssignmentResource.from_dict(template_assignment_resource_model_json).__dict__
+        template_assignment_resource_model2 = TemplateAssignmentResource(**template_assignment_resource_model_dict)
+
+        # Verify the model instances are equivalent
+        assert template_assignment_resource_model == template_assignment_resource_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        template_assignment_resource_model_json2 = template_assignment_resource_model.to_dict()
+        assert template_assignment_resource_model_json2 == template_assignment_resource_model_json
+
+
+class TestModel_TemplateAssignmentResourceError:
+    """
+    Test Class for TemplateAssignmentResourceError
+    """
+
+    def test_template_assignment_resource_error_serialization(self):
+        """
+        Test serialization/deserialization for TemplateAssignmentResourceError
+        """
+
+        # Construct a json representation of a TemplateAssignmentResourceError model
+        template_assignment_resource_error_model_json = {}
+        template_assignment_resource_error_model_json['name'] = 'testString'
+        template_assignment_resource_error_model_json['errorCode'] = 'testString'
+        template_assignment_resource_error_model_json['message'] = 'testString'
+        template_assignment_resource_error_model_json['statusCode'] = 'testString'
+
+        # Construct a model instance of TemplateAssignmentResourceError by calling from_dict on the json representation
+        template_assignment_resource_error_model = TemplateAssignmentResourceError.from_dict(template_assignment_resource_error_model_json)
+        assert template_assignment_resource_error_model != False
+
+        # Construct a model instance of TemplateAssignmentResourceError by calling from_dict on the json representation
+        template_assignment_resource_error_model_dict = TemplateAssignmentResourceError.from_dict(template_assignment_resource_error_model_json).__dict__
+        template_assignment_resource_error_model2 = TemplateAssignmentResourceError(**template_assignment_resource_error_model_dict)
+
+        # Verify the model instances are equivalent
+        assert template_assignment_resource_error_model == template_assignment_resource_error_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        template_assignment_resource_error_model_json2 = template_assignment_resource_error_model.to_dict()
+        assert template_assignment_resource_error_model_json2 == template_assignment_resource_error_model_json
+
+
+class TestModel_TemplateAssignmentResponse:
+    """
+    Test Class for TemplateAssignmentResponse
+    """
+
+    def test_template_assignment_response_serialization(self):
+        """
+        Test serialization/deserialization for TemplateAssignmentResponse
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        response_context_model = {}  # ResponseContext
+        response_context_model['transaction_id'] = 'testString'
+        response_context_model['operation'] = 'testString'
+        response_context_model['user_agent'] = 'testString'
+        response_context_model['url'] = 'testString'
+        response_context_model['instance_id'] = 'testString'
+        response_context_model['thread_id'] = 'testString'
+        response_context_model['host'] = 'testString'
+        response_context_model['start_time'] = 'testString'
+        response_context_model['end_time'] = 'testString'
+        response_context_model['elapsed_time'] = 'testString'
+        response_context_model['cluster_name'] = 'testString'
+
+        template_assignment_resource_model = {}  # TemplateAssignmentResource
+        template_assignment_resource_model['id'] = 'testString'
+
+        template_assignment_resource_error_model = {}  # TemplateAssignmentResourceError
+        template_assignment_resource_error_model['name'] = 'testString'
+        template_assignment_resource_error_model['errorCode'] = 'testString'
+        template_assignment_resource_error_model['message'] = 'testString'
+        template_assignment_resource_error_model['statusCode'] = 'testString'
+
+        template_assignment_response_resource_detail_model = {}  # TemplateAssignmentResponseResourceDetail
+        template_assignment_response_resource_detail_model['id'] = 'testString'
+        template_assignment_response_resource_detail_model['version'] = 'testString'
+        template_assignment_response_resource_detail_model['resource_created'] = template_assignment_resource_model
+        template_assignment_response_resource_detail_model['error_message'] = template_assignment_resource_error_model
+        template_assignment_response_resource_detail_model['status'] = 'testString'
+
+        template_assignment_response_resource_model = {}  # TemplateAssignmentResponseResource
+        template_assignment_response_resource_model['target'] = 'testString'
+        template_assignment_response_resource_model['profile'] = template_assignment_response_resource_detail_model
+        template_assignment_response_resource_model['account_settings'] = template_assignment_response_resource_detail_model
+        template_assignment_response_resource_model['policy_template_refs'] = [template_assignment_response_resource_detail_model]
+
+        enity_history_record_model = {}  # EnityHistoryRecord
+        enity_history_record_model['timestamp'] = 'testString'
+        enity_history_record_model['iam_id'] = 'testString'
+        enity_history_record_model['iam_id_account'] = 'testString'
+        enity_history_record_model['action'] = 'testString'
+        enity_history_record_model['params'] = ['testString']
+        enity_history_record_model['message'] = 'testString'
+
+        # Construct a json representation of a TemplateAssignmentResponse model
+        template_assignment_response_model_json = {}
+        template_assignment_response_model_json['context'] = response_context_model
+        template_assignment_response_model_json['id'] = 'testString'
+        template_assignment_response_model_json['account_id'] = 'testString'
+        template_assignment_response_model_json['template_id'] = 'testString'
+        template_assignment_response_model_json['template_version'] = 26
+        template_assignment_response_model_json['target_type'] = 'testString'
+        template_assignment_response_model_json['target'] = 'testString'
+        template_assignment_response_model_json['status'] = 'testString'
+        template_assignment_response_model_json['resources'] = [template_assignment_response_resource_model]
+        template_assignment_response_model_json['history'] = [enity_history_record_model]
+        template_assignment_response_model_json['href'] = 'testString'
+        template_assignment_response_model_json['created_at'] = 'testString'
+        template_assignment_response_model_json['created_by_id'] = 'testString'
+        template_assignment_response_model_json['last_modified_at'] = 'testString'
+        template_assignment_response_model_json['last_modified_by_id'] = 'testString'
+        template_assignment_response_model_json['entity_tag'] = 'testString'
+
+        # Construct a model instance of TemplateAssignmentResponse by calling from_dict on the json representation
+        template_assignment_response_model = TemplateAssignmentResponse.from_dict(template_assignment_response_model_json)
+        assert template_assignment_response_model != False
+
+        # Construct a model instance of TemplateAssignmentResponse by calling from_dict on the json representation
+        template_assignment_response_model_dict = TemplateAssignmentResponse.from_dict(template_assignment_response_model_json).__dict__
+        template_assignment_response_model2 = TemplateAssignmentResponse(**template_assignment_response_model_dict)
+
+        # Verify the model instances are equivalent
+        assert template_assignment_response_model == template_assignment_response_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        template_assignment_response_model_json2 = template_assignment_response_model.to_dict()
+        assert template_assignment_response_model_json2 == template_assignment_response_model_json
+
+
+class TestModel_TemplateAssignmentResponseResource:
+    """
+    Test Class for TemplateAssignmentResponseResource
+    """
+
+    def test_template_assignment_response_resource_serialization(self):
+        """
+        Test serialization/deserialization for TemplateAssignmentResponseResource
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        template_assignment_resource_model = {}  # TemplateAssignmentResource
+        template_assignment_resource_model['id'] = 'testString'
+
+        template_assignment_resource_error_model = {}  # TemplateAssignmentResourceError
+        template_assignment_resource_error_model['name'] = 'testString'
+        template_assignment_resource_error_model['errorCode'] = 'testString'
+        template_assignment_resource_error_model['message'] = 'testString'
+        template_assignment_resource_error_model['statusCode'] = 'testString'
+
+        template_assignment_response_resource_detail_model = {}  # TemplateAssignmentResponseResourceDetail
+        template_assignment_response_resource_detail_model['id'] = 'testString'
+        template_assignment_response_resource_detail_model['version'] = 'testString'
+        template_assignment_response_resource_detail_model['resource_created'] = template_assignment_resource_model
+        template_assignment_response_resource_detail_model['error_message'] = template_assignment_resource_error_model
+        template_assignment_response_resource_detail_model['status'] = 'testString'
+
+        # Construct a json representation of a TemplateAssignmentResponseResource model
+        template_assignment_response_resource_model_json = {}
+        template_assignment_response_resource_model_json['target'] = 'testString'
+        template_assignment_response_resource_model_json['profile'] = template_assignment_response_resource_detail_model
+        template_assignment_response_resource_model_json['account_settings'] = template_assignment_response_resource_detail_model
+        template_assignment_response_resource_model_json['policy_template_refs'] = [template_assignment_response_resource_detail_model]
+
+        # Construct a model instance of TemplateAssignmentResponseResource by calling from_dict on the json representation
+        template_assignment_response_resource_model = TemplateAssignmentResponseResource.from_dict(template_assignment_response_resource_model_json)
+        assert template_assignment_response_resource_model != False
+
+        # Construct a model instance of TemplateAssignmentResponseResource by calling from_dict on the json representation
+        template_assignment_response_resource_model_dict = TemplateAssignmentResponseResource.from_dict(template_assignment_response_resource_model_json).__dict__
+        template_assignment_response_resource_model2 = TemplateAssignmentResponseResource(**template_assignment_response_resource_model_dict)
+
+        # Verify the model instances are equivalent
+        assert template_assignment_response_resource_model == template_assignment_response_resource_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        template_assignment_response_resource_model_json2 = template_assignment_response_resource_model.to_dict()
+        assert template_assignment_response_resource_model_json2 == template_assignment_response_resource_model_json
+
+
+class TestModel_TemplateAssignmentResponseResourceDetail:
+    """
+    Test Class for TemplateAssignmentResponseResourceDetail
+    """
+
+    def test_template_assignment_response_resource_detail_serialization(self):
+        """
+        Test serialization/deserialization for TemplateAssignmentResponseResourceDetail
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        template_assignment_resource_model = {}  # TemplateAssignmentResource
+        template_assignment_resource_model['id'] = 'testString'
+
+        template_assignment_resource_error_model = {}  # TemplateAssignmentResourceError
+        template_assignment_resource_error_model['name'] = 'testString'
+        template_assignment_resource_error_model['errorCode'] = 'testString'
+        template_assignment_resource_error_model['message'] = 'testString'
+        template_assignment_resource_error_model['statusCode'] = 'testString'
+
+        # Construct a json representation of a TemplateAssignmentResponseResourceDetail model
+        template_assignment_response_resource_detail_model_json = {}
+        template_assignment_response_resource_detail_model_json['id'] = 'testString'
+        template_assignment_response_resource_detail_model_json['version'] = 'testString'
+        template_assignment_response_resource_detail_model_json['resource_created'] = template_assignment_resource_model
+        template_assignment_response_resource_detail_model_json['error_message'] = template_assignment_resource_error_model
+        template_assignment_response_resource_detail_model_json['status'] = 'testString'
+
+        # Construct a model instance of TemplateAssignmentResponseResourceDetail by calling from_dict on the json representation
+        template_assignment_response_resource_detail_model = TemplateAssignmentResponseResourceDetail.from_dict(template_assignment_response_resource_detail_model_json)
+        assert template_assignment_response_resource_detail_model != False
+
+        # Construct a model instance of TemplateAssignmentResponseResourceDetail by calling from_dict on the json representation
+        template_assignment_response_resource_detail_model_dict = TemplateAssignmentResponseResourceDetail.from_dict(template_assignment_response_resource_detail_model_json).__dict__
+        template_assignment_response_resource_detail_model2 = TemplateAssignmentResponseResourceDetail(**template_assignment_response_resource_detail_model_dict)
+
+        # Verify the model instances are equivalent
+        assert template_assignment_response_resource_detail_model == template_assignment_response_resource_detail_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        template_assignment_response_resource_detail_model_json2 = template_assignment_response_resource_detail_model.to_dict()
+        assert template_assignment_response_resource_detail_model_json2 == template_assignment_response_resource_detail_model_json
+
+
+class TestModel_TemplateProfileComponentRequest:
+    """
+    Test Class for TemplateProfileComponentRequest
+    """
+
+    def test_template_profile_component_request_serialization(self):
+        """
+        Test serialization/deserialization for TemplateProfileComponentRequest
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        profile_claim_rule_conditions_model = {}  # ProfileClaimRuleConditions
+        profile_claim_rule_conditions_model['claim'] = 'testString'
+        profile_claim_rule_conditions_model['operator'] = 'testString'
+        profile_claim_rule_conditions_model['value'] = 'testString'
+
+        trusted_profile_template_claim_rule_model = {}  # TrustedProfileTemplateClaimRule
+        trusted_profile_template_claim_rule_model['name'] = 'testString'
+        trusted_profile_template_claim_rule_model['type'] = 'Profile-SAML'
+        trusted_profile_template_claim_rule_model['realm_name'] = 'testString'
+        trusted_profile_template_claim_rule_model['expiration'] = 38
+        trusted_profile_template_claim_rule_model['conditions'] = [profile_claim_rule_conditions_model]
+
+        profile_identity_request_model = {}  # ProfileIdentityRequest
+        profile_identity_request_model['identifier'] = 'testString'
+        profile_identity_request_model['type'] = 'user'
+        profile_identity_request_model['accounts'] = ['testString']
+        profile_identity_request_model['description'] = 'testString'
+
+        # Construct a json representation of a TemplateProfileComponentRequest model
+        template_profile_component_request_model_json = {}
+        template_profile_component_request_model_json['name'] = 'testString'
+        template_profile_component_request_model_json['description'] = 'testString'
+        template_profile_component_request_model_json['rules'] = [trusted_profile_template_claim_rule_model]
+        template_profile_component_request_model_json['identities'] = [profile_identity_request_model]
+
+        # Construct a model instance of TemplateProfileComponentRequest by calling from_dict on the json representation
+        template_profile_component_request_model = TemplateProfileComponentRequest.from_dict(template_profile_component_request_model_json)
+        assert template_profile_component_request_model != False
+
+        # Construct a model instance of TemplateProfileComponentRequest by calling from_dict on the json representation
+        template_profile_component_request_model_dict = TemplateProfileComponentRequest.from_dict(template_profile_component_request_model_json).__dict__
+        template_profile_component_request_model2 = TemplateProfileComponentRequest(**template_profile_component_request_model_dict)
+
+        # Verify the model instances are equivalent
+        assert template_profile_component_request_model == template_profile_component_request_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        template_profile_component_request_model_json2 = template_profile_component_request_model.to_dict()
+        assert template_profile_component_request_model_json2 == template_profile_component_request_model_json
+
+
+class TestModel_TemplateProfileComponentResponse:
+    """
+    Test Class for TemplateProfileComponentResponse
+    """
+
+    def test_template_profile_component_response_serialization(self):
+        """
+        Test serialization/deserialization for TemplateProfileComponentResponse
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        profile_claim_rule_conditions_model = {}  # ProfileClaimRuleConditions
+        profile_claim_rule_conditions_model['claim'] = 'testString'
+        profile_claim_rule_conditions_model['operator'] = 'testString'
+        profile_claim_rule_conditions_model['value'] = 'testString'
+
+        trusted_profile_template_claim_rule_model = {}  # TrustedProfileTemplateClaimRule
+        trusted_profile_template_claim_rule_model['name'] = 'testString'
+        trusted_profile_template_claim_rule_model['type'] = 'Profile-SAML'
+        trusted_profile_template_claim_rule_model['realm_name'] = 'testString'
+        trusted_profile_template_claim_rule_model['expiration'] = 38
+        trusted_profile_template_claim_rule_model['conditions'] = [profile_claim_rule_conditions_model]
+
+        profile_identity_response_model = {}  # ProfileIdentityResponse
+        profile_identity_response_model['iam_id'] = 'testString'
+        profile_identity_response_model['identifier'] = 'testString'
+        profile_identity_response_model['type'] = 'user'
+        profile_identity_response_model['accounts'] = ['testString']
+        profile_identity_response_model['description'] = 'testString'
+
+        # Construct a json representation of a TemplateProfileComponentResponse model
+        template_profile_component_response_model_json = {}
+        template_profile_component_response_model_json['name'] = 'testString'
+        template_profile_component_response_model_json['description'] = 'testString'
+        template_profile_component_response_model_json['rules'] = [trusted_profile_template_claim_rule_model]
+        template_profile_component_response_model_json['identities'] = [profile_identity_response_model]
+
+        # Construct a model instance of TemplateProfileComponentResponse by calling from_dict on the json representation
+        template_profile_component_response_model = TemplateProfileComponentResponse.from_dict(template_profile_component_response_model_json)
+        assert template_profile_component_response_model != False
+
+        # Construct a model instance of TemplateProfileComponentResponse by calling from_dict on the json representation
+        template_profile_component_response_model_dict = TemplateProfileComponentResponse.from_dict(template_profile_component_response_model_json).__dict__
+        template_profile_component_response_model2 = TemplateProfileComponentResponse(**template_profile_component_response_model_dict)
+
+        # Verify the model instances are equivalent
+        assert template_profile_component_response_model == template_profile_component_response_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        template_profile_component_response_model_json2 = template_profile_component_response_model.to_dict()
+        assert template_profile_component_response_model_json2 == template_profile_component_response_model_json
+
+
 class TestModel_TrustedProfile:
     """
     Test Class for TrustedProfile
@@ -6007,6 +10174,8 @@ class TestModel_TrustedProfile:
         trusted_profile_model_json['modified_at'] = '2019-01-01T12:00:00Z'
         trusted_profile_model_json['iam_id'] = 'testString'
         trusted_profile_model_json['account_id'] = 'testString'
+        trusted_profile_model_json['template_id'] = 'testString'
+        trusted_profile_model_json['assignment_id'] = 'testString'
         trusted_profile_model_json['ims_account_id'] = 26
         trusted_profile_model_json['ims_user_id'] = 26
         trusted_profile_model_json['history'] = [enity_history_record_model]
@@ -6026,6 +10195,235 @@ class TestModel_TrustedProfile:
         # Convert model instance back to dict and verify no loss of data
         trusted_profile_model_json2 = trusted_profile_model.to_dict()
         assert trusted_profile_model_json2 == trusted_profile_model_json
+
+
+class TestModel_TrustedProfileTemplateClaimRule:
+    """
+    Test Class for TrustedProfileTemplateClaimRule
+    """
+
+    def test_trusted_profile_template_claim_rule_serialization(self):
+        """
+        Test serialization/deserialization for TrustedProfileTemplateClaimRule
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        profile_claim_rule_conditions_model = {}  # ProfileClaimRuleConditions
+        profile_claim_rule_conditions_model['claim'] = 'testString'
+        profile_claim_rule_conditions_model['operator'] = 'testString'
+        profile_claim_rule_conditions_model['value'] = 'testString'
+
+        # Construct a json representation of a TrustedProfileTemplateClaimRule model
+        trusted_profile_template_claim_rule_model_json = {}
+        trusted_profile_template_claim_rule_model_json['name'] = 'testString'
+        trusted_profile_template_claim_rule_model_json['type'] = 'Profile-SAML'
+        trusted_profile_template_claim_rule_model_json['realm_name'] = 'testString'
+        trusted_profile_template_claim_rule_model_json['expiration'] = 38
+        trusted_profile_template_claim_rule_model_json['conditions'] = [profile_claim_rule_conditions_model]
+
+        # Construct a model instance of TrustedProfileTemplateClaimRule by calling from_dict on the json representation
+        trusted_profile_template_claim_rule_model = TrustedProfileTemplateClaimRule.from_dict(trusted_profile_template_claim_rule_model_json)
+        assert trusted_profile_template_claim_rule_model != False
+
+        # Construct a model instance of TrustedProfileTemplateClaimRule by calling from_dict on the json representation
+        trusted_profile_template_claim_rule_model_dict = TrustedProfileTemplateClaimRule.from_dict(trusted_profile_template_claim_rule_model_json).__dict__
+        trusted_profile_template_claim_rule_model2 = TrustedProfileTemplateClaimRule(**trusted_profile_template_claim_rule_model_dict)
+
+        # Verify the model instances are equivalent
+        assert trusted_profile_template_claim_rule_model == trusted_profile_template_claim_rule_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        trusted_profile_template_claim_rule_model_json2 = trusted_profile_template_claim_rule_model.to_dict()
+        assert trusted_profile_template_claim_rule_model_json2 == trusted_profile_template_claim_rule_model_json
+
+
+class TestModel_TrustedProfileTemplateList:
+    """
+    Test Class for TrustedProfileTemplateList
+    """
+
+    def test_trusted_profile_template_list_serialization(self):
+        """
+        Test serialization/deserialization for TrustedProfileTemplateList
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        response_context_model = {}  # ResponseContext
+        response_context_model['transaction_id'] = 'testString'
+        response_context_model['operation'] = 'testString'
+        response_context_model['user_agent'] = 'testString'
+        response_context_model['url'] = 'testString'
+        response_context_model['instance_id'] = 'testString'
+        response_context_model['thread_id'] = 'testString'
+        response_context_model['host'] = 'testString'
+        response_context_model['start_time'] = 'testString'
+        response_context_model['end_time'] = 'testString'
+        response_context_model['elapsed_time'] = 'testString'
+        response_context_model['cluster_name'] = 'testString'
+
+        profile_claim_rule_conditions_model = {}  # ProfileClaimRuleConditions
+        profile_claim_rule_conditions_model['claim'] = 'testString'
+        profile_claim_rule_conditions_model['operator'] = 'testString'
+        profile_claim_rule_conditions_model['value'] = 'testString'
+
+        trusted_profile_template_claim_rule_model = {}  # TrustedProfileTemplateClaimRule
+        trusted_profile_template_claim_rule_model['name'] = 'testString'
+        trusted_profile_template_claim_rule_model['type'] = 'Profile-SAML'
+        trusted_profile_template_claim_rule_model['realm_name'] = 'testString'
+        trusted_profile_template_claim_rule_model['expiration'] = 38
+        trusted_profile_template_claim_rule_model['conditions'] = [profile_claim_rule_conditions_model]
+
+        profile_identity_response_model = {}  # ProfileIdentityResponse
+        profile_identity_response_model['iam_id'] = 'testString'
+        profile_identity_response_model['identifier'] = 'testString'
+        profile_identity_response_model['type'] = 'user'
+        profile_identity_response_model['accounts'] = ['testString']
+        profile_identity_response_model['description'] = 'testString'
+
+        template_profile_component_response_model = {}  # TemplateProfileComponentResponse
+        template_profile_component_response_model['name'] = 'testString'
+        template_profile_component_response_model['description'] = 'testString'
+        template_profile_component_response_model['rules'] = [trusted_profile_template_claim_rule_model]
+        template_profile_component_response_model['identities'] = [profile_identity_response_model]
+
+        policy_template_reference_model = {}  # PolicyTemplateReference
+        policy_template_reference_model['id'] = 'testString'
+        policy_template_reference_model['version'] = 'testString'
+
+        enity_history_record_model = {}  # EnityHistoryRecord
+        enity_history_record_model['timestamp'] = 'testString'
+        enity_history_record_model['iam_id'] = 'testString'
+        enity_history_record_model['iam_id_account'] = 'testString'
+        enity_history_record_model['action'] = 'testString'
+        enity_history_record_model['params'] = ['testString']
+        enity_history_record_model['message'] = 'testString'
+
+        trusted_profile_template_response_model = {}  # TrustedProfileTemplateResponse
+        trusted_profile_template_response_model['id'] = 'testString'
+        trusted_profile_template_response_model['version'] = 26
+        trusted_profile_template_response_model['account_id'] = 'testString'
+        trusted_profile_template_response_model['name'] = 'testString'
+        trusted_profile_template_response_model['description'] = 'testString'
+        trusted_profile_template_response_model['committed'] = True
+        trusted_profile_template_response_model['profile'] = template_profile_component_response_model
+        trusted_profile_template_response_model['policy_template_references'] = [policy_template_reference_model]
+        trusted_profile_template_response_model['history'] = [enity_history_record_model]
+        trusted_profile_template_response_model['entity_tag'] = 'testString'
+        trusted_profile_template_response_model['crn'] = 'testString'
+        trusted_profile_template_response_model['created_at'] = 'testString'
+        trusted_profile_template_response_model['created_by_id'] = 'testString'
+        trusted_profile_template_response_model['last_modified_at'] = 'testString'
+        trusted_profile_template_response_model['last_modified_by_id'] = 'testString'
+
+        # Construct a json representation of a TrustedProfileTemplateList model
+        trusted_profile_template_list_model_json = {}
+        trusted_profile_template_list_model_json['context'] = response_context_model
+        trusted_profile_template_list_model_json['offset'] = 26
+        trusted_profile_template_list_model_json['limit'] = 20
+        trusted_profile_template_list_model_json['first'] = 'testString'
+        trusted_profile_template_list_model_json['previous'] = 'testString'
+        trusted_profile_template_list_model_json['next'] = 'testString'
+        trusted_profile_template_list_model_json['profile_templates'] = [trusted_profile_template_response_model]
+
+        # Construct a model instance of TrustedProfileTemplateList by calling from_dict on the json representation
+        trusted_profile_template_list_model = TrustedProfileTemplateList.from_dict(trusted_profile_template_list_model_json)
+        assert trusted_profile_template_list_model != False
+
+        # Construct a model instance of TrustedProfileTemplateList by calling from_dict on the json representation
+        trusted_profile_template_list_model_dict = TrustedProfileTemplateList.from_dict(trusted_profile_template_list_model_json).__dict__
+        trusted_profile_template_list_model2 = TrustedProfileTemplateList(**trusted_profile_template_list_model_dict)
+
+        # Verify the model instances are equivalent
+        assert trusted_profile_template_list_model == trusted_profile_template_list_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        trusted_profile_template_list_model_json2 = trusted_profile_template_list_model.to_dict()
+        assert trusted_profile_template_list_model_json2 == trusted_profile_template_list_model_json
+
+
+class TestModel_TrustedProfileTemplateResponse:
+    """
+    Test Class for TrustedProfileTemplateResponse
+    """
+
+    def test_trusted_profile_template_response_serialization(self):
+        """
+        Test serialization/deserialization for TrustedProfileTemplateResponse
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        profile_claim_rule_conditions_model = {}  # ProfileClaimRuleConditions
+        profile_claim_rule_conditions_model['claim'] = 'testString'
+        profile_claim_rule_conditions_model['operator'] = 'testString'
+        profile_claim_rule_conditions_model['value'] = 'testString'
+
+        trusted_profile_template_claim_rule_model = {}  # TrustedProfileTemplateClaimRule
+        trusted_profile_template_claim_rule_model['name'] = 'testString'
+        trusted_profile_template_claim_rule_model['type'] = 'Profile-SAML'
+        trusted_profile_template_claim_rule_model['realm_name'] = 'testString'
+        trusted_profile_template_claim_rule_model['expiration'] = 38
+        trusted_profile_template_claim_rule_model['conditions'] = [profile_claim_rule_conditions_model]
+
+        profile_identity_response_model = {}  # ProfileIdentityResponse
+        profile_identity_response_model['iam_id'] = 'testString'
+        profile_identity_response_model['identifier'] = 'testString'
+        profile_identity_response_model['type'] = 'user'
+        profile_identity_response_model['accounts'] = ['testString']
+        profile_identity_response_model['description'] = 'testString'
+
+        template_profile_component_response_model = {}  # TemplateProfileComponentResponse
+        template_profile_component_response_model['name'] = 'testString'
+        template_profile_component_response_model['description'] = 'testString'
+        template_profile_component_response_model['rules'] = [trusted_profile_template_claim_rule_model]
+        template_profile_component_response_model['identities'] = [profile_identity_response_model]
+
+        policy_template_reference_model = {}  # PolicyTemplateReference
+        policy_template_reference_model['id'] = 'testString'
+        policy_template_reference_model['version'] = 'testString'
+
+        enity_history_record_model = {}  # EnityHistoryRecord
+        enity_history_record_model['timestamp'] = 'testString'
+        enity_history_record_model['iam_id'] = 'testString'
+        enity_history_record_model['iam_id_account'] = 'testString'
+        enity_history_record_model['action'] = 'testString'
+        enity_history_record_model['params'] = ['testString']
+        enity_history_record_model['message'] = 'testString'
+
+        # Construct a json representation of a TrustedProfileTemplateResponse model
+        trusted_profile_template_response_model_json = {}
+        trusted_profile_template_response_model_json['id'] = 'testString'
+        trusted_profile_template_response_model_json['version'] = 26
+        trusted_profile_template_response_model_json['account_id'] = 'testString'
+        trusted_profile_template_response_model_json['name'] = 'testString'
+        trusted_profile_template_response_model_json['description'] = 'testString'
+        trusted_profile_template_response_model_json['committed'] = True
+        trusted_profile_template_response_model_json['profile'] = template_profile_component_response_model
+        trusted_profile_template_response_model_json['policy_template_references'] = [policy_template_reference_model]
+        trusted_profile_template_response_model_json['history'] = [enity_history_record_model]
+        trusted_profile_template_response_model_json['entity_tag'] = 'testString'
+        trusted_profile_template_response_model_json['crn'] = 'testString'
+        trusted_profile_template_response_model_json['created_at'] = 'testString'
+        trusted_profile_template_response_model_json['created_by_id'] = 'testString'
+        trusted_profile_template_response_model_json['last_modified_at'] = 'testString'
+        trusted_profile_template_response_model_json['last_modified_by_id'] = 'testString'
+
+        # Construct a model instance of TrustedProfileTemplateResponse by calling from_dict on the json representation
+        trusted_profile_template_response_model = TrustedProfileTemplateResponse.from_dict(trusted_profile_template_response_model_json)
+        assert trusted_profile_template_response_model != False
+
+        # Construct a model instance of TrustedProfileTemplateResponse by calling from_dict on the json representation
+        trusted_profile_template_response_model_dict = TrustedProfileTemplateResponse.from_dict(trusted_profile_template_response_model_json).__dict__
+        trusted_profile_template_response_model2 = TrustedProfileTemplateResponse(**trusted_profile_template_response_model_dict)
+
+        # Verify the model instances are equivalent
+        assert trusted_profile_template_response_model == trusted_profile_template_response_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        trusted_profile_template_response_model_json2 = trusted_profile_template_response_model.to_dict()
+        assert trusted_profile_template_response_model_json2 == trusted_profile_template_response_model_json
 
 
 class TestModel_TrustedProfilesList:
@@ -6076,6 +10474,8 @@ class TestModel_TrustedProfilesList:
         trusted_profile_model['modified_at'] = '2019-01-01T12:00:00Z'
         trusted_profile_model['iam_id'] = 'testString'
         trusted_profile_model['account_id'] = 'testString'
+        trusted_profile_model['template_id'] = 'testString'
+        trusted_profile_model['assignment_id'] = 'testString'
         trusted_profile_model['ims_account_id'] = 26
         trusted_profile_model['ims_user_id'] = 26
         trusted_profile_model['history'] = [enity_history_record_model]
@@ -6234,18 +10634,12 @@ class TestModel_UserReportMfaEnrollmentStatus:
         user_report_mfa_enrollment_status_model_json['enrollments'] = mfa_enrollments_model
 
         # Construct a model instance of UserReportMfaEnrollmentStatus by calling from_dict on the json representation
-        user_report_mfa_enrollment_status_model = UserReportMfaEnrollmentStatus.from_dict(
-            user_report_mfa_enrollment_status_model_json
-        )
+        user_report_mfa_enrollment_status_model = UserReportMfaEnrollmentStatus.from_dict(user_report_mfa_enrollment_status_model_json)
         assert user_report_mfa_enrollment_status_model != False
 
         # Construct a model instance of UserReportMfaEnrollmentStatus by calling from_dict on the json representation
-        user_report_mfa_enrollment_status_model_dict = UserReportMfaEnrollmentStatus.from_dict(
-            user_report_mfa_enrollment_status_model_json
-        ).__dict__
-        user_report_mfa_enrollment_status_model2 = UserReportMfaEnrollmentStatus(
-            **user_report_mfa_enrollment_status_model_dict
-        )
+        user_report_mfa_enrollment_status_model_dict = UserReportMfaEnrollmentStatus.from_dict(user_report_mfa_enrollment_status_model_json).__dict__
+        user_report_mfa_enrollment_status_model2 = UserReportMfaEnrollmentStatus(**user_report_mfa_enrollment_status_model_dict)
 
         # Verify the model instances are equivalent
         assert user_report_mfa_enrollment_status_model == user_report_mfa_enrollment_status_model2

--- a/test/unit/test_iam_identity_v1.py
+++ b/test/unit/test_iam_identity_v1.py
@@ -31,9 +31,7 @@ import urllib
 from ibm_platform_services.iam_identity_v1 import *
 
 
-_service = IamIdentityV1(
-    authenticator=NoAuthAuthenticator()
-)
+_service = IamIdentityV1(authenticator=NoAuthAuthenticator())
 
 _base_url = 'https://iam.cloud.ibm.com'
 _service.set_service_url(_base_url)
@@ -7933,11 +7931,15 @@ class TestModel_AccountBasedMfaEnrollment:
         account_based_mfa_enrollment_model_json['complies'] = True
 
         # Construct a model instance of AccountBasedMfaEnrollment by calling from_dict on the json representation
-        account_based_mfa_enrollment_model = AccountBasedMfaEnrollment.from_dict(account_based_mfa_enrollment_model_json)
+        account_based_mfa_enrollment_model = AccountBasedMfaEnrollment.from_dict(
+            account_based_mfa_enrollment_model_json
+        )
         assert account_based_mfa_enrollment_model != False
 
         # Construct a model instance of AccountBasedMfaEnrollment by calling from_dict on the json representation
-        account_based_mfa_enrollment_model_dict = AccountBasedMfaEnrollment.from_dict(account_based_mfa_enrollment_model_json).__dict__
+        account_based_mfa_enrollment_model_dict = AccountBasedMfaEnrollment.from_dict(
+            account_based_mfa_enrollment_model_json
+        ).__dict__
         account_based_mfa_enrollment_model2 = AccountBasedMfaEnrollment(**account_based_mfa_enrollment_model_dict)
 
         # Verify the model instances are equivalent
@@ -7982,7 +7984,9 @@ class TestModel_AccountSettingsComponent:
         assert account_settings_component_model != False
 
         # Construct a model instance of AccountSettingsComponent by calling from_dict on the json representation
-        account_settings_component_model_dict = AccountSettingsComponent.from_dict(account_settings_component_model_json).__dict__
+        account_settings_component_model_dict = AccountSettingsComponent.from_dict(
+            account_settings_component_model_json
+        ).__dict__
         account_settings_component_model2 = AccountSettingsComponent(**account_settings_component_model_dict)
 
         # Verify the model instances are equivalent
@@ -8052,7 +8056,9 @@ class TestModel_AccountSettingsResponse:
         assert account_settings_response_model != False
 
         # Construct a model instance of AccountSettingsResponse by calling from_dict on the json representation
-        account_settings_response_model_dict = AccountSettingsResponse.from_dict(account_settings_response_model_json).__dict__
+        account_settings_response_model_dict = AccountSettingsResponse.from_dict(
+            account_settings_response_model_json
+        ).__dict__
         account_settings_response_model2 = AccountSettingsResponse(**account_settings_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -8136,14 +8142,20 @@ class TestModel_AccountSettingsTemplateList:
         account_settings_template_list_model_json['first'] = 'testString'
         account_settings_template_list_model_json['previous'] = 'testString'
         account_settings_template_list_model_json['next'] = 'testString'
-        account_settings_template_list_model_json['account_settings_templates'] = [account_settings_template_response_model]
+        account_settings_template_list_model_json['account_settings_templates'] = [
+            account_settings_template_response_model
+        ]
 
         # Construct a model instance of AccountSettingsTemplateList by calling from_dict on the json representation
-        account_settings_template_list_model = AccountSettingsTemplateList.from_dict(account_settings_template_list_model_json)
+        account_settings_template_list_model = AccountSettingsTemplateList.from_dict(
+            account_settings_template_list_model_json
+        )
         assert account_settings_template_list_model != False
 
         # Construct a model instance of AccountSettingsTemplateList by calling from_dict on the json representation
-        account_settings_template_list_model_dict = AccountSettingsTemplateList.from_dict(account_settings_template_list_model_json).__dict__
+        account_settings_template_list_model_dict = AccountSettingsTemplateList.from_dict(
+            account_settings_template_list_model_json
+        ).__dict__
         account_settings_template_list_model2 = AccountSettingsTemplateList(**account_settings_template_list_model_dict)
 
         # Verify the model instances are equivalent
@@ -8208,12 +8220,18 @@ class TestModel_AccountSettingsTemplateResponse:
         account_settings_template_response_model_json['last_modified_by_id'] = 'testString'
 
         # Construct a model instance of AccountSettingsTemplateResponse by calling from_dict on the json representation
-        account_settings_template_response_model = AccountSettingsTemplateResponse.from_dict(account_settings_template_response_model_json)
+        account_settings_template_response_model = AccountSettingsTemplateResponse.from_dict(
+            account_settings_template_response_model_json
+        )
         assert account_settings_template_response_model != False
 
         # Construct a model instance of AccountSettingsTemplateResponse by calling from_dict on the json representation
-        account_settings_template_response_model_dict = AccountSettingsTemplateResponse.from_dict(account_settings_template_response_model_json).__dict__
-        account_settings_template_response_model2 = AccountSettingsTemplateResponse(**account_settings_template_response_model_dict)
+        account_settings_template_response_model_dict = AccountSettingsTemplateResponse.from_dict(
+            account_settings_template_response_model_json
+        ).__dict__
+        account_settings_template_response_model2 = AccountSettingsTemplateResponse(
+            **account_settings_template_response_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert account_settings_template_response_model == account_settings_template_response_model2
@@ -8243,7 +8261,9 @@ class TestModel_AccountSettingsUserMFA:
         assert account_settings_user_mfa_model != False
 
         # Construct a model instance of AccountSettingsUserMFA by calling from_dict on the json representation
-        account_settings_user_mfa_model_dict = AccountSettingsUserMFA.from_dict(account_settings_user_mfa_model_json).__dict__
+        account_settings_user_mfa_model_dict = AccountSettingsUserMFA.from_dict(
+            account_settings_user_mfa_model_json
+        ).__dict__
         account_settings_user_mfa_model2 = AccountSettingsUserMFA(**account_settings_user_mfa_model_dict)
 
         # Verify the model instances are equivalent
@@ -8374,19 +8394,27 @@ class TestModel_ApiKeyInsideCreateServiceIdRequest:
         api_key_inside_create_service_id_request_model_json['store_value'] = True
 
         # Construct a model instance of ApiKeyInsideCreateServiceIdRequest by calling from_dict on the json representation
-        api_key_inside_create_service_id_request_model = ApiKeyInsideCreateServiceIdRequest.from_dict(api_key_inside_create_service_id_request_model_json)
+        api_key_inside_create_service_id_request_model = ApiKeyInsideCreateServiceIdRequest.from_dict(
+            api_key_inside_create_service_id_request_model_json
+        )
         assert api_key_inside_create_service_id_request_model != False
 
         # Construct a model instance of ApiKeyInsideCreateServiceIdRequest by calling from_dict on the json representation
-        api_key_inside_create_service_id_request_model_dict = ApiKeyInsideCreateServiceIdRequest.from_dict(api_key_inside_create_service_id_request_model_json).__dict__
-        api_key_inside_create_service_id_request_model2 = ApiKeyInsideCreateServiceIdRequest(**api_key_inside_create_service_id_request_model_dict)
+        api_key_inside_create_service_id_request_model_dict = ApiKeyInsideCreateServiceIdRequest.from_dict(
+            api_key_inside_create_service_id_request_model_json
+        ).__dict__
+        api_key_inside_create_service_id_request_model2 = ApiKeyInsideCreateServiceIdRequest(
+            **api_key_inside_create_service_id_request_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert api_key_inside_create_service_id_request_model == api_key_inside_create_service_id_request_model2
 
         # Convert model instance back to dict and verify no loss of data
         api_key_inside_create_service_id_request_model_json2 = api_key_inside_create_service_id_request_model.to_dict()
-        assert api_key_inside_create_service_id_request_model_json2 == api_key_inside_create_service_id_request_model_json
+        assert (
+            api_key_inside_create_service_id_request_model_json2 == api_key_inside_create_service_id_request_model_json
+        )
 
 
 class TestModel_ApiKeyList:
@@ -8536,7 +8564,9 @@ class TestModel_ApikeyActivityServiceid:
         assert apikey_activity_serviceid_model != False
 
         # Construct a model instance of ApikeyActivityServiceid by calling from_dict on the json representation
-        apikey_activity_serviceid_model_dict = ApikeyActivityServiceid.from_dict(apikey_activity_serviceid_model_json).__dict__
+        apikey_activity_serviceid_model_dict = ApikeyActivityServiceid.from_dict(
+            apikey_activity_serviceid_model_json
+        ).__dict__
         apikey_activity_serviceid_model2 = ApikeyActivityServiceid(**apikey_activity_serviceid_model_dict)
 
         # Verify the model instances are equivalent
@@ -8597,12 +8627,18 @@ class TestModel_CreateProfileLinkRequestLink:
         create_profile_link_request_link_model_json['name'] = 'testString'
 
         # Construct a model instance of CreateProfileLinkRequestLink by calling from_dict on the json representation
-        create_profile_link_request_link_model = CreateProfileLinkRequestLink.from_dict(create_profile_link_request_link_model_json)
+        create_profile_link_request_link_model = CreateProfileLinkRequestLink.from_dict(
+            create_profile_link_request_link_model_json
+        )
         assert create_profile_link_request_link_model != False
 
         # Construct a model instance of CreateProfileLinkRequestLink by calling from_dict on the json representation
-        create_profile_link_request_link_model_dict = CreateProfileLinkRequestLink.from_dict(create_profile_link_request_link_model_json).__dict__
-        create_profile_link_request_link_model2 = CreateProfileLinkRequestLink(**create_profile_link_request_link_model_dict)
+        create_profile_link_request_link_model_dict = CreateProfileLinkRequestLink.from_dict(
+            create_profile_link_request_link_model_json
+        ).__dict__
+        create_profile_link_request_link_model2 = CreateProfileLinkRequestLink(
+            **create_profile_link_request_link_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert create_profile_link_request_link_model == create_profile_link_request_link_model2
@@ -8819,7 +8855,9 @@ class TestModel_MfaEnrollmentTypeStatus:
         assert mfa_enrollment_type_status_model != False
 
         # Construct a model instance of MfaEnrollmentTypeStatus by calling from_dict on the json representation
-        mfa_enrollment_type_status_model_dict = MfaEnrollmentTypeStatus.from_dict(mfa_enrollment_type_status_model_json).__dict__
+        mfa_enrollment_type_status_model_dict = MfaEnrollmentTypeStatus.from_dict(
+            mfa_enrollment_type_status_model_json
+        ).__dict__
         mfa_enrollment_type_status_model2 = MfaEnrollmentTypeStatus(**mfa_enrollment_type_status_model_dict)
 
         # Verify the model instances are equivalent
@@ -8900,7 +8938,9 @@ class TestModel_PolicyTemplateReference:
         assert policy_template_reference_model != False
 
         # Construct a model instance of PolicyTemplateReference by calling from_dict on the json representation
-        policy_template_reference_model_dict = PolicyTemplateReference.from_dict(policy_template_reference_model_json).__dict__
+        policy_template_reference_model_dict = PolicyTemplateReference.from_dict(
+            policy_template_reference_model_json
+        ).__dict__
         policy_template_reference_model2 = PolicyTemplateReference(**policy_template_reference_model_dict)
 
         # Verify the model instances are equivalent
@@ -8974,11 +9014,15 @@ class TestModel_ProfileClaimRuleConditions:
         profile_claim_rule_conditions_model_json['value'] = 'testString'
 
         # Construct a model instance of ProfileClaimRuleConditions by calling from_dict on the json representation
-        profile_claim_rule_conditions_model = ProfileClaimRuleConditions.from_dict(profile_claim_rule_conditions_model_json)
+        profile_claim_rule_conditions_model = ProfileClaimRuleConditions.from_dict(
+            profile_claim_rule_conditions_model_json
+        )
         assert profile_claim_rule_conditions_model != False
 
         # Construct a model instance of ProfileClaimRuleConditions by calling from_dict on the json representation
-        profile_claim_rule_conditions_model_dict = ProfileClaimRuleConditions.from_dict(profile_claim_rule_conditions_model_json).__dict__
+        profile_claim_rule_conditions_model_dict = ProfileClaimRuleConditions.from_dict(
+            profile_claim_rule_conditions_model_json
+        ).__dict__
         profile_claim_rule_conditions_model2 = ProfileClaimRuleConditions(**profile_claim_rule_conditions_model_dict)
 
         # Verify the model instances are equivalent
@@ -9081,7 +9125,9 @@ class TestModel_ProfileIdentitiesResponse:
         assert profile_identities_response_model != False
 
         # Construct a model instance of ProfileIdentitiesResponse by calling from_dict on the json representation
-        profile_identities_response_model_dict = ProfileIdentitiesResponse.from_dict(profile_identities_response_model_json).__dict__
+        profile_identities_response_model_dict = ProfileIdentitiesResponse.from_dict(
+            profile_identities_response_model_json
+        ).__dict__
         profile_identities_response_model2 = ProfileIdentitiesResponse(**profile_identities_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -9114,7 +9160,9 @@ class TestModel_ProfileIdentityRequest:
         assert profile_identity_request_model != False
 
         # Construct a model instance of ProfileIdentityRequest by calling from_dict on the json representation
-        profile_identity_request_model_dict = ProfileIdentityRequest.from_dict(profile_identity_request_model_json).__dict__
+        profile_identity_request_model_dict = ProfileIdentityRequest.from_dict(
+            profile_identity_request_model_json
+        ).__dict__
         profile_identity_request_model2 = ProfileIdentityRequest(**profile_identity_request_model_dict)
 
         # Verify the model instances are equivalent
@@ -9148,7 +9196,9 @@ class TestModel_ProfileIdentityResponse:
         assert profile_identity_response_model != False
 
         # Construct a model instance of ProfileIdentityResponse by calling from_dict on the json representation
-        profile_identity_response_model_dict = ProfileIdentityResponse.from_dict(profile_identity_response_model_json).__dict__
+        profile_identity_response_model_dict = ProfileIdentityResponse.from_dict(
+            profile_identity_response_model_json
+        ).__dict__
         profile_identity_response_model2 = ProfileIdentityResponse(**profile_identity_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -9400,11 +9450,15 @@ class TestModel_ReportMfaEnrollmentStatus:
         report_mfa_enrollment_status_model_json['users'] = [user_report_mfa_enrollment_status_model]
 
         # Construct a model instance of ReportMfaEnrollmentStatus by calling from_dict on the json representation
-        report_mfa_enrollment_status_model = ReportMfaEnrollmentStatus.from_dict(report_mfa_enrollment_status_model_json)
+        report_mfa_enrollment_status_model = ReportMfaEnrollmentStatus.from_dict(
+            report_mfa_enrollment_status_model_json
+        )
         assert report_mfa_enrollment_status_model != False
 
         # Construct a model instance of ReportMfaEnrollmentStatus by calling from_dict on the json representation
-        report_mfa_enrollment_status_model_dict = ReportMfaEnrollmentStatus.from_dict(report_mfa_enrollment_status_model_json).__dict__
+        report_mfa_enrollment_status_model_dict = ReportMfaEnrollmentStatus.from_dict(
+            report_mfa_enrollment_status_model_json
+        ).__dict__
         report_mfa_enrollment_status_model2 = ReportMfaEnrollmentStatus(**report_mfa_enrollment_status_model_dict)
 
         # Verify the model instances are equivalent
@@ -9714,8 +9768,12 @@ class TestModel_TemplateAssignmentListResponse:
         template_assignment_response_resource_model = {}  # TemplateAssignmentResponseResource
         template_assignment_response_resource_model['target'] = 'testString'
         template_assignment_response_resource_model['profile'] = template_assignment_response_resource_detail_model
-        template_assignment_response_resource_model['account_settings'] = template_assignment_response_resource_detail_model
-        template_assignment_response_resource_model['policy_template_refs'] = [template_assignment_response_resource_detail_model]
+        template_assignment_response_resource_model[
+            'account_settings'
+        ] = template_assignment_response_resource_detail_model
+        template_assignment_response_resource_model['policy_template_refs'] = [
+            template_assignment_response_resource_detail_model
+        ]
 
         enity_history_record_model = {}  # EnityHistoryRecord
         enity_history_record_model['timestamp'] = 'testString'
@@ -9754,12 +9812,18 @@ class TestModel_TemplateAssignmentListResponse:
         template_assignment_list_response_model_json['assignments'] = [template_assignment_response_model]
 
         # Construct a model instance of TemplateAssignmentListResponse by calling from_dict on the json representation
-        template_assignment_list_response_model = TemplateAssignmentListResponse.from_dict(template_assignment_list_response_model_json)
+        template_assignment_list_response_model = TemplateAssignmentListResponse.from_dict(
+            template_assignment_list_response_model_json
+        )
         assert template_assignment_list_response_model != False
 
         # Construct a model instance of TemplateAssignmentListResponse by calling from_dict on the json representation
-        template_assignment_list_response_model_dict = TemplateAssignmentListResponse.from_dict(template_assignment_list_response_model_json).__dict__
-        template_assignment_list_response_model2 = TemplateAssignmentListResponse(**template_assignment_list_response_model_dict)
+        template_assignment_list_response_model_dict = TemplateAssignmentListResponse.from_dict(
+            template_assignment_list_response_model_json
+        ).__dict__
+        template_assignment_list_response_model2 = TemplateAssignmentListResponse(
+            **template_assignment_list_response_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert template_assignment_list_response_model == template_assignment_list_response_model2
@@ -9784,11 +9848,15 @@ class TestModel_TemplateAssignmentResource:
         template_assignment_resource_model_json['id'] = 'testString'
 
         # Construct a model instance of TemplateAssignmentResource by calling from_dict on the json representation
-        template_assignment_resource_model = TemplateAssignmentResource.from_dict(template_assignment_resource_model_json)
+        template_assignment_resource_model = TemplateAssignmentResource.from_dict(
+            template_assignment_resource_model_json
+        )
         assert template_assignment_resource_model != False
 
         # Construct a model instance of TemplateAssignmentResource by calling from_dict on the json representation
-        template_assignment_resource_model_dict = TemplateAssignmentResource.from_dict(template_assignment_resource_model_json).__dict__
+        template_assignment_resource_model_dict = TemplateAssignmentResource.from_dict(
+            template_assignment_resource_model_json
+        ).__dict__
         template_assignment_resource_model2 = TemplateAssignmentResource(**template_assignment_resource_model_dict)
 
         # Verify the model instances are equivalent
@@ -9817,12 +9885,18 @@ class TestModel_TemplateAssignmentResourceError:
         template_assignment_resource_error_model_json['statusCode'] = 'testString'
 
         # Construct a model instance of TemplateAssignmentResourceError by calling from_dict on the json representation
-        template_assignment_resource_error_model = TemplateAssignmentResourceError.from_dict(template_assignment_resource_error_model_json)
+        template_assignment_resource_error_model = TemplateAssignmentResourceError.from_dict(
+            template_assignment_resource_error_model_json
+        )
         assert template_assignment_resource_error_model != False
 
         # Construct a model instance of TemplateAssignmentResourceError by calling from_dict on the json representation
-        template_assignment_resource_error_model_dict = TemplateAssignmentResourceError.from_dict(template_assignment_resource_error_model_json).__dict__
-        template_assignment_resource_error_model2 = TemplateAssignmentResourceError(**template_assignment_resource_error_model_dict)
+        template_assignment_resource_error_model_dict = TemplateAssignmentResourceError.from_dict(
+            template_assignment_resource_error_model_json
+        ).__dict__
+        template_assignment_resource_error_model2 = TemplateAssignmentResourceError(
+            **template_assignment_resource_error_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert template_assignment_resource_error_model == template_assignment_resource_error_model2
@@ -9876,8 +9950,12 @@ class TestModel_TemplateAssignmentResponse:
         template_assignment_response_resource_model = {}  # TemplateAssignmentResponseResource
         template_assignment_response_resource_model['target'] = 'testString'
         template_assignment_response_resource_model['profile'] = template_assignment_response_resource_detail_model
-        template_assignment_response_resource_model['account_settings'] = template_assignment_response_resource_detail_model
-        template_assignment_response_resource_model['policy_template_refs'] = [template_assignment_response_resource_detail_model]
+        template_assignment_response_resource_model[
+            'account_settings'
+        ] = template_assignment_response_resource_detail_model
+        template_assignment_response_resource_model['policy_template_refs'] = [
+            template_assignment_response_resource_detail_model
+        ]
 
         enity_history_record_model = {}  # EnityHistoryRecord
         enity_history_record_model['timestamp'] = 'testString'
@@ -9907,11 +9985,15 @@ class TestModel_TemplateAssignmentResponse:
         template_assignment_response_model_json['entity_tag'] = 'testString'
 
         # Construct a model instance of TemplateAssignmentResponse by calling from_dict on the json representation
-        template_assignment_response_model = TemplateAssignmentResponse.from_dict(template_assignment_response_model_json)
+        template_assignment_response_model = TemplateAssignmentResponse.from_dict(
+            template_assignment_response_model_json
+        )
         assert template_assignment_response_model != False
 
         # Construct a model instance of TemplateAssignmentResponse by calling from_dict on the json representation
-        template_assignment_response_model_dict = TemplateAssignmentResponse.from_dict(template_assignment_response_model_json).__dict__
+        template_assignment_response_model_dict = TemplateAssignmentResponse.from_dict(
+            template_assignment_response_model_json
+        ).__dict__
         template_assignment_response_model2 = TemplateAssignmentResponse(**template_assignment_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -9954,16 +10036,26 @@ class TestModel_TemplateAssignmentResponseResource:
         template_assignment_response_resource_model_json = {}
         template_assignment_response_resource_model_json['target'] = 'testString'
         template_assignment_response_resource_model_json['profile'] = template_assignment_response_resource_detail_model
-        template_assignment_response_resource_model_json['account_settings'] = template_assignment_response_resource_detail_model
-        template_assignment_response_resource_model_json['policy_template_refs'] = [template_assignment_response_resource_detail_model]
+        template_assignment_response_resource_model_json[
+            'account_settings'
+        ] = template_assignment_response_resource_detail_model
+        template_assignment_response_resource_model_json['policy_template_refs'] = [
+            template_assignment_response_resource_detail_model
+        ]
 
         # Construct a model instance of TemplateAssignmentResponseResource by calling from_dict on the json representation
-        template_assignment_response_resource_model = TemplateAssignmentResponseResource.from_dict(template_assignment_response_resource_model_json)
+        template_assignment_response_resource_model = TemplateAssignmentResponseResource.from_dict(
+            template_assignment_response_resource_model_json
+        )
         assert template_assignment_response_resource_model != False
 
         # Construct a model instance of TemplateAssignmentResponseResource by calling from_dict on the json representation
-        template_assignment_response_resource_model_dict = TemplateAssignmentResponseResource.from_dict(template_assignment_response_resource_model_json).__dict__
-        template_assignment_response_resource_model2 = TemplateAssignmentResponseResource(**template_assignment_response_resource_model_dict)
+        template_assignment_response_resource_model_dict = TemplateAssignmentResponseResource.from_dict(
+            template_assignment_response_resource_model_json
+        ).__dict__
+        template_assignment_response_resource_model2 = TemplateAssignmentResponseResource(
+            **template_assignment_response_resource_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert template_assignment_response_resource_model == template_assignment_response_resource_model2
@@ -9999,23 +10091,36 @@ class TestModel_TemplateAssignmentResponseResourceDetail:
         template_assignment_response_resource_detail_model_json['id'] = 'testString'
         template_assignment_response_resource_detail_model_json['version'] = 'testString'
         template_assignment_response_resource_detail_model_json['resource_created'] = template_assignment_resource_model
-        template_assignment_response_resource_detail_model_json['error_message'] = template_assignment_resource_error_model
+        template_assignment_response_resource_detail_model_json[
+            'error_message'
+        ] = template_assignment_resource_error_model
         template_assignment_response_resource_detail_model_json['status'] = 'testString'
 
         # Construct a model instance of TemplateAssignmentResponseResourceDetail by calling from_dict on the json representation
-        template_assignment_response_resource_detail_model = TemplateAssignmentResponseResourceDetail.from_dict(template_assignment_response_resource_detail_model_json)
+        template_assignment_response_resource_detail_model = TemplateAssignmentResponseResourceDetail.from_dict(
+            template_assignment_response_resource_detail_model_json
+        )
         assert template_assignment_response_resource_detail_model != False
 
         # Construct a model instance of TemplateAssignmentResponseResourceDetail by calling from_dict on the json representation
-        template_assignment_response_resource_detail_model_dict = TemplateAssignmentResponseResourceDetail.from_dict(template_assignment_response_resource_detail_model_json).__dict__
-        template_assignment_response_resource_detail_model2 = TemplateAssignmentResponseResourceDetail(**template_assignment_response_resource_detail_model_dict)
+        template_assignment_response_resource_detail_model_dict = TemplateAssignmentResponseResourceDetail.from_dict(
+            template_assignment_response_resource_detail_model_json
+        ).__dict__
+        template_assignment_response_resource_detail_model2 = TemplateAssignmentResponseResourceDetail(
+            **template_assignment_response_resource_detail_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert template_assignment_response_resource_detail_model == template_assignment_response_resource_detail_model2
 
         # Convert model instance back to dict and verify no loss of data
-        template_assignment_response_resource_detail_model_json2 = template_assignment_response_resource_detail_model.to_dict()
-        assert template_assignment_response_resource_detail_model_json2 == template_assignment_response_resource_detail_model_json
+        template_assignment_response_resource_detail_model_json2 = (
+            template_assignment_response_resource_detail_model.to_dict()
+        )
+        assert (
+            template_assignment_response_resource_detail_model_json2
+            == template_assignment_response_resource_detail_model_json
+        )
 
 
 class TestModel_TemplateProfileComponentRequest:
@@ -10056,12 +10161,18 @@ class TestModel_TemplateProfileComponentRequest:
         template_profile_component_request_model_json['identities'] = [profile_identity_request_model]
 
         # Construct a model instance of TemplateProfileComponentRequest by calling from_dict on the json representation
-        template_profile_component_request_model = TemplateProfileComponentRequest.from_dict(template_profile_component_request_model_json)
+        template_profile_component_request_model = TemplateProfileComponentRequest.from_dict(
+            template_profile_component_request_model_json
+        )
         assert template_profile_component_request_model != False
 
         # Construct a model instance of TemplateProfileComponentRequest by calling from_dict on the json representation
-        template_profile_component_request_model_dict = TemplateProfileComponentRequest.from_dict(template_profile_component_request_model_json).__dict__
-        template_profile_component_request_model2 = TemplateProfileComponentRequest(**template_profile_component_request_model_dict)
+        template_profile_component_request_model_dict = TemplateProfileComponentRequest.from_dict(
+            template_profile_component_request_model_json
+        ).__dict__
+        template_profile_component_request_model2 = TemplateProfileComponentRequest(
+            **template_profile_component_request_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert template_profile_component_request_model == template_profile_component_request_model2
@@ -10110,12 +10221,18 @@ class TestModel_TemplateProfileComponentResponse:
         template_profile_component_response_model_json['identities'] = [profile_identity_response_model]
 
         # Construct a model instance of TemplateProfileComponentResponse by calling from_dict on the json representation
-        template_profile_component_response_model = TemplateProfileComponentResponse.from_dict(template_profile_component_response_model_json)
+        template_profile_component_response_model = TemplateProfileComponentResponse.from_dict(
+            template_profile_component_response_model_json
+        )
         assert template_profile_component_response_model != False
 
         # Construct a model instance of TemplateProfileComponentResponse by calling from_dict on the json representation
-        template_profile_component_response_model_dict = TemplateProfileComponentResponse.from_dict(template_profile_component_response_model_json).__dict__
-        template_profile_component_response_model2 = TemplateProfileComponentResponse(**template_profile_component_response_model_dict)
+        template_profile_component_response_model_dict = TemplateProfileComponentResponse.from_dict(
+            template_profile_component_response_model_json
+        ).__dict__
+        template_profile_component_response_model2 = TemplateProfileComponentResponse(
+            **template_profile_component_response_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert template_profile_component_response_model == template_profile_component_response_model2
@@ -10223,12 +10340,18 @@ class TestModel_TrustedProfileTemplateClaimRule:
         trusted_profile_template_claim_rule_model_json['conditions'] = [profile_claim_rule_conditions_model]
 
         # Construct a model instance of TrustedProfileTemplateClaimRule by calling from_dict on the json representation
-        trusted_profile_template_claim_rule_model = TrustedProfileTemplateClaimRule.from_dict(trusted_profile_template_claim_rule_model_json)
+        trusted_profile_template_claim_rule_model = TrustedProfileTemplateClaimRule.from_dict(
+            trusted_profile_template_claim_rule_model_json
+        )
         assert trusted_profile_template_claim_rule_model != False
 
         # Construct a model instance of TrustedProfileTemplateClaimRule by calling from_dict on the json representation
-        trusted_profile_template_claim_rule_model_dict = TrustedProfileTemplateClaimRule.from_dict(trusted_profile_template_claim_rule_model_json).__dict__
-        trusted_profile_template_claim_rule_model2 = TrustedProfileTemplateClaimRule(**trusted_profile_template_claim_rule_model_dict)
+        trusted_profile_template_claim_rule_model_dict = TrustedProfileTemplateClaimRule.from_dict(
+            trusted_profile_template_claim_rule_model_json
+        ).__dict__
+        trusted_profile_template_claim_rule_model2 = TrustedProfileTemplateClaimRule(
+            **trusted_profile_template_claim_rule_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert trusted_profile_template_claim_rule_model == trusted_profile_template_claim_rule_model2
@@ -10328,11 +10451,15 @@ class TestModel_TrustedProfileTemplateList:
         trusted_profile_template_list_model_json['profile_templates'] = [trusted_profile_template_response_model]
 
         # Construct a model instance of TrustedProfileTemplateList by calling from_dict on the json representation
-        trusted_profile_template_list_model = TrustedProfileTemplateList.from_dict(trusted_profile_template_list_model_json)
+        trusted_profile_template_list_model = TrustedProfileTemplateList.from_dict(
+            trusted_profile_template_list_model_json
+        )
         assert trusted_profile_template_list_model != False
 
         # Construct a model instance of TrustedProfileTemplateList by calling from_dict on the json representation
-        trusted_profile_template_list_model_dict = TrustedProfileTemplateList.from_dict(trusted_profile_template_list_model_json).__dict__
+        trusted_profile_template_list_model_dict = TrustedProfileTemplateList.from_dict(
+            trusted_profile_template_list_model_json
+        ).__dict__
         trusted_profile_template_list_model2 = TrustedProfileTemplateList(**trusted_profile_template_list_model_dict)
 
         # Verify the model instances are equivalent
@@ -10411,12 +10538,18 @@ class TestModel_TrustedProfileTemplateResponse:
         trusted_profile_template_response_model_json['last_modified_by_id'] = 'testString'
 
         # Construct a model instance of TrustedProfileTemplateResponse by calling from_dict on the json representation
-        trusted_profile_template_response_model = TrustedProfileTemplateResponse.from_dict(trusted_profile_template_response_model_json)
+        trusted_profile_template_response_model = TrustedProfileTemplateResponse.from_dict(
+            trusted_profile_template_response_model_json
+        )
         assert trusted_profile_template_response_model != False
 
         # Construct a model instance of TrustedProfileTemplateResponse by calling from_dict on the json representation
-        trusted_profile_template_response_model_dict = TrustedProfileTemplateResponse.from_dict(trusted_profile_template_response_model_json).__dict__
-        trusted_profile_template_response_model2 = TrustedProfileTemplateResponse(**trusted_profile_template_response_model_dict)
+        trusted_profile_template_response_model_dict = TrustedProfileTemplateResponse.from_dict(
+            trusted_profile_template_response_model_json
+        ).__dict__
+        trusted_profile_template_response_model2 = TrustedProfileTemplateResponse(
+            **trusted_profile_template_response_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert trusted_profile_template_response_model == trusted_profile_template_response_model2
@@ -10634,12 +10767,18 @@ class TestModel_UserReportMfaEnrollmentStatus:
         user_report_mfa_enrollment_status_model_json['enrollments'] = mfa_enrollments_model
 
         # Construct a model instance of UserReportMfaEnrollmentStatus by calling from_dict on the json representation
-        user_report_mfa_enrollment_status_model = UserReportMfaEnrollmentStatus.from_dict(user_report_mfa_enrollment_status_model_json)
+        user_report_mfa_enrollment_status_model = UserReportMfaEnrollmentStatus.from_dict(
+            user_report_mfa_enrollment_status_model_json
+        )
         assert user_report_mfa_enrollment_status_model != False
 
         # Construct a model instance of UserReportMfaEnrollmentStatus by calling from_dict on the json representation
-        user_report_mfa_enrollment_status_model_dict = UserReportMfaEnrollmentStatus.from_dict(user_report_mfa_enrollment_status_model_json).__dict__
-        user_report_mfa_enrollment_status_model2 = UserReportMfaEnrollmentStatus(**user_report_mfa_enrollment_status_model_dict)
+        user_report_mfa_enrollment_status_model_dict = UserReportMfaEnrollmentStatus.from_dict(
+            user_report_mfa_enrollment_status_model_json
+        ).__dict__
+        user_report_mfa_enrollment_status_model2 = UserReportMfaEnrollmentStatus(
+            **user_report_mfa_enrollment_status_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert user_report_mfa_enrollment_status_model == user_report_mfa_enrollment_status_model2


### PR DESCRIPTION
## PR summary
Added support for IAM enterprise feature. Enterprise admins can create templates for account settings and trusted profiles and assign them to accounts and account groups in the enterprise.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
SDK adopters will be able to work with IAM enterprise feature.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
API definition: [Staging](https://test.cloud.ibm.com/apidocs/iam-identity-token-api#list-profile-templates)

Test information:

Integration Tests:
```
==================================================== test session starts ====================================================
platform win32 -- Python 3.10.11, pytest-7.4.0, pluggy-1.2.0
rootdir: D:\BlueMix\repos\platform-services-python-sdk
collected 87 items

test\integration\test_iam_identity_v1.py ............................................................................. [ 88%]
..........                                                                                                             [100%]

============================================== 87 passed in 701.43s (0:11:41) ===============================================
```

Examples:
```
==================================================== test session starts ====================================================
platform win32 -- Python 3.10.11, pytest-7.4.0, pluggy-1.2.0
rootdir: D:\BlueMix\repos\platform-services-python-sdk
collected 68 items

examples\test_iam_identity_v1_examples.py ....................................................................         [100%]

============================================== 68 passed in 657.28s (0:10:57) ===============================================
```