### PR TITLE
fix: bump min supported version of python to 3.8

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -62,7 +62,8 @@ disable=too-many-arguments,
         deprecated-pragma,
         use-symbolic-message-instead,
         invalid-name,
-        global-statement
+        global-statement,
+        use-implicit-booleaness-not-comparison
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -191,14 +192,6 @@ attr-naming-style=snake_case
 # Regular expression matching correct attribute names. Overrides attr-naming-
 # style.
 #attr-rgx=
-
-# Bad variable names which should always be refused, separated by a comma.
-bad-names=foo,
-          bar,
-          baz,
-          toto,
-          tutu,
-          tata
 
 # Naming style matching correct class attribute names.
 class-attribute-naming-style=any
@@ -501,5 +494,5 @@ valid-metaclass-classmethod-first-arg=cls
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ language: python
 
 matrix:
   include:
-    - python: 3.7
     - python: 3.8
     - python: 3.9
     - python: 3.10
+    - python: 3.11
 
 cache: pip
 
@@ -32,7 +32,7 @@ deploy:
   script: npm run semantic-release
   skip_cleanup: true
   on:
-    python: '3.7'
+    python: '3.8'
     branch: main
 
 - provider: pypi
@@ -42,5 +42,5 @@ deploy:
   repository: https://upload.pypi.org/legacy
   skip_cleanup: true
   on:
-    python: '3.7'
+    python: '3.8'
     tags: true

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # example: "make setup"
 
 PYTHON=python
-LINT_DIRS=ibm_platform_services test examples
+LINT_DIRS=ibm_platform_services test/unit test/integration examples
 
 setup: deps dev_deps install_project
 

--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ Service Name | Module Name | Service Class Name
 
 * An [IBM Cloud][ibm-cloud-onboarding] account.
 * An IAM API key to allow the SDK to access your account. Create one [here](https://cloud.ibm.com/iam/apikeys).
-* Python 3.7 or above.
+* Python 3.8 or above.
 
 ## Installation
 
 To install, use `pip`:
 
 ```bash
-pip install --upgrade ibm-platform-services
+python -m pip install --upgrade ibm-platform-services
 ```
 
 Then in your code, you can import the appropriate service like this:

--- a/examples/test_context_based_restrictions_v1_examples.py
+++ b/examples/test_context_based_restrictions_v1_examples.py
@@ -53,6 +53,7 @@ zone_rev = None
 rule_id = None
 rule_rev = None
 
+
 ##############################################################################
 # Start of Examples for Service: ContextBasedRestrictionsV1
 ##############################################################################

--- a/examples/test_enterprise_billing_units_v1_examples.py
+++ b/examples/test_enterprise_billing_units_v1_examples.py
@@ -43,6 +43,8 @@ config_file = 'enterprise_billing_units.env'
 enterprise_billing_units_service = None
 
 config = None
+enterprise_id = None
+billing_unit_id = None
 
 
 ##############################################################################
@@ -87,7 +89,6 @@ class TestEnterpriseBillingUnitsV1Examples:
         get_billing_unit request example
         """
         try:
-            global billing_unit_id
             print('\nget_billing_unit() result:')
 
             # begin-get_billing_unit
@@ -109,7 +110,6 @@ class TestEnterpriseBillingUnitsV1Examples:
         list_billing_units request example
         """
         try:
-            global enterprise_id
             print('\nlist_billing_units() result:')
             # begin-list_billing_units
 
@@ -137,7 +137,6 @@ class TestEnterpriseBillingUnitsV1Examples:
         list_billing_options request example
         """
         try:
-            global billing_unit_id
             print('\nlist_billing_options() result:')
             # begin-list_billing_options
 
@@ -165,7 +164,6 @@ class TestEnterpriseBillingUnitsV1Examples:
         get_credit_pools request example
         """
         try:
-            global billing_unit_id
             print('\nget_credit_pools() result:')
 
             # begin-get_credit_pools

--- a/examples/test_global_catalog_v1_examples.py
+++ b/examples/test_global_catalog_v1_examples.py
@@ -131,7 +131,6 @@ class TestGlobalCatalogV1Examples:
         """
         get_catalog_entry request example
         """
-        global catalog_entry_id
         assert catalog_entry_id is not None
 
         try:
@@ -155,7 +154,6 @@ class TestGlobalCatalogV1Examples:
         """
         update_catalog_entry request example
         """
-        global catalog_entry_id
         assert catalog_entry_id is not None
 
         try:
@@ -234,7 +232,6 @@ class TestGlobalCatalogV1Examples:
         """
         get_child_objects request example
         """
-        global catalog_entry_id
         assert catalog_entry_id is not None
 
         try:
@@ -261,7 +258,6 @@ class TestGlobalCatalogV1Examples:
         """
         restore_catalog_entry request example
         """
-        global catalog_entry_id
         assert catalog_entry_id is not None
 
         try:
@@ -283,7 +279,6 @@ class TestGlobalCatalogV1Examples:
         """
         get_visibility request example
         """
-        global catalog_entry_id
         assert catalog_entry_id is not None
 
         try:
@@ -306,7 +301,6 @@ class TestGlobalCatalogV1Examples:
         """
         update_visibility request example
         """
-        global catalog_entry_id
         assert catalog_entry_id is not None
 
         try:
@@ -329,7 +323,6 @@ class TestGlobalCatalogV1Examples:
         """
         get_pricing request example
         """
-        global catalog_entry_id
         assert catalog_entry_id is not None
 
         try:
@@ -352,7 +345,6 @@ class TestGlobalCatalogV1Examples:
         """
         get_audit_logs request example
         """
-        global catalog_entry_id
         assert catalog_entry_id is not None
 
         try:
@@ -377,7 +369,6 @@ class TestGlobalCatalogV1Examples:
         """
         upload_artifact request example
         """
-        global catalog_entry_id
         assert catalog_entry_id is not None
 
         try:
@@ -404,7 +395,6 @@ class TestGlobalCatalogV1Examples:
         """
         get_artifact request example
         """
-        global catalog_entry_id
         assert catalog_entry_id is not None
 
         try:
@@ -430,7 +420,6 @@ class TestGlobalCatalogV1Examples:
         """
         list_artifacts request example
         """
-        global catalog_entry_id
         assert catalog_entry_id is not None
 
         try:
@@ -451,7 +440,6 @@ class TestGlobalCatalogV1Examples:
         """
         delete_artifact request example
         """
-        global catalog_entry_id
         assert catalog_entry_id is not None
 
         try:
@@ -474,7 +462,6 @@ class TestGlobalCatalogV1Examples:
         """
         delete_catalog_entry request example
         """
-        global catalog_entry_id
         assert catalog_entry_id is not None
 
         try:

--- a/examples/test_iam_access_groups_v2_examples.py
+++ b/examples/test_iam_access_groups_v2_examples.py
@@ -58,6 +58,8 @@ test_template_latest_etag = None
 test_account_group_id = None
 test_assignment_id = None
 test_assignment_etag = None
+access_group_e_tag_link = None
+
 
 ##############################################################################
 # Start of Examples for Service: IamAccessGroupsV2
@@ -101,7 +103,6 @@ class TestIamAccessGroupsV2Examples:
         create_access_group request example
         """
         try:
-            global access_group_id_link
             print('\ncreate_access_group() result:')
             # begin-create_access_group
 
@@ -128,7 +129,6 @@ class TestIamAccessGroupsV2Examples:
         get_access_group request example
         """
         try:
-            global access_group_e_tag_link
             print('\nget_access_group() result:')
             # begin-get_access_group
 
@@ -141,6 +141,7 @@ class TestIamAccessGroupsV2Examples:
 
             # end-get_access_group
 
+            global access_group_e_tag_link
             access_group_e_tag_link = response.get_headers().get('ETag')
         except ApiException as e:
             pytest.fail(str(e))

--- a/examples/test_iam_identity_v1_examples.py
+++ b/examples/test_iam_identity_v1_examples.py
@@ -52,6 +52,7 @@ config = None
 apikey_name = 'Example-ApiKey'
 serviceid_name = 'Example-ServiceId'
 
+# config property values
 account_id = None
 iam_id = None
 iam_id_member = None
@@ -61,6 +62,7 @@ enterprise_subaccount_id = None
 
 apikey_id = None
 apikey_etag = None
+
 svc_id = None
 svc_id_etag = None
 
@@ -190,19 +192,16 @@ class TestIamIdentityV1Examples:
         create_api_key request example
         """
         try:
-            global apikey_name, iam_id, apikey_id
-
             print('\ncreate_api_key() result:')
             # begin-create_api_key
 
             api_key = iam_identity_service.create_api_key(name=apikey_name, iam_id=iam_id).get_result()
-
-            apikey_id = api_key['id']
-
             print(json.dumps(api_key, indent=2))
 
             # end-create_api_key
 
+            global apikey_id
+            apikey_id = api_key['id']
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -212,15 +211,12 @@ class TestIamIdentityV1Examples:
         list_api_keys request example
         """
         try:
-            global account_id, iam_id
-
             print('\nlist_api_keys() result:')
             # begin-list_api_keys
 
             api_key_list = iam_identity_service.list_api_keys(
                 account_id=account_id, iam_id=iam_id, include_history=True
             ).get_result()
-
             print(json.dumps(api_key_list, indent=2))
 
             # end-list_api_keys
@@ -234,13 +230,10 @@ class TestIamIdentityV1Examples:
         get_api_keys_details request example
         """
         try:
-            global apikey
-
             print('\nget_api_keys_details() result:')
             # begin-get_api_keys_details
 
             api_key = iam_identity_service.get_api_keys_details(iam_api_key=apikey).get_result()
-
             print(json.dumps(api_key, indent=2))
 
             # end-get_api_keys_details
@@ -254,8 +247,6 @@ class TestIamIdentityV1Examples:
         get_api_key request example
         """
         try:
-            global apikey_id, apikey_etag
-
             print('\nget_api_key() result:')
             # begin-get_api_key
 
@@ -263,13 +254,13 @@ class TestIamIdentityV1Examples:
                 id=apikey_id,
                 include_activity=True,
             )
-
-            apikey_etag = response.get_headers()['Etag']
             api_key = response.get_result()
-
             print(json.dumps(api_key, indent=2))
 
             # end-get_api_key
+
+            global apikey_etag
+            apikey_etag = response.get_headers()['Etag']
 
         except ApiException as e:
             pytest.fail(str(e))
@@ -280,15 +271,12 @@ class TestIamIdentityV1Examples:
         update_api_key request example
         """
         try:
-            global apikey_id, apikey_etag
-
             print('\nupdate_api_key() result:')
             # begin-update_api_key
 
             api_key = iam_identity_service.update_api_key(
                 id=apikey_id, if_match=apikey_etag, description='This is an updated description'
             ).get_result()
-
             print(json.dumps(api_key, indent=2))
 
             # end-update_api_key
@@ -302,8 +290,6 @@ class TestIamIdentityV1Examples:
         lock_api_key request example
         """
         try:
-            global apikey_id
-
             # begin-lock_api_key
 
             response = iam_identity_service.lock_api_key(id=apikey_id)
@@ -320,13 +306,12 @@ class TestIamIdentityV1Examples:
         unlock_api_key request example
         """
         try:
-            global apikey_id
-
             # begin-unlock_api_key
 
             response = iam_identity_service.unlock_api_key(id=apikey_id)
 
             # end-unlock_api_key
+
             print('\nunlock_api_key() response status code: ', response.get_status_code())
 
         except ApiException as e:
@@ -338,13 +323,12 @@ class TestIamIdentityV1Examples:
         delete_api_key request example
         """
         try:
-            global apikey_id
-
             # begin-delete_api_key
 
             response = iam_identity_service.delete_api_key(id=apikey_id)
 
             # end-delete_api_key
+
             print('\ndelete_api_key() response status code: ', response.get_status_code())
 
         except ApiException as e:
@@ -356,20 +340,18 @@ class TestIamIdentityV1Examples:
         create_service_id request example
         """
         try:
-            global account_id, serviceid_name, svc_id
-
             print('\ncreate_service_id() result:')
             # begin-create_service_id
 
             service_id = iam_identity_service.create_service_id(
                 account_id=account_id, name=serviceid_name, description='Example ServiceId'
             ).get_result()
-
-            svc_id = service_id['id']
-
             print(json.dumps(service_id, indent=2))
 
             # end-create_service_id
+
+            global svc_id
+            svc_id = service_id['id']
 
         except ApiException as e:
             pytest.fail(str(e))
@@ -380,8 +362,6 @@ class TestIamIdentityV1Examples:
         get_service_id request example
         """
         try:
-            global svc_id, svc_id_etag
-
             print('\nget_service_id() result:')
             # begin-get_service_id
 
@@ -390,15 +370,13 @@ class TestIamIdentityV1Examples:
                 include_history=True,
                 include_activity=True,
             )
-
-            svc_id_etag = response.get_headers()['Etag']
             service_id = response.get_result()
-
             print(json.dumps(service_id, indent=2))
 
             # end-get_service_id
 
-            serviceIDEtag = service_id['entity_tag']
+            global svc_id_etag
+            svc_id_etag = response.get_headers()['Etag']
 
         except ApiException as e:
             pytest.fail(str(e))
@@ -409,15 +387,12 @@ class TestIamIdentityV1Examples:
         list_service_ids request example
         """
         try:
-            global account_id, serviceid_name
-
             print('\nlist_service_ids() result:')
             # begin-list_service_ids
 
             service_id_list = iam_identity_service.list_service_ids(
                 account_id=account_id, name=serviceid_name
             ).get_result()
-
             print(json.dumps(service_id_list, indent=2))
 
             # end-list_service_ids
@@ -431,15 +406,12 @@ class TestIamIdentityV1Examples:
         update_service_id request example
         """
         try:
-            global svc_id, svc_id_etag
-
             print('\nupdate_service_id() result:')
             # begin-update_service_id
 
             service_id = iam_identity_service.update_service_id(
                 id=svc_id, if_match=svc_id_etag, description='This is an updated description'
             ).get_result()
-
             print(json.dumps(service_id, indent=2))
 
             # end-update_service_id
@@ -453,13 +425,12 @@ class TestIamIdentityV1Examples:
         lock_service_id request example
         """
         try:
-            global svc_id
-
             # begin-lock_service_id
 
             response = iam_identity_service.lock_service_id(id=svc_id)
 
             # end-lock_service_id
+
             print('\nlock_service_id() response status code: ', response.get_status_code())
 
         except ApiException as e:
@@ -471,13 +442,12 @@ class TestIamIdentityV1Examples:
         unlock_service_id request example
         """
         try:
-            global svc_id
-
             # begin-unlock_service_id
 
             response = iam_identity_service.unlock_service_id(id=svc_id)
 
             # end-unlock_service_id
+
             print('\nunlock_service_id() response status code: ', response.get_status_code())
 
         except ApiException as e:
@@ -489,13 +459,12 @@ class TestIamIdentityV1Examples:
         delete_service_id request example
         """
         try:
-            global svc_id
-
             # begin-delete_service_id
 
             response = iam_identity_service.delete_service_id(id=svc_id)
 
             # end-delete_service_id
+
             print('\ndelete_service_id() response status code: ', response.get_status_code())
 
         except ApiException as e:
@@ -507,19 +476,18 @@ class TestIamIdentityV1Examples:
         create_profile request example
         """
         try:
-            global profile_id
             print('\ncreate_profile() result:')
             # begin-create_profile
 
             profile = iam_identity_service.create_profile(
                 name="example profile", description="example profile", account_id=account_id
             ).get_result()
-
-            profile_id = profile['id']
-
             print(json.dumps(profile, indent=2))
 
             # end-create_profile
+
+            global profile_id
+            profile_id = profile['id']
 
         except ApiException as e:
             pytest.fail(str(e))
@@ -530,8 +498,6 @@ class TestIamIdentityV1Examples:
         get_profile request example
         """
         try:
-            global profile_id, profile_etag
-
             print('\nget_profile() result:')
             # begin-get_profile
 
@@ -539,13 +505,12 @@ class TestIamIdentityV1Examples:
                 profile_id=profile_id,
                 include_activity=True,
             )
-
-            profile_etag = response.get_headers()['Etag']
             profile = response.get_result()
-
             print(json.dumps(profile, indent=2))
 
             # end-get_profile
+            global profile_etag
+            profile_etag = response.get_headers()['Etag']
 
         except ApiException as e:
             pytest.fail(str(e))
@@ -556,13 +521,10 @@ class TestIamIdentityV1Examples:
         list_profiles request example
         """
         try:
-            global account_id
-
             print('\nlist_profiles() result:')
             # begin-list_profiles
 
             profile_list = iam_identity_service.list_profiles(account_id=account_id, include_history=True).get_result()
-
             print(json.dumps(profile_list, indent=2))
 
             # end-list_profiles
@@ -576,8 +538,6 @@ class TestIamIdentityV1Examples:
         update_profile request example
         """
         try:
-            global profile_id, profile_etag
-
             print('\nupdate_profile() result:')
             # begin-update_profile
 
@@ -598,7 +558,6 @@ class TestIamIdentityV1Examples:
         create_claim_rule request example
         """
         try:
-            global claimRule_id, profile_id
             print('\ncreate_claim_rule() result:')
             # begin-create_claim_rule
 
@@ -606,7 +565,6 @@ class TestIamIdentityV1Examples:
             profile_claim_rule_conditions_model['claim'] = 'blueGroups'
             profile_claim_rule_conditions_model['operator'] = 'EQUALS'
             profile_claim_rule_conditions_model['value'] = '\"cloud-docs-dev\"'
-
             claimRule = iam_identity_service.create_claim_rule(
                 profile_id=profile_id,
                 type='Profile-SAML',
@@ -614,12 +572,12 @@ class TestIamIdentityV1Examples:
                 expiration=43200,
                 conditions=[profile_claim_rule_conditions_model],
             ).get_result()
-
-            claimRule_id = claimRule['id']
-
             print(json.dumps(claimRule, indent=2))
 
             # end-create_claim_rule
+
+            global claimRule_id
+            claimRule_id = claimRule['id']
 
         except ApiException as e:
             pytest.fail(str(e))
@@ -630,19 +588,17 @@ class TestIamIdentityV1Examples:
         get_claim_rule request example
         """
         try:
-            global profile_id, claimRule_id, claimRule_etag
-
             print('\nget_claim_rule() result:')
             # begin-get_claim_rule
 
             response = iam_identity_service.get_claim_rule(profile_id=profile_id, rule_id=claimRule_id)
-
-            claimRule_etag = response.get_headers()['Etag']
             claimRule = response.get_result()
-
             print(json.dumps(claimRule, indent=2))
 
             # end-get_claim_rule
+
+            global claimRule_etag
+            claimRule_etag = response.get_headers()['Etag']
 
         except ApiException as e:
             pytest.fail(str(e))
@@ -653,15 +609,12 @@ class TestIamIdentityV1Examples:
         list_claim_rules request example
         """
         try:
-            global profile_id
-
             print('\nlist_claim_rules() result:')
             # begin-list_claim_rules
 
             claimRule_list = iam_identity_service.list_claim_rules(
                 profile_id=profile_id,
             ).get_result()
-
             print(json.dumps(claimRule_list, indent=2))
 
             # end-list_claim_rules
@@ -675,8 +628,6 @@ class TestIamIdentityV1Examples:
         update_claim_rule request example
         """
         try:
-            global claimRule_id, claimRule_etag, profile_id
-
             print('\nupdate_claim_rule() result:')
             # begin-update_claim_rule
 
@@ -684,7 +635,6 @@ class TestIamIdentityV1Examples:
             profile_claim_rule_conditions_model['claim'] = 'blueGroups'
             profile_claim_rule_conditions_model['operator'] = 'EQUALS'
             profile_claim_rule_conditions_model['value'] = '\"Europe_Group\"'
-
             claimRule = iam_identity_service.update_claim_rule(
                 profile_id=profile_id,
                 rule_id=claimRule_id,
@@ -694,7 +644,6 @@ class TestIamIdentityV1Examples:
                 type='Profile-SAML',
                 realm_name='https://sdk.test.realm/1234',
             ).get_result()
-
             print(json.dumps(claimRule, indent=2))
 
             # end-update_claim_rule
@@ -708,8 +657,6 @@ class TestIamIdentityV1Examples:
         delete_claim_rule request example
         """
         try:
-            global profile_id, claimRule_id
-
             # begin-delete_claim_rule
 
             response = iam_identity_service.delete_claim_rule(profile_id=profile_id, rule_id=claimRule_id)
@@ -726,7 +673,6 @@ class TestIamIdentityV1Examples:
         create_link request example
         """
         try:
-            global profile_id, link_id
             print('\ncreate_link() result:')
             # begin-create_link
 
@@ -736,16 +682,15 @@ class TestIamIdentityV1Examples:
             )
             CreateProfileLinkRequestLink['namespace'] = 'default'
             CreateProfileLinkRequestLink['name'] = 'nice name'
-
             link = iam_identity_service.create_link(
                 profile_id=profile_id, name='nice link', cr_type='ROKS_SA', link=CreateProfileLinkRequestLink
             ).get_result()
-
-            link_id = link['id']
-
             print(json.dumps(link, indent=2))
 
             # end-create_link
+
+            global link_id
+            link_id = link['id']
 
         except ApiException as e:
             pytest.fail(str(e))
@@ -756,15 +701,11 @@ class TestIamIdentityV1Examples:
         get_link request example
         """
         try:
-            global profile_id, link_id
-
             print('\nget_link() result:')
             # begin-get_link
 
             response = iam_identity_service.get_link(profile_id=profile_id, link_id=link_id)
-
             link = response.get_result()
-
             print(json.dumps(link, indent=2))
 
             # end-get_link
@@ -778,15 +719,12 @@ class TestIamIdentityV1Examples:
         list_links request example
         """
         try:
-            global profile_id
-
             print('\nlist_links() result:')
             # begin-list_links
 
             link_list = iam_identity_service.list_links(
                 profile_id=profile_id,
             ).get_result()
-
             print(json.dumps(link_list, indent=2))
 
             # end-list_links
@@ -800,8 +738,6 @@ class TestIamIdentityV1Examples:
         delete_link request example
         """
         try:
-            global profile_id, link_id
-
             # begin-delete_link
 
             response = iam_identity_service.delete_link(profile_id=profile_id, link_id=link_id)
@@ -818,14 +754,14 @@ class TestIamIdentityV1Examples:
         get_profile_identities request example
         """
         try:
-            global profile_id, profile_identity_etag
-
             # begin-get_profile_identities
 
             response = iam_identity_service.get_profile_identities(profile_id=profile_id)
 
             # end-get_profile_identities
+
             print('\nget_profile_identities() response status code: ', response.get_status_code())
+            global profile_identity_etag
             profile_identity_etag = response.get_headers()['Etag']
 
         except ApiException as e:
@@ -837,20 +773,17 @@ class TestIamIdentityV1Examples:
         set_profile_identities request example
         """
         try:
-            global profile_id, profile_identity_etag
-
             # begin-set_profile_identities
             accounts = [account_id]
             profileIdentity = ProfileIdentityRequest(
                 identifier=iam_id, accounts=accounts, type="user", description="Identity description"
             )
             profile_identities_input = [profileIdentity]
-
             response = iam_identity_service.set_profile_identities(
                 profile_id=profile_id, if_match=profile_identity_etag, identities=profile_identities_input
             )
-
             # end-set_profile_identities
+
             print('\nset_profile_identities() response status code: ', response.get_status_code())
 
         except ApiException as e:
@@ -862,9 +795,8 @@ class TestIamIdentityV1Examples:
         set_profile_identity request example
         """
         try:
-            global profile_id
-
             # begin-set_profile_identity
+
             accounts = [account_id]
             response = iam_identity_service.set_profile_identity(
                 profile_id=profile_id,
@@ -876,6 +808,7 @@ class TestIamIdentityV1Examples:
             )
 
             # end-set_profile_identity
+
             print('\nset_profile_identities() response status code: ', response.get_status_code())
         except ApiException as e:
             pytest.fail(str(e))
@@ -886,8 +819,6 @@ class TestIamIdentityV1Examples:
         get_profile_identity request example
         """
         try:
-            global profile_id
-
             # begin-get_profile_identity
 
             response = iam_identity_service.get_profile_identity(
@@ -895,6 +826,7 @@ class TestIamIdentityV1Examples:
             )
 
             # end-get_profile_identity
+
             print('\nget_profile_identities() response status code: ', response.get_status_code())
         except ApiException as e:
             pytest.fail(str(e))
@@ -905,8 +837,6 @@ class TestIamIdentityV1Examples:
         delete_profile_identity request example
         """
         try:
-            global profile_id
-
             # begin-delete_profile_identity
 
             response = iam_identity_service.delete_profile_identity(
@@ -914,6 +844,7 @@ class TestIamIdentityV1Examples:
             )
 
             # end-delete_profile_identity
+
             print('\ndelete_profile_identity() response status code: ', response.get_status_code())
         except ApiException as e:
             pytest.fail(str(e))
@@ -924,13 +855,12 @@ class TestIamIdentityV1Examples:
         delete_profile request example
         """
         try:
-            global profile_id
-
             # begin-delete_profile
 
             response = iam_identity_service.delete_profile(profile_id=profile_id)
 
             # end-delete_profile
+
             print('\ndelete_profile() response status code: ', response.get_status_code())
 
         except ApiException as e:
@@ -942,18 +872,17 @@ class TestIamIdentityV1Examples:
         get_account_settings request example
         """
         try:
-            global account_settings_etag
-
             print('\nget_account_settings() result:')
             # begin-getAccountSettings
 
             response = iam_identity_service.get_account_settings(account_id=account_id)
             settings = response.get_result()
-            account_settings_etag = response.get_headers()['Etag']
-
             print(json.dumps(settings, indent=2))
 
             # end-getAccountSettings
+
+            global account_settings_etag
+            account_settings_etag = response.get_headers()['Etag']
 
         except ApiException as e:
             pytest.fail(str(e))
@@ -964,15 +893,12 @@ class TestIamIdentityV1Examples:
         update_account_settings request example
         """
         try:
-            global account_settings_etag
-
             print('\nupdate_account_settings() result:')
             # begin-updateAccountSettings
 
             account_settings_user_mfa = {}
             account_settings_user_mfa['iam_id'] = iam_id_member
             account_settings_user_mfa['mfa'] = 'NONE'
-
             account_settings_response = iam_identity_service.update_account_settings(
                 account_id=account_id,
                 if_match=account_settings_etag,
@@ -986,7 +912,6 @@ class TestIamIdentityV1Examples:
                 system_access_token_expiration_in_seconds='3600',
                 system_refresh_token_expiration_in_seconds='259200',
             ).get_result()
-
             print(json.dumps(account_settings_response, indent=2))
 
             # end-updateAccountSettings
@@ -1008,7 +933,6 @@ class TestIamIdentityV1Examples:
                 type="inactive",
                 duration="120",
             ).get_result()
-
             print(json.dumps(create_report_response, indent=2))
 
             # end-create_report
@@ -1028,7 +952,6 @@ class TestIamIdentityV1Examples:
             get_report_response = iam_identity_service.get_report(
                 account_id=account_id, reference="latest"
             ).get_result()
-
             print(json.dumps(get_report_response, indent=2))
 
             # end-get_report
@@ -1042,18 +965,17 @@ class TestIamIdentityV1Examples:
         create_mfa_report request example
         """
         try:
-            global report_reference_mfa
             print('\ncreate_mfa_report() result:')
             # begin-create_mfa_report
 
             create_report_response = iam_identity_service.create_mfa_report(
                 account_id=account_id, type="mfa_status"
             ).get_result()
-
             print(json.dumps(create_report_response, indent=2))
-            report_reference_mfa = create_report_response['reference']
 
             # end-create_mfa_report
+            global report_reference_mfa
+            report_reference_mfa = create_report_response['reference']
 
         except ApiException as e:
             pytest.fail(str(e))
@@ -1070,7 +992,6 @@ class TestIamIdentityV1Examples:
             get_report_response = iam_identity_service.get_mfa_report(
                 account_id=account_id, reference=report_reference_mfa
             ).get_result()
-
             print(json.dumps(get_report_response, indent=2))
 
             # end-get_mfa_report
@@ -1090,7 +1011,6 @@ class TestIamIdentityV1Examples:
             get_mfa_status_response = iam_identity_service.get_mfa_status(
                 account_id=account_id, iam_id=iam_id
             ).get_result()
-
             print(json.dumps(get_mfa_status_response, indent=2))
 
             # end-get_mfa_status
@@ -1106,6 +1026,7 @@ class TestIamIdentityV1Examples:
         try:
             print('\ncreate_profile_template() result:')
             # begin-create_profile_template
+
             profile_claim_rule_conditions = {}
             profile_claim_rule_conditions['claim'] = 'blueGroups'
             profile_claim_rule_conditions['operator'] = 'EQUALS'
@@ -1129,15 +1050,15 @@ class TestIamIdentityV1Examples:
                 account_id=enterprise_account_id,
                 profile=profile,
             )
-
             profile_template = create_response.get_result()
             print('\ncreate_profile_template() response: ', json.dumps(profile_template, indent=2))
 
+            # end-create_profile_template
             global profile_template_id
             profile_template_id = profile_template['id']
             global profile_template_version
             profile_template_version = profile_template['version']
-            # end-create_profile_template
+
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -1148,21 +1069,19 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\nget_profile_template() result:')
-            global profile_template_id
-            global profile_template_version
-
             # begin-get_profile_template_version
+
             get_response = iam_identity_service.get_profile_template_version(
                 template_id=profile_template_id, version=str(profile_template_version)
             )
-
             profile_template = get_response.get_result()
             print('\nget_profile_template response: ', json.dumps(profile_template, indent=2))
+
+            # end-get_profile_template_version
 
             global profile_template_etag
             profile_template_etag = get_response.get_headers()['Etag']
             profile_template_etag is not None
-            # end-get_profile_template_version
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -1176,9 +1095,9 @@ class TestIamIdentityV1Examples:
             # begin-list_profile_templates
 
             list_response = iam_identity_service.list_profile_templates(account_id=enterprise_account_id)
-
             profile_template_list = list_response.get_result()
             print('\nlist_profile_templates response: ', json.dumps(profile_template_list, indent=2))
+
             # end-list_profile_templates
         except ApiException as e:
             pytest.fail(str(e))
@@ -1190,11 +1109,8 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\nupdate_profile_template() result:')
-            global profile_template_id
-            global profile_template_version
-            global profile_template_etag
-
             # begin-update_profile_template_version
+
             update_response = iam_identity_service.update_profile_template_version(
                 account_id=enterprise_account_id,
                 template_id=profile_template_id,
@@ -1203,12 +1119,13 @@ class TestIamIdentityV1Examples:
                 name='Example-Profile-Template',
                 description='IAM enterprise trusted profile template example - updated',
             )
-
             profile_template = update_response.get_result()
             print('\nupdate_profile_template() response: ', json.dumps(profile_template, indent=2))
 
-            profile_template_etag = update_response.get_headers()['Etag']
             # end-update_profile_template_version
+            global profile_template_etag
+            profile_template_etag = update_response.get_headers()['Etag']
+
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -1219,19 +1136,19 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\nupdate_profile_template() result:')
-            global profile_template_id
-            global profile_template_version
-
             # begin-commit_profile_template
+
             commit_response = iam_identity_service.commit_profile_template(
                 template_id=profile_template_id, version=str(profile_template_version)
             )
+
             # end-commit_profile_template
 
             """
             create_trusted_profile_assignment request example
             """
             # begin-create_trusted_profile_assignment
+
             assign_response = iam_identity_service.create_trusted_profile_assignment(
                 template_id=profile_template_id,
                 template_version=profile_template_version,
@@ -1240,11 +1157,13 @@ class TestIamIdentityV1Examples:
             )
             assignment = assign_response.get_result()
             print('\ncreate_trusted_profile_assignment() response: ', json.dumps(assignment, indent=2))
+
+            # end-create_trusted_profile_assignment
+
             global profile_template_assignment_id
             profile_template_assignment_id = assignment['id']
             global profile_template_assignment_etag
             profile_template_assignment_etag = assign_response.get_headers()['Etag']
-            # end-create_trusted_profile_assignment
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -1255,13 +1174,14 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\nget_trusted_profile_assignment() result:')
-            global profile_template_assignment_id
-
             # begin-get_trusted_profile_assignment
+
             response = iam_identity_service.get_trusted_profile_assignment(assignment_id=profile_template_assignment_id)
             assignment = response.get_result()
             print('\nget_trusted_profile_assignment() response: ', json.dumps(assignment, indent=2))
+
             # end-get_trusted_profile_assignment
+
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -1272,14 +1192,14 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\nlist_profile_template_assignments() result:')
-            global profile_template_id
-
             # begin-list_trusted_profile_assignments
+
             list_response = iam_identity_service.list_trusted_profile_assignments(
                 account_id=enterprise_account_id, template_id=profile_template_id
             )
             assignment_list = list_response.get_result()
             print('\nlist_trusted_profile_assignments() response: ', json.dumps(assignment_list, indent=2))
+
             # end-list_trusted_profile_assignments
         except ApiException as e:
             pytest.fail(str(e))
@@ -1291,9 +1211,8 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\ncreate_profile_template_version() result:')
-            global profile_template_id
-
             # begin-create_profile_template_version
+
             profile_claim_rule_conditions = {}
             profile_claim_rule_conditions['claim'] = 'blueGroups'
             profile_claim_rule_conditions['operator'] = 'EQUALS'
@@ -1325,13 +1244,12 @@ class TestIamIdentityV1Examples:
                 account_id=enterprise_account_id,
                 profile=profile,
             )
-
             profile_template = create_response.get_result()
             print('\ncreate_profile_template_version() response: ', json.dumps(profile_template, indent=2))
 
+            # end-create_profile_template_version
             global profile_template_version
             profile_template_version = profile_template['version']
-            # end-create_profile_template_version
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -1342,13 +1260,13 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\nget_latest_profile_template_version() result:')
-            global profile_template_id
-
             # begin-get_latest_profile_template_version
+
             get_response = iam_identity_service.get_latest_profile_template_version(template_id=profile_template_id)
 
             profile_template = get_response.get_result()
             print('\nget_latest_profile_template_version response: ', json.dumps(profile_template, indent=2))
+
             # end-get_latest_profile_template_version
         except ApiException as e:
             pytest.fail(str(e))
@@ -1360,12 +1278,12 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\nlist_profile_template_versions() result:')
-            global profile_template_id
-
             # begin-list_versions_of_profile_template
+
             list_response = iam_identity_service.list_versions_of_profile_template(template_id=profile_template_id)
             profile_template_list = list_response.get_result()
             print('\nlist_profile_template_versions response: ', json.dumps(profile_template_list, indent=2))
+
             # end-list_versions_of_profile_template
         except ApiException as e:
             pytest.fail(str(e))
@@ -1377,18 +1295,12 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\nupdate_trusted_profile_assignment() result:')
-            global profile_template_id
-            global profile_template_version
-            global profile_template_assignment_id
-            global profile_template_assignment_etag
-
             commit_response = iam_identity_service.commit_profile_template(
                 template_id=profile_template_id, version=str(profile_template_version)
             )
-
             self.waitUntilTrustedProfileAssignmentFinished(iam_identity_service, profile_template_assignment_id)
-
             # begin-update_trusted_profile_assignment
+
             assign_response = iam_identity_service.update_trusted_profile_assignment(
                 assignment_id=profile_template_assignment_id,
                 template_version=profile_template_version,
@@ -1396,8 +1308,12 @@ class TestIamIdentityV1Examples:
             )
             assignment = assign_response.get_result()
             print('\nupdate_profile_template_assignment response: ', json.dumps(assignment, indent=2))
-            profile_template_assignment_etag = assign_response.get_headers()['Etag']
+
             # end-update_trusted_profile_assignment
+
+            global profile_template_assignment_etag
+            profile_template_assignment_etag = assign_response.get_headers()['Etag']
+
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -1408,14 +1324,13 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\ndelete_trusted_profile_assignment() result:')
-            global profile_template_assignment_id
-
             self.waitUntilTrustedProfileAssignmentFinished(iam_identity_service, profile_template_assignment_id)
-
             # begin-delete_trusted_profile_assignment
+
             delete_response = iam_identity_service.delete_trusted_profile_assignment(
                 assignment_id=profile_template_assignment_id
             )
+
             # end-delete_trusted_profile_assignment
         except ApiException as e:
             pytest.fail(str(e))
@@ -1427,13 +1342,12 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\ndelete_profile_template_version() result:')
-            global profile_template_id
-            global profile_template_assignment_id
-
             # begin-delete_profile_template_version
+
             delete_response = iam_identity_service.delete_profile_template_version(
                 template_id=profile_template_id, version='1'
             )
+
             # end-delete_profile_template_version
         except ApiException as e:
             pytest.fail(str(e))
@@ -1445,14 +1359,13 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\ndelete_all_versions_of_profile_template() result:')
-            global profile_template_id
-
             self.waitUntilTrustedProfileAssignmentFinished(iam_identity_service, profile_template_assignment_id)
-
             # begin-delete_all_versions_of_profile_template
+
             delete_response = iam_identity_service.delete_all_versions_of_profile_template(
                 template_id=profile_template_id
             )
+
             # end-delete_all_versions_of_profile_template
         except ApiException as e:
             pytest.fail(str(e))
@@ -1465,6 +1378,7 @@ class TestIamIdentityV1Examples:
         try:
             print('\ncreate_account_settings_template() result:')
             # begin-create_account_settings_template
+
             account_settings = {}
             account_settings['mfa'] = 'LEVEL1'
             account_settings['system_access_token_expiration_in_seconds'] = 3000
@@ -1475,15 +1389,15 @@ class TestIamIdentityV1Examples:
                 account_id=enterprise_account_id,
                 account_settings=account_settings,
             )
-
             account_settings_template = create_response.get_result()
             print('\ncreate_account_settings_template() response: ', json.dumps(account_settings_template, indent=2))
 
-            global account_settings_template_id
-            account_settings_template_id = account_settings_template['id']
-            global account_settings_template_version
-            account_settings_template_version = account_settings_template['version']
             # end-create_account_settings_template
+            global account_settings_template_id
+            global account_settings_template_version
+            account_settings_template_id = account_settings_template['id']
+            account_settings_template_version = account_settings_template['version']
+
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -1494,10 +1408,8 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\nget_account_settings_template_version() result:')
-            global account_settings_template_id
-            global account_settings_template_version
-
             # begin-get_account_settings_template_version
+
             get_response = iam_identity_service.get_account_settings_template_version(
                 template_id=account_settings_template_id, version=str(account_settings_template_version)
             )
@@ -1505,9 +1417,10 @@ class TestIamIdentityV1Examples:
             account_settings_template = get_response.get_result()
             print('\nget_account_settings_template response: ', json.dumps(account_settings_template, indent=2))
 
+            # end-get_account_settings_template_version
+
             global account_settings_template_etag
             account_settings_template_etag = get_response.get_headers()['Etag']
-            # end-get_account_settings_template_version
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -1518,12 +1431,12 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\nlist_account_settings_templates() result:')
-
             # begin-list_account_settings_templates
-            list_response = iam_identity_service.list_account_settings_templates(account_id=enterprise_account_id)
 
+            list_response = iam_identity_service.list_account_settings_templates(account_id=enterprise_account_id)
             account_settings_template_list = list_response.get_result()
             print('\nlist_account_settings_templates response: ', json.dumps(account_settings_template_list, indent=2))
+
             # end-list_account_settings_templates
         except ApiException as e:
             pytest.fail(str(e))
@@ -1535,10 +1448,6 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\nupdate_account_settings_template_version() result:')
-
-            global account_settings_template_id
-            global account_settings_template_version
-            global account_settings_template_etag
             # begin-update_account_settings_template_version
 
             account_settings = {}
@@ -1554,12 +1463,13 @@ class TestIamIdentityV1Examples:
                 description='IAM enterprise account settings template example - updated',
                 account_settings=account_settings,
             )
-
             account_settings_template = update_response.get_result()
             print('\nupdate_account_settings_template() response: ', json.dumps(account_settings_template, indent=2))
 
-            account_settings_template_etag = update_response.get_headers()['Etag']
             # end-update_account_settings_template_version
+            global account_settings_template_etag
+            account_settings_template_etag = update_response.get_headers()['Etag']
+
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -1570,19 +1480,20 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\ncommit_account_settings_template() result:')
-
-            global account_settings_template_id
-            global account_settings_template_version
             # begin-commit_account_settings_template
+
             commit_response = iam_identity_service.commit_account_settings_template(
                 template_id=account_settings_template_id, version=str(account_settings_template_version)
             )
+
             # end-commit_account_settings_template
+
             """
             create_account_settings_assignment request example
             """
             print('\ncreate_account_settings_assignment() result:')
             # begin-create_account_settings_assignment
+
             assign_response = iam_identity_service.create_account_settings_assignment(
                 template_id=account_settings_template_id,
                 template_version=account_settings_template_version,
@@ -1591,11 +1502,13 @@ class TestIamIdentityV1Examples:
             )
             assignment = assign_response.get_result()
             print('\ncreate_account_settings_assignment() response: ', json.dumps(assignment, indent=2))
+
+            # end-create_account_settings_assignment
+
             global account_settings_template_assignment_id
             account_settings_template_assignment_id = assignment['id']
             global account_settings_template_assignment_etag
             account_settings_template_assignment_etag = assign_response.get_headers()['Etag']
-            # end-create_account_settings_assignment
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -1606,8 +1519,6 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\nlist_account_settings_assignments() result:')
-
-            global account_settings_template_id
             # begin-list_account_settings_assignments
 
             list_response = iam_identity_service.list_account_settings_assignments(
@@ -1615,6 +1526,7 @@ class TestIamIdentityV1Examples:
             )
             assignment_list = list_response.get_result()
             print('\ncreate_account_settings_assignment() response: ', json.dumps(assignment_list, indent=2))
+
             # end-list_account_settings_assignments
         except ApiException as e:
             pytest.fail(str(e))
@@ -1626,12 +1538,14 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\nget_account_settings_assignment() result:')
-            global account_settings_template_assignment_id
-
             # begin-get_account_settings_assignment
-            response = service.get_account_settings_assignment(assignment_id=account_settings_template_assignment_id)
+
+            response = iam_identity_service.get_account_settings_assignment(
+                assignment_id=account_settings_template_assignment_id
+            )
             assignment = response.get_result()
             print('\nget_latest_account_settings_template_version response: ', json.dumps(assignment, indent=2))
+
             # end-get_account_settings_assignment
         except ApiException as e:
             pytest.fail(str(e))
@@ -1643,8 +1557,6 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\ncreate_account_settings_template_version() result:')
-
-            global account_settings_template_id
             # begin-create_account_settings_template_version
 
             account_settings = {}
@@ -1660,16 +1572,16 @@ class TestIamIdentityV1Examples:
                 account_id=enterprise_account_id,
                 account_settings=account_settings,
             )
-
             account_settings_template = create_response.get_result()
             print(
                 '\ncreate_account_settings_template_version() response: ',
                 json.dumps(account_settings_template, indent=2),
             )
 
+            # end-create_account_settings_template_version
+
             global account_settings_template_version
             account_settings_template_version = account_settings_template['version']
-            # end-create_account_settings_template_version
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -1680,9 +1592,8 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\nget_latest_account_settings_template_version() result:')
-
-            global account_settings_template_id
             # begin-get_latest_account_settings_template_version
+
             get_response = iam_identity_service.get_latest_account_settings_template_version(
                 template_id=account_settings_template_id
             )
@@ -1691,6 +1602,7 @@ class TestIamIdentityV1Examples:
                 '\nget_latest_account_settings_template_version response: ',
                 json.dumps(account_settings_template, indent=2),
             )
+
             # end-get_latest_account_settings_template_version
         except ApiException as e:
             pytest.fail(str(e))
@@ -1702,9 +1614,8 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\nlist_versions_of_account_settings_template() result:')
-
-            global account_settings_template_id
             # begin-list_versions_of_account_settings_template
+
             list_response = iam_identity_service.list_versions_of_account_settings_template(
                 template_id=account_settings_template_id
             )
@@ -1713,6 +1624,7 @@ class TestIamIdentityV1Examples:
                 '\nlist_account_settings_template_versions response: ',
                 json.dumps(account_settings_template_list, indent=2),
             )
+
             # end-list_versions_of_account_settings_template
         except ApiException as e:
             pytest.fail(str(e))
@@ -1724,11 +1636,6 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\nupdate_account_settings_assignment() result:')
-
-            global account_settings_template_id
-            global account_settings_template_version
-            global account_settings_template_assignment_id
-            global account_settings_template_assignment_etag
             commit_response = iam_identity_service.commit_account_settings_template(
                 template_id=account_settings_template_id, version=str(account_settings_template_version)
             )
@@ -1738,6 +1645,7 @@ class TestIamIdentityV1Examples:
             )
 
             # begin-update_account_settings_assignment
+
             assign_response = iam_identity_service.update_account_settings_assignment(
                 assignment_id=account_settings_template_assignment_id,
                 template_version=account_settings_template_version,
@@ -1745,8 +1653,10 @@ class TestIamIdentityV1Examples:
             )
             assignment = assign_response.get_result()
             print('\nupdate_account_settings_template_assignment response: ', json.dumps(assignment, indent=2))
-            account_settings_template_assignment_etag = assign_response.get_headers()['Etag']
+
             # end-update_account_settings_assignment
+            global account_settings_template_assignment_etag
+            account_settings_template_assignment_etag = assign_response.get_headers()['Etag']
         except ApiException as e:
             pytest.fail(str(e))
 
@@ -1757,15 +1667,16 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\ndelete_account_settings_assignment() result:')
-            global account_settings_template_assignment_id
-
             self.waitUntilAccountSettingsAssignmentFinished(
                 iam_identity_service, account_settings_template_assignment_id
             )
+
             # begin-delete_account_settings_assignment
+
             delete_response = iam_identity_service.delete_account_settings_assignment(
                 assignment_id=account_settings_template_assignment_id
             )
+
             # end-delete_account_settings_assignment
         except ApiException as e:
             pytest.fail(str(e))
@@ -1777,13 +1688,12 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\ndelete_account_settings_template_version() result:')
-            global account_settings_template_assignment_id
-            global account_settings_template_assignment_id
             # begin-delete_account_settings_template_version
 
             delete_response = iam_identity_service.delete_account_settings_template_version(
                 template_id=account_settings_template_id, version='1'
             )
+
             # end-delete_account_settings_template_version
         except ApiException as e:
             pytest.fail(str(e))
@@ -1795,14 +1705,17 @@ class TestIamIdentityV1Examples:
         """
         try:
             print('\ndelete_all_versions_of_account_settings_template() result:')
-            global account_settings_template_id
+
             self.waitUntilAccountSettingsAssignmentFinished(
                 iam_identity_service, account_settings_template_assignment_id
             )
+
             # begin-delete_all_versions_of_account_settings_template
+
             delete_response = iam_identity_service.delete_all_versions_of_account_settings_template(
                 template_id=account_settings_template_id
             )
+
             # end-delete_all_versions_of_account_settings_template
         except ApiException as e:
             pytest.fail(str(e))

--- a/examples/test_iam_policy_management_v1_examples.py
+++ b/examples/test_iam_policy_management_v1_examples.py
@@ -56,6 +56,7 @@ example_assignment_id = None
 example_user_id = "IBMid-user1"
 example_service_name = "iam-groups"
 example_assignment_policy_id = None
+example_updated_policy_etag = None
 
 ##############################################################################
 # Start of Examples for Service: IamPolicyManagementV1
@@ -98,8 +99,6 @@ class TestIamPolicyManagementV1Examples:
         create_policy request example
         """
         try:
-            global example_policy_id
-
             print('\ncreate_policy() result:')
             # begin-create_policy
 
@@ -120,6 +119,7 @@ class TestIamPolicyManagementV1Examples:
 
             # end-create_policy
 
+            global example_policy_id
             example_policy_id = policy['id']
 
         except ApiException as e:
@@ -131,8 +131,6 @@ class TestIamPolicyManagementV1Examples:
         get_policy request example
         """
         try:
-            global example_policy_etag
-
             print('\nget_policy() result:')
             # begin-get_policy
 
@@ -143,6 +141,7 @@ class TestIamPolicyManagementV1Examples:
 
             # end-get_policy
 
+            global example_policy_etag
             example_policy_etag = response.get_headers().get("Etag")
 
         except ApiException as e:
@@ -154,8 +153,6 @@ class TestIamPolicyManagementV1Examples:
         replace_policy request example
         """
         try:
-            global example_updated_policy_etag
-
             print('\nreplace_policy() result:')
             # begin-replace_policy
 
@@ -182,6 +179,7 @@ class TestIamPolicyManagementV1Examples:
 
             # end-replace_policy
 
+            global example_updated_policy_etag
             example_updated_policy_etag = response.get_headers().get("Etag")
 
         except ApiException as e:
@@ -251,8 +249,6 @@ class TestIamPolicyManagementV1Examples:
         create_v2_policy request example
         """
         try:
-            global example_policy_id
-
             print('\ncreate_v2_policy() result:')
             # begin-create_v2_policy
 
@@ -306,6 +302,7 @@ class TestIamPolicyManagementV1Examples:
 
             # end-create_v2_policy
 
+            global example_policy_id
             example_policy_id = policy['id']
 
         except ApiException as e:
@@ -317,8 +314,6 @@ class TestIamPolicyManagementV1Examples:
         get_v2_policy request example
         """
         try:
-            global example_policy_etag
-
             print('\nget_v2_policy() result:')
             # begin-get_v2_policy
 
@@ -329,6 +324,7 @@ class TestIamPolicyManagementV1Examples:
 
             # end-get_v2_policy
 
+            global example_policy_etag
             example_policy_etag = response.get_headers().get("Etag")
 
         except ApiException as e:
@@ -443,8 +439,6 @@ class TestIamPolicyManagementV1Examples:
         create_role request example
         """
         try:
-            global example_custom_role_id
-
             print('\ncreate_role() result:')
             # begin-create_role
 
@@ -460,6 +454,7 @@ class TestIamPolicyManagementV1Examples:
 
             # end-create_role
 
+            global example_custom_role_id
             example_custom_role_id = custom_role["id"]
 
         except ApiException as e:
@@ -471,8 +466,6 @@ class TestIamPolicyManagementV1Examples:
         get_role request example
         """
         try:
-            global example_custom_role_etag
-
             print('\nget_role() result:')
             # begin-get_role
 
@@ -483,6 +476,7 @@ class TestIamPolicyManagementV1Examples:
 
             # end-get_role
 
+            global example_custom_role_etag
             example_custom_role_etag = response.get_headers().get("Etag")
 
         except ApiException as e:
@@ -555,9 +549,6 @@ class TestIamPolicyManagementV1Examples:
         """
         try:
             print('\ncreate_policy_template() result:')
-
-            global example_template_id
-            global example_template_version
             # begin-create_policy_template
 
             v2_policy_resource_attribute_model = {
@@ -599,7 +590,9 @@ class TestIamPolicyManagementV1Examples:
 
             # end-create_policy_template
 
+            global example_template_id
             example_template_id = policy_template['id']
+            global example_template_version
             example_template_version = policy_template['version']
 
         except ApiException as e:
@@ -612,8 +605,6 @@ class TestIamPolicyManagementV1Examples:
         """
         try:
             print('\nget_policy_template() result:')
-
-            global example_template_etag
             # begin-get_policy_template
 
             print('example_template_id: ', example_template_id)
@@ -626,6 +617,7 @@ class TestIamPolicyManagementV1Examples:
 
             # end-get_policy_template
 
+            global example_template_etag
             example_template_etag = response.get_headers().get("Etag")
 
         except ApiException as e:
@@ -794,6 +786,7 @@ class TestIamPolicyManagementV1Examples:
 
             # end-get_policy_template_version
 
+            global example_template_etag
             example_template_etag = response.get_headers().get("Etag")
 
         except ApiException as e:
@@ -825,8 +818,6 @@ class TestIamPolicyManagementV1Examples:
         """
         try:
             print('\nlist_policy_assignments() result:')
-
-            global example_assignment_id
             # begin-list_Policy Assignments
 
             response = iam_policy_management_service.list_policy_assignments(
@@ -838,6 +829,7 @@ class TestIamPolicyManagementV1Examples:
 
             # end-list_Policy Assignments
 
+            global example_assignment_id
             example_assignment_id = polcy_template_assignment_collection['assignments'][0]['id']
 
         except ApiException as e:
@@ -850,8 +842,6 @@ class TestIamPolicyManagementV1Examples:
         """
         try:
             print('\nget_policy_assignment() result:')
-
-            global example_assignment_policy_id
             # begin-get_policy_assignment
 
             response = iam_policy_management_service.get_policy_assignment(
@@ -861,9 +851,9 @@ class TestIamPolicyManagementV1Examples:
 
             print(json.dumps(policy_assignment_record, indent=2))
 
-            example_assignment_policy_id = policy_assignment_record['resources'][0]['policy']['resource_created']['id']
-
             # end-get_policy_assignment
+            global example_assignment_policy_id
+            example_assignment_policy_id = policy_assignment_record['resources'][0]['policy']['resource_created']['id']
 
         except ApiException as e:
             pytest.fail(str(e))
@@ -874,7 +864,6 @@ class TestIamPolicyManagementV1Examples:
         get_v2_assignment_policy request example
         """
         try:
-
             print('\nget_v2_assignment_policy() result:')
             # begin-get_v2_assignment_policy
 

--- a/examples/test_open_service_broker_v1_examples.py
+++ b/examples/test_open_service_broker_v1_examples.py
@@ -125,8 +125,6 @@ class TestOpenServiceBrokerV1Examples:
         get_service_instance_state request example
         """
         try:
-            global instanceId
-
             print('\nget_service_instance_state() result:')
             # begin-get_service_instance_state
 
@@ -145,8 +143,6 @@ class TestOpenServiceBrokerV1Examples:
         replace_service_instance_state request example
         """
         try:
-            global instanceId, initiatorId, reasonCode
-
             print('\nreplace_service_instance_state() result:')
             # begin-replace_service_instance_state
 
@@ -167,8 +163,6 @@ class TestOpenServiceBrokerV1Examples:
         replace_service_instance request example
         """
         try:
-            global instanceId, orgGuid, planId, serviceId, accountId
-
             print('\nreplace_service_instance() result:')
             # begin-replace_service_instance
 
@@ -198,8 +192,6 @@ class TestOpenServiceBrokerV1Examples:
         update_service_instance request example
         """
         try:
-            global instanceId, planId, serviceId, accountId
-
             print('\nupdate_service_instance() result:')
             # begin-update_service_instance
 
@@ -247,8 +239,6 @@ class TestOpenServiceBrokerV1Examples:
         get_last_operation request example
         """
         try:
-            global instanceId, operation, planId, serviceId
-
             print('\nget_last_operation() result:')
             # begin-get_last_operation
 
@@ -269,8 +259,6 @@ class TestOpenServiceBrokerV1Examples:
         replace_service_binding request example
         """
         try:
-            global instanceId, bindingId, appGuid, planId, serviceId, spaceGuid, accountId
-
             print('\nreplace_service_binding() result:')
             # begin-replace_service_binding
 
@@ -298,8 +286,6 @@ class TestOpenServiceBrokerV1Examples:
         delete_service_instance request example
         """
         try:
-            global instanceId, planId, serviceId
-
             print('\ndelete_service_instance() result:')
             # begin-delete_service_instance
 
@@ -322,8 +308,6 @@ class TestOpenServiceBrokerV1Examples:
         delete_service_binding request example
         """
         try:
-            global bindingId, instanceId, planId, serviceId
-
             print('\ndelete_service_binding() result:')
             # begin-delete_service_binding
 

--- a/examples/test_resource_controller_v2_examples.py
+++ b/examples/test_resource_controller_v2_examples.py
@@ -123,7 +123,6 @@ class TestResourceControllerV2Examples:
         create_resource_instance request example
         """
         try:
-            global instance_guid, resource_instance_name, target_region, resource_group, resource_plan_id
             print('\ncreate_resource_instance() result:')
             # begin-create_resource_instance
 
@@ -138,6 +137,7 @@ class TestResourceControllerV2Examples:
 
             # end-create_resource_instance
 
+            global instance_guid
             instance_guid = resource_instance.get('guid')
 
         except ApiException as e:
@@ -149,7 +149,6 @@ class TestResourceControllerV2Examples:
         get_resource_instance request example
         """
         try:
-            global instance_guid
             print('\nget_resource_instance() result:')
             # begin-get_resource_instance
 
@@ -193,7 +192,6 @@ class TestResourceControllerV2Examples:
         update_resource_instance request example
         """
         try:
-            global instance_guid, resource_instance_update_name
             print('\nupdate_resource_instance() result:')
             # begin-update_resource_instance
 
@@ -215,7 +213,6 @@ class TestResourceControllerV2Examples:
         create_resource_alias request example
         """
         try:
-            global instance_guid, alias_name, alias_guid, alias_target_crn
             print('\ncreate_resource_alias() result:')
             # begin-create_resource_alias
 
@@ -227,6 +224,7 @@ class TestResourceControllerV2Examples:
 
             # end-create_resource_alias
 
+            global alias_guid
             alias_guid = resource_alias.get('guid')
 
         except ApiException as e:
@@ -238,7 +236,6 @@ class TestResourceControllerV2Examples:
         get_resource_alias request example
         """
         try:
-            global alias_guid
             print('\nget_resource_alias() result:')
             # begin-get_resource_alias
 
@@ -257,7 +254,6 @@ class TestResourceControllerV2Examples:
         list_resource_aliases request example
         """
         try:
-            global alias_name
             print('\nlist_resource_aliases() result:')
             # begin-list_resource_aliases
 
@@ -283,7 +279,6 @@ class TestResourceControllerV2Examples:
         update_resource_alias request example
         """
         try:
-            global alias_guid, alias_update_name
             print('\nupdate_resource_alias() result:')
             # begin-update_resource_alias
 
@@ -304,7 +299,6 @@ class TestResourceControllerV2Examples:
         list_resource_aliases_for_instance request example
         """
         try:
-            global instance_guid
             print('\nlist_resource_aliases_for_instance() result:')
             # begin-list_resource_aliases_for_instance
 
@@ -330,7 +324,6 @@ class TestResourceControllerV2Examples:
         create_resource_binding request example
         """
         try:
-            global alias_guid, binding_guid, binding_name, binding_target_crn
             print('\ncreate_resource_binding() result:')
             # begin-create_resource_binding
 
@@ -343,6 +336,7 @@ class TestResourceControllerV2Examples:
 
             # end-create_resource_binding
 
+            global binding_guid
             binding_guid = resource_binding.get('guid')
 
         except ApiException as e:
@@ -354,7 +348,6 @@ class TestResourceControllerV2Examples:
         get_resource_binding request example
         """
         try:
-            global binding_guid
             print('\nget_resource_binding() result:')
             # begin-get_resource_binding
 
@@ -378,7 +371,6 @@ class TestResourceControllerV2Examples:
         list_resource_bindings request example
         """
         try:
-            global binding_name
             print('\nlist_resource_bindings() result:')
             # begin-list_resource_bindings
 
@@ -404,7 +396,6 @@ class TestResourceControllerV2Examples:
         update_resource_binding request example
         """
         try:
-            global binding_guid, binding_update_name
             print('\nupdate_resource_binding() result:')
             # begin-update_resource_binding
 
@@ -425,7 +416,6 @@ class TestResourceControllerV2Examples:
         list_resource_bindings_for_alias request example
         """
         try:
-            global alias_guid
             print('\nlist_resource_bindings_for_alias() result:')
             # begin-list_resource_bindings_for_alias
 
@@ -451,7 +441,6 @@ class TestResourceControllerV2Examples:
         create_resource_key request example
         """
         try:
-            global instance_guid, instance_key_guid, key_name
             print('\ncreate_resource_key() result:')
             # begin-create_resource_key
 
@@ -464,6 +453,7 @@ class TestResourceControllerV2Examples:
 
             # end-create_resource_key
 
+            global instance_key_guid
             instance_key_guid = resource_key.get('guid')
 
         except ApiException as e:
@@ -475,7 +465,6 @@ class TestResourceControllerV2Examples:
         get_resource_key request example
         """
         try:
-            global instance_key_guid
             print('\nget_resource_key() result:')
             # begin-get_resource_key
 
@@ -500,7 +489,6 @@ class TestResourceControllerV2Examples:
         list_resource_keys request example
         """
         try:
-            global key_name
             print('\nlist_resource_keys() result:')
             # begin-list_resource_keys
 
@@ -526,7 +514,6 @@ class TestResourceControllerV2Examples:
         update_resource_key request example
         """
         try:
-            global instance_key_guid, key_update_name
             print('\nupdate_resource_key() result:')
             # begin-update_resource_key
 
@@ -547,7 +534,6 @@ class TestResourceControllerV2Examples:
         list_resource_keys_for_instance request example
         """
         try:
-            global instance_guid
             print('\nlist_resource_keys_for_instance() result:')
             # begin-list_resource_keys_for_instance
 
@@ -573,7 +559,6 @@ class TestResourceControllerV2Examples:
         delete_resource_binding request example
         """
         try:
-            global binding_guid
             # begin-delete_resource_binding
 
             response = resource_controller_service.delete_resource_binding(id=binding_guid)
@@ -590,7 +575,6 @@ class TestResourceControllerV2Examples:
         delete_resource_key request example
         """
         try:
-            global instance_key_guid
             # begin-delete_resource_key
 
             response = resource_controller_service.delete_resource_key(id=instance_key_guid)
@@ -607,7 +591,6 @@ class TestResourceControllerV2Examples:
         delete_resource_alias request example
         """
         try:
-            global alias_guid
             # begin-delete_resource_alias
 
             response = resource_controller_service.delete_resource_alias(id=alias_guid)
@@ -624,7 +607,6 @@ class TestResourceControllerV2Examples:
         lock_resource_instance request example
         """
         try:
-            global instance_guid
             print('\nlock_resource_instance() result:')
             # begin-lock_resource_instance
 
@@ -643,7 +625,6 @@ class TestResourceControllerV2Examples:
         unlock_resource_instance request example
         """
         try:
-            global instance_guid
             print('\nunlock_resource_instance() result:')
             # begin-unlock_resource_instance
 
@@ -662,7 +643,6 @@ class TestResourceControllerV2Examples:
         delete_resource_instance request example
         """
         try:
-            global instance_guid
             # begin-delete_resource_instance
 
             response = resource_controller_service.delete_resource_instance(id=instance_guid, recursive=False)
@@ -682,7 +662,6 @@ class TestResourceControllerV2Examples:
         list_reclamations request example
         """
         try:
-            global instance_guid, reclamation_id, account_id
             print('\nlist_reclamations() result:')
             # begin-list_reclamations
 
@@ -705,7 +684,6 @@ class TestResourceControllerV2Examples:
         run_reclamation_action request example
         """
         try:
-            global reclamation_id
             assert reclamation_id is not None
             print('\nrun_reclamation_action() result:')
             # begin-run_reclamation_action

--- a/examples/test_usage_reports_v4_examples.py
+++ b/examples/test_usage_reports_v4_examples.py
@@ -49,6 +49,10 @@ account_id = None
 resource_group_id = None
 org_id = None
 billing_month = None
+cos_bucket = None
+cos_location = None
+snapshot_date_from = None
+snapshot_date_to = None
 
 ##############################################################################
 # Start of Examples for Service: UsageReportsV4
@@ -124,8 +128,6 @@ class TestUsageReportsV4Examples:
         get_account_summary request example
         """
         try:
-            global account_id, billing_month
-
             print('\nget_account_summary() result:')
             # begin-get_account_summary
 
@@ -146,8 +148,6 @@ class TestUsageReportsV4Examples:
         get_account_usage request example
         """
         try:
-            global account_id, billing_month
-
             print('\nget_account_usage() result:')
             # begin-get_account_usage
 
@@ -168,8 +168,6 @@ class TestUsageReportsV4Examples:
         get_resource_group_usage request example
         """
         try:
-            global account_id, resource_group_id, billing_month
-
             print('\nget_resource_group_usage() result:')
             # begin-get_resource_group_usage
 
@@ -190,8 +188,6 @@ class TestUsageReportsV4Examples:
         get_org_usage request example
         """
         try:
-            global account_id, org_id, billing_month
-
             print('\nget_org_usage() result:')
             # begin-get_org_usage
 
@@ -212,8 +208,6 @@ class TestUsageReportsV4Examples:
         get_resource_usage_account request example
         """
         try:
-            global account_id, billing_month
-
             print('\nget_resource_usage_account() result:')
             # begin-get_resource_usage_account
 
@@ -234,8 +228,6 @@ class TestUsageReportsV4Examples:
         get_resource_usage_resource_group request example
         """
         try:
-            global account_id, resource_group_id, billing_month
-
             print('\nget_resource_usage_resource_group() result:')
             # begin-get_resource_usage_resource_group
 
@@ -256,8 +248,6 @@ class TestUsageReportsV4Examples:
         get_resource_usage_org request example
         """
         try:
-            global account_id, org_id, billing_month
-
             print('\nget_resource_usage_org() result:')
             # begin-get_resource_usage_org
 
@@ -278,8 +268,6 @@ class TestUsageReportsV4Examples:
         create_reports_snapshot_config request example
         """
         try:
-            global account_id, cos_bucket, cos_location
-
             print('\ncreate_reports_snapshot_config() result:')
             # begin-create_reports_snapshot_config
 
@@ -304,8 +292,6 @@ class TestUsageReportsV4Examples:
         get_reports_snapshot_config request example
         """
         try:
-            global account_id
-
             print('\nget_reports_snapshot_config() result:')
             # begin-get_reports_snapshot_config
 
@@ -327,8 +313,6 @@ class TestUsageReportsV4Examples:
         update_reports_snapshot_config request example
         """
         try:
-            global account_id
-
             print('\nupdate_reports_snapshot_config() result:')
             # begin-update_reports_snapshot_config
 
@@ -350,8 +334,6 @@ class TestUsageReportsV4Examples:
         get_reports_snapshot request example
         """
         try:
-            global account_id, billing_month, snapshot_date_from, snapshot_date_to
-
             print('\nget_reports_snapshot() result:')
             # begin-get_reports_snapshot
 
@@ -376,8 +358,6 @@ class TestUsageReportsV4Examples:
         delete_reports_snapshot_config request example
         """
         try:
-            global account_id
-
             # begin-delete_reports_snapshot_config
 
             response = usage_reports_service.delete_reports_snapshot_config(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,6 @@
-# test dependencies
-couchdb>=1.2,<2.0.0
-coverage>=4.5.4
-pylint==2.15.10
-pytest>=7.0.1,<8.0.0
-pytest-cov>=2.2.1,<3.0.0
-responses>=0.12.1,<1.0.0
-tox>=3.2.0,<4.0.0
-black==22.12
+coverage>=7.3.2,<8.0.0
+pylint>=3.0.0,<4.0.0
+pytest>=7.4.2,<8.0.0
+pytest-cov>=4.1.0,<5.0.0
+responses>=0.23.3,<1.0.0
+black>=23.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-requests>=2.31.0,<3.0.0
-urllib3>=1.26.0,<2.0.0
-python_dateutil>=2.5.3,<3.0.0
-ibm_cloud_sdk_core>=3.16.7,<4.0.0
+ibm_cloud_sdk_core>=3.17.0,<4.0.0

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2019, 2021 IBM All Rights Reserved.
+# Copyright 2019, 2023 IBM All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -59,10 +59,10 @@ setup(
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',

--- a/test/integration/test_catalog_management_v1.py
+++ b/test/integration/test_catalog_management_v1.py
@@ -309,8 +309,6 @@ class TestCatalogManagementV1:
 
     @needscredentials
     def test_create_offering(self):
-        global offering_id
-        global created_offering_ids
         assert catalog_id is not None
 
         for i in range(2):
@@ -326,6 +324,7 @@ class TestCatalogManagementV1:
             assert offering is not None
             assert offering['id'] is not None
             print('offering id: ' + offering['id'])
+            global offering_id
             if offering_id is None:
                 offering_id = offering['id']
 
@@ -837,8 +836,6 @@ class TestCatalogManagementV1:
 
     @needscredentials
     def test_create_object(self):
-        global object_id
-        global created_object_ids
         assert catalog_id is not None
 
         for i in range(2):
@@ -868,6 +865,7 @@ class TestCatalogManagementV1:
             assert catalog_object is not None
             assert catalog_object['id'] is not None
 
+            global object_id
             if object_id is None:
                 object_id = catalog_object['id']
 

--- a/test/integration/test_context_based_restrictions_v1.py
+++ b/test/integration/test_context_based_restrictions_v1.py
@@ -655,7 +655,7 @@ class TestContextBasedRestrictionsV1:
         operations_list = response.get_result()
         assert operations_list is not None
         for api_type in operations_list['api_types']:
-            assert api_type is not ""
+            assert api_type != ""
 
     @needscredentials
     def test_list_available_service_operations_with_service_group(self):
@@ -668,7 +668,7 @@ class TestContextBasedRestrictionsV1:
         operations_list = response.get_result()
         assert operations_list is not None
         for api_type in operations_list['api_types']:
-            assert api_type is not ""
+            assert api_type != ""
 
     @needscredentials
     def test_list_available_service_operations_with_resource_type(self):
@@ -682,7 +682,7 @@ class TestContextBasedRestrictionsV1:
         operations_list = response.get_result()
         assert operations_list is not None
         for api_type in operations_list['api_types']:
-            assert api_type is not ""
+            assert api_type != ""
 
     @needscredentials
     def test_list_available_service_operations_with_mutual_exclusion_error(self):

--- a/test/integration/test_enterprise_management_v1.py
+++ b/test/integration/test_enterprise_management_v1.py
@@ -357,7 +357,6 @@ class TestEnterpriseManagementV1:
 
     @needscredentials
     def test_delete_account(self):
-
         response = self.enterprise_management_service.delete_account(
             account_id=example_account_id,
         )
@@ -366,7 +365,6 @@ class TestEnterpriseManagementV1:
 
     @needscredentials
     def test_delete_account_group(self):
-
         response = self.enterprise_management_service.delete_account_group(
             account_group_id=first_example_account_group_id,
         )

--- a/test/integration/test_iam_access_groups_v2.py
+++ b/test/integration/test_iam_access_groups_v2.py
@@ -17,11 +17,9 @@
 Integration Tests for IamAccessGroupsV2
 """
 
-from ibm_cloud_sdk_core import *
 import os
 import time
 import pytest
-import os
 import os.path
 from datetime import datetime, timezone
 import random

--- a/test/integration/test_iam_identity_v1.py
+++ b/test/integration/test_iam_identity_v1.py
@@ -350,7 +350,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_get_api_key(self):
-        global apikey_id1
         assert apikey_id1 is not None
 
         get_api_key_response = self.iam_identity_service.get_api_key(
@@ -422,10 +421,7 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_update_api_key(self):
-        global apikey_id1
         assert apikey_id1 is not None
-
-        global apikey_etag1
         assert apikey_etag1 is not None
 
         new_description = 'This is an updated description'
@@ -441,7 +437,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_lock_api_key(self):
-        global apikey_id1
         assert apikey_id1 is not None
 
         lock_api_key_response = self.iam_identity_service.lock_api_key(id=apikey_id1)
@@ -455,7 +450,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_unlock_api_key(self):
-        global apikey_id1
         assert apikey_id1 is not None
 
         unlock_api_key_response = self.iam_identity_service.unlock_api_key(id=apikey_id1)
@@ -469,7 +463,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_delete_api_key1(self):
-        global apikey_id1
         assert apikey_id1 is not None
 
         delete_api_key_response = self.iam_identity_service.delete_api_key(id=apikey_id1)
@@ -481,7 +474,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_delete_api_key2(self):
-        global apikey_id2
         assert apikey_id2 is not None
 
         delete_api_key_response = self.iam_identity_service.delete_api_key(id=apikey_id2)
@@ -510,7 +502,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_get_service_id(self):
-        global serviceid_id1
         assert serviceid_id1 is not None
 
         get_service_id_response = self.iam_identity_service.get_service_id(
@@ -546,10 +537,7 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_update_service_id(self):
-        global serviceid_id1
         assert serviceid_id1 is not None
-
-        global serviceid_etag1
         assert serviceid_etag1 is not None
 
         new_description = 'This is an updated description'
@@ -566,7 +554,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_lock_service_id(self):
-        global serviceid_id1
         assert serviceid_id1 is not None
 
         lock_service_id_response = self.iam_identity_service.lock_service_id(id=serviceid_id1)
@@ -579,7 +566,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_unlock_service_id(self):
-        global serviceid_id1
         assert serviceid_id1 is not None
 
         unlock_service_id_response = self.iam_identity_service.unlock_service_id(id=serviceid_id1)
@@ -592,7 +578,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_delete_service_id(self):
-        global serviceid_id1
         assert serviceid_id1 is not None
 
         delete_service_id_response = self.iam_identity_service.delete_service_id(id=serviceid_id1)
@@ -637,7 +622,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_get_profile(self):
-        global profile_id1
         assert profile_id1 is not None
 
         get_profile_response = self.iam_identity_service.get_profile(
@@ -687,10 +671,7 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_update_profile(self):
-        global profile_id1
         assert profile_id1 is not None
-
-        global profile_etag
         assert profile_etag is not None
 
         new_description = 'This is an updated description'
@@ -706,7 +687,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_delete_profile1(self):
-        global profile_id1
         assert profile_id1 is not None
 
         delete_profile_response = self.iam_identity_service.delete_profile(profile_id=profile_id1)
@@ -766,7 +746,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_get_claimRule(self):
-        global claimRule_id1
         assert claimRule_id1 is not None
 
         get_claimRule_response = self.iam_identity_service.get_claim_rule(profile_id=profile_id2, rule_id=claimRule_id1)
@@ -804,10 +783,7 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_update_claimRule(self):
-        global claimRule_id1
         assert claimRule_id1 is not None
-
-        global claimRule_etag
         assert claimRule_etag is not None
 
         profile_claim_rule_conditions_model = {}
@@ -832,7 +808,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_delete_claimRule1(self):
-        global claimRule_id1
         assert claimRule_id1 is not None
 
         delete_claimRule_response = self.iam_identity_service.delete_claim_rule(
@@ -846,7 +821,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_delete_claimRule2(self):
-        global claimRule_id2
         assert claimRule_id2 is not None
 
         delete_claimRule_response = self.iam_identity_service.delete_claim_rule(
@@ -882,7 +856,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_get_link(self):
-        global link_id
         assert link_id is not None
 
         get_link_response = self.iam_identity_service.get_link(profile_id=profile_id2, link_id=link_id)
@@ -916,7 +889,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_delete_link(self):
-        global link_id
         assert link_id is not None
 
         delete_link_response = self.iam_identity_service.delete_link(profile_id=profile_id2, link_id=link_id)
@@ -1008,7 +980,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_delete_profile2(self):
-        global profile_id2
         assert profile_id2 is not None
 
         delete_profile_response = self.iam_identity_service.delete_profile(profile_id=profile_id2)
@@ -1135,7 +1106,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_update_account_settings(self):
-        global account_setting_etag
         assert account_setting_etag is not None
 
         account_settings_user_mfa = {}
@@ -1338,9 +1308,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_get_profile_template(self):
-        global profile_template_id
-        global profile_template_version
-
         assert profile_template_id is not None
         assert profile_template_version is not None
 
@@ -1362,7 +1329,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_list_profile_templates(self):
-
         list_response = self.iam_identity_service.list_profile_templates(account_id=self.enterprise_account_id)
 
         assert list_response.get_status_code() == 200
@@ -1372,8 +1338,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_update_profile_template(self):
-        global profile_template_id
-        global profile_template_version
         global profile_template_etag
 
         assert profile_template_id is not None
@@ -1399,9 +1363,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_assign_profile_template(self):
-        global profile_template_id
-        global profile_template_version
-
         assert profile_template_id is not None
         assert profile_template_version is not None
 
@@ -1427,7 +1388,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_list_profile_template_assignments(self):
-        global profile_template_id
         assert profile_template_id is not None
 
         list_response = self.iam_identity_service.list_trusted_profile_assignments(
@@ -1440,7 +1400,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_create_new_profile_template_version(self):
-        global profile_template_id
         assert profile_template_id is not None
 
         profile_claim_rule_conditions = {}
@@ -1486,7 +1445,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_get_latest_profile_template_version(self):
-        global profile_template_id
         assert profile_template_id is not None
 
         get_response = self.iam_identity_service.get_latest_profile_template_version(template_id=profile_template_id)
@@ -1498,7 +1456,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_list_profile_template_versions(self):
-        global profile_template_id
         assert profile_template_id is not None
 
         list_response = self.iam_identity_service.list_versions_of_profile_template(template_id=profile_template_id)
@@ -1510,9 +1467,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_update_profile_template_assignment(self):
-        global profile_template_id
-        global profile_template_version
-        global profile_template_assignment_id
         global profile_template_assignment_etag
 
         assert profile_template_id is not None
@@ -1540,7 +1494,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_delete_profile_template_assignment(self):
-        global profile_template_assignment_id
         assert profile_template_assignment_id is not None
 
         self.waitUntilTrustedProfileAssignmentFinished(self.iam_identity_service, profile_template_assignment_id)
@@ -1552,8 +1505,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_delete_profile_template_version(self):
-        global profile_template_id
-        global profile_template_assignment_id
         assert profile_template_id is not None
         assert profile_template_assignment_id is not None
 
@@ -1564,7 +1515,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_delete_profile_template(self):
-        global profile_template_id
         assert profile_template_id is not None
 
         self.waitUntilTrustedProfileAssignmentFinished(self.iam_identity_service, profile_template_assignment_id)
@@ -1601,9 +1551,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_get_account_settings_template(self):
-        global account_settings_template_id
-        global account_settings_template_version
-
         assert account_settings_template_id is not None
         assert account_settings_template_version is not None
 
@@ -1625,7 +1572,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_list_account_settings_templates(self):
-
         list_response = self.iam_identity_service.list_account_settings_templates(account_id=self.enterprise_account_id)
 
         assert list_response.get_status_code() == 200
@@ -1635,8 +1581,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_update_account_settings_template(self):
-        global account_settings_template_id
-        global account_settings_template_version
         global account_settings_template_etag
 
         assert account_settings_template_id is not None
@@ -1667,9 +1611,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_assign_account_settings_template(self):
-        global account_settings_template_id
-        global account_settings_template_version
-
         assert account_settings_template_id is not None
         assert account_settings_template_version is not None
 
@@ -1695,7 +1636,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_list_account_settings_template_assignments(self):
-        global account_settings_template_id
         assert account_settings_template_id is not None
 
         list_response = self.iam_identity_service.list_account_settings_assignments(
@@ -1708,7 +1648,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_create_new_account_settings_template_version(self):
-        global account_settings_template_id
         assert account_settings_template_id is not None
 
         account_settings = {}
@@ -1738,7 +1677,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_get_latest_account_settings_template_version(self):
-        global account_settings_template_id
         assert account_settings_template_id is not None
 
         get_response = self.iam_identity_service.get_latest_account_settings_template_version(
@@ -1754,7 +1692,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_list_account_settings_template_versions(self):
-        global account_settings_template_id
         assert account_settings_template_id is not None
 
         list_response = self.iam_identity_service.list_versions_of_account_settings_template(
@@ -1770,9 +1707,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_update_account_settings_template_assignment(self):
-        global account_settings_template_id
-        global account_settings_template_version
-        global account_settings_template_assignment_id
         global account_settings_template_assignment_etag
 
         assert account_settings_template_id is not None
@@ -1802,7 +1736,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_delete_account_settings_template_assignment(self):
-        global account_settings_template_assignment_id
         assert account_settings_template_assignment_id is not None
 
         self.waitUntilAccountSettingsAssignmentFinished(
@@ -1816,8 +1749,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_delete_account_settings_template_version(self):
-        global account_settings_template_id
-        global account_settings_template_assignment_id
         assert account_settings_template_id is not None
         assert account_settings_template_assignment_id is not None
 
@@ -1828,7 +1759,6 @@ class TestIamIdentityV1:
 
     @needscredentials
     def test_delete_account_settings_template(self):
-        global account_settings_template_id
         assert account_settings_template_id is not None
 
         self.waitUntilAccountSettingsAssignmentFinished(

--- a/test/integration/test_iam_policy_management_v1.py
+++ b/test/integration/test_iam_policy_management_v1.py
@@ -529,7 +529,6 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert foundTestPolicy
 
     def test_14_list_v2_roles(self):
-
         response = self.service.list_roles(account_id=self.testCustomRole.account_id, service_group_id="IAM")
         assert response is not None
         assert response.get_status_code() == 200
@@ -557,7 +556,6 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert testServiceRolePresent
 
     def test_15_create_policy_template(self):
-
         response = self.service.create_policy_template(
             name=self.testTemplateName,
             account_id=self.testAccountId,
@@ -642,7 +640,6 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert foundTestTemplate
 
     def test_19_create_policy_template_version(self):
-
         self.testV2PolicyControl.grant.roles[0].role_id = self.testViewerRoleCrn
         response = self.service.create_policy_template_version(
             policy_template_id=self.testTemplateId,
@@ -708,7 +705,6 @@ class TestIamPolicyManagementV1(unittest.TestCase):
             )
 
     def test_22_delete_policy_template_version(self):
-
         response = self.service.delete_policy_template_version(
             policy_template_id=self.testTemplateId,
             version=self.testNewTemplateVersion,
@@ -716,7 +712,6 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert response.get_status_code() == 204
 
     def test_23_list_policy_template_versions(self):
-
         response = self.service.list_policy_template_versions(
             policy_template_id=self.testTemplateId,
         )
@@ -752,7 +747,6 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         self.__class__.testAssignmentId = result.assignments[0].id
 
     def test_25_get_policy_assignment(self):
-
         response = self.service.get_policy_assignment(
             assignment_id=self.testAssignmentId,
         )

--- a/test/integration/test_user_management_v1.py
+++ b/test/integration/test_user_management_v1.py
@@ -244,7 +244,6 @@ class TestUserManagementV1(unittest.TestCase):
         assert response.get_status_code() == 204
 
     def test_07_remove_user(self):
-        global REMOVED_USERID
         assert REMOVED_USERID is not None
 
         response = self.user_management_service.remove_user(account_id=self.ACCOUNT_ID, iam_id=REMOVED_USERID)

--- a/test/unit/test_context_based_restrictions_v1.py
+++ b/test/unit/test_context_based_restrictions_v1.py
@@ -59,8 +59,7 @@ def preprocess_url(operation_path: str):
     # Otherwise, return a regular expression that matches one or more trailing /.
     if re.fullmatch('.*/+', request_url) is None:
         return request_url
-    else:
-        return re.compile(request_url.rstrip('/') + '/+')
+    return re.compile(request_url.rstrip('/') + '/+')
 
 
 ##############################################################################

--- a/test/unit/test_enterprise_management_v1.py
+++ b/test/unit/test_enterprise_management_v1.py
@@ -59,8 +59,7 @@ def preprocess_url(operation_path: str):
     # Otherwise, return a regular expression that matches one or more trailing /.
     if re.fullmatch('.*/+', request_url) is None:
         return request_url
-    else:
-        return re.compile(request_url.rstrip('/') + '/+')
+    return re.compile(request_url.rstrip('/') + '/+')
 
 
 ##############################################################################

--- a/test/unit/test_global_search_v2.py
+++ b/test/unit/test_global_search_v2.py
@@ -57,8 +57,7 @@ def preprocess_url(operation_path: str):
     # Otherwise, return a regular expression that matches one or more trailing /.
     if re.fullmatch('.*/+', request_url) is None:
         return request_url
-    else:
-        return re.compile(request_url.rstrip('/') + '/+')
+    return re.compile(request_url.rstrip('/') + '/+')
 
 
 ##############################################################################

--- a/test/unit/test_global_tagging_v1.py
+++ b/test/unit/test_global_tagging_v1.py
@@ -57,8 +57,7 @@ def preprocess_url(operation_path: str):
     # Otherwise, return a regular expression that matches one or more trailing /.
     if re.fullmatch('.*/+', request_url) is None:
         return request_url
-    else:
-        return re.compile(request_url.rstrip('/') + '/+')
+    return re.compile(request_url.rstrip('/') + '/+')
 
 
 ##############################################################################

--- a/test/unit/test_iam_access_groups_v2.py
+++ b/test/unit/test_iam_access_groups_v2.py
@@ -59,8 +59,7 @@ def preprocess_url(operation_path: str):
     # Otherwise, return a regular expression that matches one or more trailing /.
     if re.fullmatch('.*/+', request_url) is None:
         return request_url
-    else:
-        return re.compile(request_url.rstrip('/') + '/+')
+    return re.compile(request_url.rstrip('/') + '/+')
 
 
 ##############################################################################

--- a/test/unit/test_iam_identity_v1.py
+++ b/test/unit/test_iam_identity_v1.py
@@ -59,8 +59,7 @@ def preprocess_url(operation_path: str):
     # Otherwise, return a regular expression that matches one or more trailing /.
     if re.fullmatch('.*/+', request_url) is None:
         return request_url
-    else:
-        return re.compile(request_url.rstrip('/') + '/+')
+    return re.compile(request_url.rstrip('/') + '/+')
 
 
 ##############################################################################

--- a/test/unit/test_iam_policy_management_v1.py
+++ b/test/unit/test_iam_policy_management_v1.py
@@ -59,8 +59,7 @@ def preprocess_url(operation_path: str):
     # Otherwise, return a regular expression that matches one or more trailing /.
     if re.fullmatch('.*/+', request_url) is None:
         return request_url
-    else:
-        return re.compile(request_url.rstrip('/') + '/+')
+    return re.compile(request_url.rstrip('/') + '/+')
 
 
 ##############################################################################

--- a/test/unit/test_usage_reports_v4.py
+++ b/test/unit/test_usage_reports_v4.py
@@ -59,8 +59,7 @@ def preprocess_url(operation_path: str):
     # Otherwise, return a regular expression that matches one or more trailing /.
     if re.fullmatch('.*/+', request_url) is None:
         return request_url
-    else:
-        return re.compile(request_url.rstrip('/') + '/+')
+    return re.compile(request_url.rstrip('/') + '/+')
 
 
 ##############################################################################

--- a/update_service.md
+++ b/update_service.md
@@ -177,15 +177,9 @@ see [Running Integration Tests/Examples](#running-integration-testsexamples).
 
 ### 8. Open PR with your changes
 After completing the previous steps to update the service, unit test, integration test, and working examples
-code, commit your changes.  This is also a good time to make sure that the entire project builds and tests
-cleanly.
+code, commit your changes.
 Example:  
 ```sh
-cd <project-root>
-npm ci
-npm run all
-# Fix any remaining lint-check errors with "npm run lint-fix"
-
 git add .
 git commit -s -m "feat(Example Service): re-gen service after recent API changes"
 git push
@@ -227,17 +221,17 @@ make all
 ```sh
 cd <project-root>
 
-pytest test/integration/test_example_service_v1.py
+python -m pytest test/integration/test_example_service_v1.py
 ```
-You should see 100% clean test results from the `pytest` command above, with no tests being skipped.
+You should see 100% clean test results from the command above, with no tests being skipped.
 
 4. To run the examples code for a service, follow these steps:  
 ```sh
 cd <project-root>
 
-pytest examples/test_example_service_v1_examples.py
+python -m pytest examples/test_example_service_v1_examples.py
 ```
-You should see 100% clean results from the `pytest` command above, with no tests being skipped.
+You should see 100% clean results from the command above, with no tests being skipped.
 
 
 ### Updating Integration Tests/Examples


### PR DESCRIPTION
## PR summary
This commit contains these changes:
- bumps the min supported version of python to 3.8
- change to Makefile to allow unit and int tests to be processed by pylint
- minor changes to existing unit/int tests and examples to avoid lint-check warnings

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->