### PR TITLE
fix(IAM Policy Management): S2S support for enterprise accounts

### DIFF
--- a/examples/test_iam_policy_management_v1_examples.py
+++ b/examples/test_iam_policy_management_v1_examples.py
@@ -52,11 +52,14 @@ example_custom_role_etag = None
 example_template_id = None
 example_template_etag = None
 example_template_version = None
+example_basic_template_version = None
 example_assignment_id = None
 example_user_id = "IBMid-user1"
 example_service_name = "iam-groups"
 example_assignment_policy_id = None
 example_updated_policy_etag = None
+example_target_account_id = None
+example_assignment_etag = None
 
 ##############################################################################
 # Start of Examples for Service: IamPolicyManagementV1
@@ -83,9 +86,10 @@ class TestIamPolicyManagementV1Examples:
             assert iam_policy_management_service is not None
 
             # Load the configuration
-            global config, example_account_id
+            global config, example_account_id, example_target_account_id
             config = read_external_sources(IamPolicyManagementV1.DEFAULT_SERVICE_NAME)
             example_account_id = config['TEST_ACCOUNT_ID']
+            example_target_account_id = config['TEST_TARGET_ACCOUNT_ID']
 
         print('Setup complete.')
 
@@ -545,21 +549,31 @@ class TestIamPolicyManagementV1Examples:
         create_policy_template request example
         """
         try:
-            print('\ncreate_policy_template() result:')
+            print('\ncreate_policy_s2s_template() result:')
             # begin-create_policy_template
 
             v2_policy_resource_attribute_model = {
-                'key': 'serviceType',
+                'key': 'serviceName',
                 'operator': 'stringEquals',
-                'value': 'service',
+                'value': 'cloud-object-storage',
             }
 
             v2_policy_resource_model = {
                 'attributes': [v2_policy_resource_attribute_model],
             }
 
+            v2_policy_subject_attribute_model = {
+                'key': 'serviceName',
+                'operator': 'stringEquals',
+                'value': 'compliance',
+            }
+
+            v2_policy_subject_model = {
+                'attributes': [v2_policy_subject_attribute_model],
+            }
+
             roles_model = {
-                'role_id': 'crn:v1:bluemix:public:iam::::role:Viewer',
+                'role_id': 'crn:v1:bluemix:public:iam::::serviceRole:Writer',
             }
 
             grant_model = {
@@ -571,9 +585,10 @@ class TestIamPolicyManagementV1Examples:
             }
 
             template_policy_model = {
-                'type': 'access',
+                'type': 'authorization',
                 'resource': v2_policy_resource_model,
                 'control': control_model,
+                'subject': v2_policy_subject_model,
             }
 
             response = iam_policy_management_service.create_policy_template(
@@ -585,8 +600,8 @@ class TestIamPolicyManagementV1Examples:
 
             global example_template_id
             example_template_id = policy_template['id']
-            global example_template_version
-            example_template_version = policy_template['version']
+            global example_basic_template_version
+            example_basic_template_version = policy_template['version']
 
             print(json.dumps(policy_template, indent=2))
 
@@ -626,21 +641,31 @@ class TestIamPolicyManagementV1Examples:
         replace_policy_template request example
         """
         try:
-            print('\nreplace_policy_template() result:')
+            print('\nreplace_policy_s2s_template() result:')
             # begin-replace_policy_template
 
             v2_policy_resource_attribute_model = {
-                'key': 'serviceType',
+                'key': 'serviceName',
                 'operator': 'stringEquals',
-                'value': 'service',
+                'value': 'kms',
             }
 
             v2_policy_resource_model = {
                 'attributes': [v2_policy_resource_attribute_model],
             }
 
+            v2_policy_subject_attribute_model = {
+                'key': 'serviceName',
+                'operator': 'stringEquals',
+                'value': 'compliance',
+            }
+
+            v2_policy_subject_model = {
+                'attributes': [v2_policy_subject_attribute_model],
+            }
+
             roles_model = {
-                'role_id': 'crn:v1:bluemix:public:iam::::role:Editor',
+                'role_id': 'crn:v1:bluemix:public:iam::::serviceRole:Reader',
             }
 
             grant_model = {
@@ -652,14 +677,15 @@ class TestIamPolicyManagementV1Examples:
             }
 
             template_policy_model = {
-                'type': 'access',
+                'type': 'authorization',
                 'resource': v2_policy_resource_model,
+                'subject': v2_policy_subject_model,
                 'control': control_model,
             }
 
             response = iam_policy_management_service.replace_policy_template(
                 policy_template_id=example_template_id,
-                version=example_template_version,
+                version=example_basic_template_version,
                 if_match=example_template_etag,
                 policy=template_policy_model,
             )
@@ -703,17 +729,27 @@ class TestIamPolicyManagementV1Examples:
             # begin-create_policy_template_version
 
             v2_policy_resource_attribute_model = {
-                'key': 'serviceType',
+                'key': 'serviceName',
                 'operator': 'stringEquals',
-                'value': 'service',
+                'value': 'appid',
             }
 
             v2_policy_resource_model = {
                 'attributes': [v2_policy_resource_attribute_model],
             }
 
+            v2_policy_subject_attribute_model = {
+                'key': 'serviceName',
+                'operator': 'stringEquals',
+                'value': 'compliance',
+            }
+
+            v2_policy_subject_model = {
+                'attributes': [v2_policy_subject_attribute_model],
+            }
+
             roles_model = {
-                'role_id': 'crn:v1:bluemix:public:iam::::role:Viewer',
+                'role_id': 'crn:v1:bluemix:public:iam::::serviceRole:Reader',
             }
 
             grant_model = {
@@ -725,17 +761,20 @@ class TestIamPolicyManagementV1Examples:
             }
 
             template_policy_model = {
-                'type': 'access',
+                'type': 'authorization',
                 'resource': v2_policy_resource_model,
                 'control': control_model,
+                'subject': v2_policy_subject_model,
             }
 
             response = iam_policy_management_service.create_policy_template_version(
                 policy_template_id=example_template_id,
                 policy=template_policy_model,
+                committed=True,
             )
             policy_template = response.get_result()
-
+            global example_template_version
+            example_template_version = policy_template['version']
             print(json.dumps(policy_template, indent=2))
 
             # end-create_policy_template_version
@@ -799,11 +838,67 @@ class TestIamPolicyManagementV1Examples:
 
             response = iam_policy_management_service.commit_policy_template(
                 policy_template_id=example_template_id,
-                version=example_template_version,
+                version=example_basic_template_version,
             )
 
             # end-commit_policy_template
             print('\ncommit_policy_template() response status code: ', response.get_status_code())
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    
+    @needscredentials
+    def test_create_policy_assignment_example(self):
+        """
+        create_policy_template_assignment request example
+        """
+        try:
+            print('\ncreate_policy_template_assignment() result:')
+            # begin-create_policy_template_assignment
+            response=iam_policy_management_service.create_policy_template_assignment(
+            version="1.0",
+            target=AssignmentTargetDetails(
+                type="Account",
+                id=example_target_account_id,
+            ),
+            options=PolicyAssignmentV1Options(root=PolicyAssignmentV1OptionsRoot(requester_id="test_sdk", assignment_id="test")),
+            templates=[AssignmentTemplateDetails(id=example_template_id, version=example_basic_template_version)],
+         )
+            result = response.get_result()
+            assert result is not None
+
+            global example_assignment_id
+            example_assignment_id = result['assignments'][0]['id']
+            global example_assignment_etag
+            example_assignment_etag = response.get_headers().get("Etag")
+            print(json.dumps(result, indent=2))
+
+            # end-create_policy_template_assignment
+
+        except ApiException as e:
+            pytest.fail(str(e))
+    
+    @needscredentials
+    def test_update_policy_assignment_example(self):
+        """
+        update_policy_assignment request example
+        """
+        try:
+            print('\nupdate_policy_assignment() result:')
+            # begin-update_policy_assignment
+
+            response = iam_policy_management_service.update_policy_assignment(
+                assignment_id=example_assignment_id,
+                version="1.0",
+                if_match=example_assignment_etag,
+                template_version=example_template_version,
+            )
+            assignment = response.get_result()
+
+            print(json.dumps(assignment, indent=2))
+
+            # end-update_policy_assignment
 
         except ApiException as e:
             pytest.fail(str(e))
@@ -819,11 +914,9 @@ class TestIamPolicyManagementV1Examples:
 
             response = iam_policy_management_service.list_policy_assignments(
                 account_id=example_account_id,
+                version="1.0",
             )
             polcy_template_assignment_collection = response.get_result()
-
-            global example_assignment_id
-            example_assignment_id = polcy_template_assignment_collection['assignments'][0]['id']
 
             print(json.dumps(polcy_template_assignment_collection, indent=2))
 
@@ -843,6 +936,7 @@ class TestIamPolicyManagementV1Examples:
 
             response = iam_policy_management_service.get_policy_assignment(
                 assignment_id=example_assignment_id,
+                version="1.0",
             )
             policy_assignment_record = response.get_result()
 
@@ -871,6 +965,24 @@ class TestIamPolicyManagementV1Examples:
             print(json.dumps(policy, indent=2))
 
             # end-get_v2_assignment_policy
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_delete_policy_assignment_example(self):
+        """
+        delete_policy_assignment request example
+        """
+        try:
+            # begin-delete_policy_assignment
+
+            response = iam_policy_management_service.delete_policy_assignment(
+            assignment_id=example_assignment_id,
+        )
+
+            # end-delete_policy_assignment
+            print('\ndelete_policy_assignment() response status code: ', response.get_status_code())
 
         except ApiException as e:
             pytest.fail(str(e))

--- a/examples/test_iam_policy_management_v1_examples.py
+++ b/examples/test_iam_policy_management_v1_examples.py
@@ -847,7 +847,6 @@ class TestIamPolicyManagementV1Examples:
         except ApiException as e:
             pytest.fail(str(e))
 
-    
     @needscredentials
     def test_create_policy_assignment_example(self):
         """
@@ -856,15 +855,17 @@ class TestIamPolicyManagementV1Examples:
         try:
             print('\ncreate_policy_template_assignment() result:')
             # begin-create_policy_template_assignment
-            response=iam_policy_management_service.create_policy_template_assignment(
-            version="1.0",
-            target=AssignmentTargetDetails(
-                type="Account",
-                id=example_target_account_id,
-            ),
-            options=PolicyAssignmentV1Options(root=PolicyAssignmentV1OptionsRoot(requester_id="test_sdk", assignment_id="test")),
-            templates=[AssignmentTemplateDetails(id=example_template_id, version=example_basic_template_version)],
-         )
+            response = iam_policy_management_service.create_policy_template_assignment(
+                version="1.0",
+                target=AssignmentTargetDetails(
+                    type="Account",
+                    id=example_target_account_id,
+                ),
+                options=PolicyAssignmentV1Options(
+                    root=PolicyAssignmentV1OptionsRoot(requester_id="test_sdk", assignment_id="test")
+                ),
+                templates=[AssignmentTemplateDetails(id=example_template_id, version=example_basic_template_version)],
+            )
             result = response.get_result()
             assert result is not None
 
@@ -878,7 +879,7 @@ class TestIamPolicyManagementV1Examples:
 
         except ApiException as e:
             pytest.fail(str(e))
-    
+
     @needscredentials
     def test_update_policy_assignment_example(self):
         """
@@ -978,8 +979,8 @@ class TestIamPolicyManagementV1Examples:
             # begin-delete_policy_assignment
 
             response = iam_policy_management_service.delete_policy_assignment(
-            assignment_id=example_assignment_id,
-        )
+                assignment_id=example_assignment_id,
+            )
 
             # end-delete_policy_assignment
             print('\ndelete_policy_assignment() response status code: ', response.get_status_code())

--- a/ibm_platform_services/iam_policy_management_v1.py
+++ b/ibm_platform_services/iam_policy_management_v1.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# IBM OpenAPI SDK Code Generator Version: 3.85.0-75c38f8f-20240206-210220
+# IBM OpenAPI SDK Code Generator Version: 3.88.0-b0b4c159-20240402-205910
 
 """
 IAM Policy Management API
@@ -1619,17 +1619,25 @@ class IamPolicyManagementV1(BaseService):
         *,
         accept_language: Optional[str] = None,
         state: Optional[str] = None,
+        name: Optional[str] = None,
+        policy_service_type: Optional[str] = None,
+        policy_service_name: Optional[str] = None,
+        policy_service_group_id: Optional[str] = None,
+        policy_type: Optional[str] = None,
         **kwargs,
     ) -> DetailedResponse:
         """
         List policy templates by attributes.
 
         List policy templates and filter by attributes by using query parameters. The
-        following attributes are supported: `account_id`.
-        `account_id` is a required query parameter. Only policy templates that have the
-        specified attributes and that the caller has read access to are returned. If the
-        caller does not have read access to any policy templates an empty array is
-        returned.
+        following attributes are supported:
+        `account_id`, `policy_service_name`, `policy_service_type`,
+        `policy_service_group_id` and `policy_type`.
+        `account_id` is a required query parameter. These attributes
+        `policy_service_name`, `policy_service_type` and `policy_service_group_id` are
+        mutually exclusive. Only policy templates that have the specified attributes and
+        that the caller has read access to are returned. If the caller does not have read
+        access to any policy templates an empty array is returned.
 
         :param str account_id: The account GUID that the policy templates belong
                to.
@@ -1646,6 +1654,11 @@ class IamPolicyManagementV1(BaseService):
                * `zh-cn` - Chinese (Simplified, PRC)
                * `zh-tw` - (Chinese, Taiwan).
         :param str state: (optional) The policy template state.
+        :param str name: (optional) The policy template name.
+        :param str policy_service_type: (optional) Service type, Optional.
+        :param str policy_service_name: (optional) Service name, Optional.
+        :param str policy_service_group_id: (optional) Service group id, Optional.
+        :param str policy_type: (optional) Policy type, Optional.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `PolicyTemplateCollection` object
@@ -1666,6 +1679,11 @@ class IamPolicyManagementV1(BaseService):
         params = {
             'account_id': account_id,
             'state': state,
+            'name': name,
+            'policy_service_type': policy_service_type,
+            'policy_service_name': policy_service_name,
+            'policy_service_group_id': policy_service_group_id,
+            'policy_type': policy_type,
         }
 
         if 'headers' in kwargs:
@@ -2239,6 +2257,7 @@ class IamPolicyManagementV1(BaseService):
 
     def list_policy_assignments(
         self,
+        version: str,
         account_id: str,
         *,
         accept_language: Optional[str] = None,
@@ -2257,6 +2276,7 @@ class IamPolicyManagementV1(BaseService):
         If the caller does not have read access to any policy template assignments an
         empty array is returned.
 
+        :param str version: specify version of response body format.
         :param str account_id: The account GUID in which the policies belong to.
         :param str accept_language: (optional) Language code for translations
                * `default` - English
@@ -2277,6 +2297,8 @@ class IamPolicyManagementV1(BaseService):
         :rtype: DetailedResponse with `dict` result representing a `PolicyTemplateAssignmentCollection` object
         """
 
+        if not version:
+            raise ValueError('version must be provided')
         if not account_id:
             raise ValueError('account_id must be provided')
         headers = {
@@ -2290,6 +2312,7 @@ class IamPolicyManagementV1(BaseService):
         headers.update(sdk_headers)
 
         params = {
+            'version': version,
             'account_id': account_id,
             'template_id': template_id,
             'template_version': template_version,
@@ -2311,9 +2334,100 @@ class IamPolicyManagementV1(BaseService):
         response = self.send(request, **kwargs)
         return response
 
+    def create_policy_template_assignment(
+        self,
+        version: str,
+        target: 'AssignmentTargetDetails',
+        options: 'PolicyAssignmentV1Options',
+        templates: List['AssignmentTemplateDetails'],
+        *,
+        accept_language: Optional[str] = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Create a policy authorization template assignment.
+
+        Assign a policy template to child accounts and account groups. This creates the
+        policy in the accounts and account groups that you specify.
+
+        :param str version: specify version of response body format.
+        :param AssignmentTargetDetails target: assignment target account and type.
+        :param PolicyAssignmentV1Options options: The set of properties required
+               for a policy assignment.
+        :param List[AssignmentTemplateDetails] templates: List of template details
+               for policy assignment.
+        :param str accept_language: (optional) Language code for translations
+               * `default` - English
+               * `de` -  German (Standard)
+               * `en` - English
+               * `es` - Spanish (Spain)
+               * `fr` - French (Standard)
+               * `it` - Italian (Standard)
+               * `ja` - Japanese
+               * `ko` - Korean
+               * `pt-br` - Portuguese (Brazil)
+               * `zh-cn` - Chinese (Simplified, PRC)
+               * `zh-tw` - (Chinese, Taiwan).
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `PolicyAssignmentV1Collection` object
+        """
+
+        if not version:
+            raise ValueError('version must be provided')
+        if target is None:
+            raise ValueError('target must be provided')
+        if options is None:
+            raise ValueError('options must be provided')
+        if templates is None:
+            raise ValueError('templates must be provided')
+        target = convert_model(target)
+        options = convert_model(options)
+        templates = [convert_model(x) for x in templates]
+        headers = {
+            'Accept-Language': accept_language,
+        }
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='create_policy_template_assignment',
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'version': version,
+        }
+
+        data = {
+            'target': target,
+            'options': options,
+            'templates': templates,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v1/policy_assignments'
+        request = self.prepare_request(
+            method='POST',
+            url=url,
+            headers=headers,
+            params=params,
+            data=data,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
     def get_policy_assignment(
         self,
         assignment_id: str,
+        version: str,
         **kwargs,
     ) -> DetailedResponse:
         """
@@ -2322,13 +2436,16 @@ class IamPolicyManagementV1(BaseService):
         Retrieve a policy template assignment by providing a policy assignment ID.
 
         :param str assignment_id: The policy template assignment ID.
+        :param str version: specify version of response body format.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
-        :rtype: DetailedResponse with `dict` result representing a `PolicyAssignment` object
+        :rtype: DetailedResponse with `dict` result representing a `GetPolicyAssignmentResponse` object
         """
 
         if not assignment_id:
             raise ValueError('assignment_id must be provided')
+        if not version:
+            raise ValueError('version must be provided')
         headers = {}
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME,
@@ -2336,6 +2453,10 @@ class IamPolicyManagementV1(BaseService):
             operation_id='get_policy_assignment',
         )
         headers.update(sdk_headers)
+
+        params = {
+            'version': version,
+        }
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
@@ -2348,6 +2469,125 @@ class IamPolicyManagementV1(BaseService):
         url = '/v1/policy_assignments/{assignment_id}'.format(**path_param_dict)
         request = self.prepare_request(
             method='GET',
+            url=url,
+            headers=headers,
+            params=params,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def update_policy_assignment(
+        self,
+        assignment_id: str,
+        version: str,
+        if_match: str,
+        template_version: str,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Update a policy authorization type assignment.
+
+        Update a policy assignment by providing a policy assignment ID.
+
+        :param str assignment_id: The policy template assignment ID.
+        :param str version: specify version of response body format.
+        :param str if_match: The revision number for updating a policy assignment
+               and must match the ETag value of the existing policy assignment. The Etag
+               can be retrieved using the GET /v1/policy_assignments/{assignment_id} API
+               and looking at the ETag response header.
+        :param str template_version: The policy template version to update to.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `PolicyAssignmentV1` object
+        """
+
+        if not assignment_id:
+            raise ValueError('assignment_id must be provided')
+        if not version:
+            raise ValueError('version must be provided')
+        if not if_match:
+            raise ValueError('if_match must be provided')
+        if template_version is None:
+            raise ValueError('template_version must be provided')
+        headers = {
+            'If-Match': if_match,
+        }
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='update_policy_assignment',
+        )
+        headers.update(sdk_headers)
+
+        params = {
+            'version': version,
+        }
+
+        data = {
+            'template_version': template_version,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['assignment_id']
+        path_param_values = self.encode_path_vars(assignment_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/policy_assignments/{assignment_id}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='PATCH',
+            url=url,
+            headers=headers,
+            params=params,
+            data=data,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def delete_policy_assignment(
+        self,
+        assignment_id: str,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Remove a policy assignment.
+
+        Remove a policy template assignment by providing a policy assignment ID. You can't
+        delete a policy assignment if the status is "in_progress".
+
+        :param str assignment_id: The policy template assignment ID.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse
+        """
+
+        if not assignment_id:
+            raise ValueError('assignment_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='delete_policy_assignment',
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+
+        path_param_keys = ['assignment_id']
+        path_param_values = self.encode_path_vars(assignment_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/policy_assignments/{assignment_id}'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='DELETE',
             url=url,
             headers=headers,
         )
@@ -2490,6 +2730,22 @@ class ListPolicyTemplatesEnums:
         ACTIVE = 'active'
         DELETED = 'deleted'
 
+    class PolicyServiceType(str, Enum):
+        """
+        Service type, Optional.
+        """
+
+        SERVICE = 'service'
+        PLATFORM_SERVICE = 'platform_service'
+
+    class PolicyType(str, Enum):
+        """
+        Policy type, Optional.
+        """
+
+        ACCESS = 'access'
+        AUTHORIZATION = 'authorization'
+
 
 class GetPolicyTemplateEnums:
     """
@@ -2578,6 +2834,145 @@ class AssignmentResourceCreated:
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other: 'AssignmentResourceCreated') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class AssignmentTargetDetails:
+    """
+    assignment target account and type.
+
+    :param str type: (optional) Assignment target type.
+    :param str id: (optional) ID of the target account.
+    """
+
+    def __init__(
+        self,
+        *,
+        type: Optional[str] = None,
+        id: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize a AssignmentTargetDetails object.
+
+        :param str type: (optional) Assignment target type.
+        :param str id: (optional) ID of the target account.
+        """
+        self.type = type
+        self.id = id
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'AssignmentTargetDetails':
+        """Initialize a AssignmentTargetDetails object from a json dictionary."""
+        args = {}
+        if (type := _dict.get('type')) is not None:
+            args['type'] = type
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a AssignmentTargetDetails object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'type') and self.type is not None:
+            _dict['type'] = self.type
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this AssignmentTargetDetails object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'AssignmentTargetDetails') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'AssignmentTargetDetails') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class TypeEnum(str, Enum):
+        """
+        Assignment target type.
+        """
+
+        ACCOUNT = 'Account'
+
+
+class AssignmentTemplateDetails:
+    """
+    policy template details.
+
+    :param str id: (optional) policy template id.
+    :param str version: (optional) policy template version.
+    """
+
+    def __init__(
+        self,
+        *,
+        id: Optional[str] = None,
+        version: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize a AssignmentTemplateDetails object.
+
+        :param str id: (optional) policy template id.
+        :param str version: (optional) policy template version.
+        """
+        self.id = id
+        self.version = version
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'AssignmentTemplateDetails':
+        """Initialize a AssignmentTemplateDetails object from a json dictionary."""
+        args = {}
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
+        if (version := _dict.get('version')) is not None:
+            args['version'] = version
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a AssignmentTemplateDetails object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'version') and self.version is not None:
+            _dict['version'] = self.version
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this AssignmentTemplateDetails object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'AssignmentTemplateDetails') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'AssignmentTemplateDetails') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -3262,6 +3657,97 @@ class ErrorResponse:
         return not self == other
 
 
+class GetPolicyAssignmentResponse:
+    """
+    GetPolicyAssignmentResponse.
+
+    """
+
+    def __init__(
+        self,
+    ) -> None:
+        """
+        Initialize a GetPolicyAssignmentResponse object.
+
+        """
+        msg = "Cannot instantiate base class. Instead, instantiate one of the defined subclasses: {0}".format(
+            ", ".join(['GetPolicyAssignmentResponsePolicyAssignmentV1', 'GetPolicyAssignmentResponsePolicyAssignment'])
+        )
+        raise Exception(msg)
+
+
+class GetPolicyAssignmentResponsePolicyAssignmentV1Subject:
+    """
+    subject details of access type assignment.
+
+    :param str id: (optional)
+    :param str type: (optional)
+    """
+
+    def __init__(
+        self,
+        *,
+        id: Optional[str] = None,
+        type: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize a GetPolicyAssignmentResponsePolicyAssignmentV1Subject object.
+
+        """
+        self.id = id
+        self.type = type
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'GetPolicyAssignmentResponsePolicyAssignmentV1Subject':
+        """Initialize a GetPolicyAssignmentResponsePolicyAssignmentV1Subject object from a json dictionary."""
+        args = {}
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
+        if (type := _dict.get('type')) is not None:
+            args['type'] = type
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a GetPolicyAssignmentResponsePolicyAssignmentV1Subject object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'id') and getattr(self, 'id') is not None:
+            _dict['id'] = getattr(self, 'id')
+        if hasattr(self, 'type') and getattr(self, 'type') is not None:
+            _dict['type'] = getattr(self, 'type')
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this GetPolicyAssignmentResponsePolicyAssignmentV1Subject object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'GetPolicyAssignmentResponsePolicyAssignmentV1Subject') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'GetPolicyAssignmentResponsePolicyAssignmentV1Subject') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class TypeEnum(str, Enum):
+        """
+        type.
+        """
+
+        IAM_ID = 'iam_id'
+        ACCESS_GROUP_ID = 'access_group_id'
+
+
 class Grant:
     """
     Permission granted by the policy.
@@ -3659,223 +4145,6 @@ class Policy:
         DELETED = 'deleted'
 
 
-class PolicyAssignment:
-    """
-    The set of properties associated with the policy template assignment.
-
-    :param str template_id: policy template id.
-    :param str template_version: policy template version.
-    :param str assignment_id: Passed in value to correlate with other assignments.
-    :param str target_type: Assignment target type.
-    :param str target: ID of the target account.
-    :param List[PolicyAssignmentOptions] options: List of objects with required
-          properties for a policy assignment.
-    :param str id: (optional) Policy assignment ID.
-    :param str account_id: (optional) The account GUID that the policies assignments
-          belong to..
-    :param str href: (optional) The href URL that links to the policies assignments
-          API by policy assignment ID.
-    :param datetime created_at: (optional) The UTC timestamp when the policy
-          assignment was created.
-    :param str created_by_id: (optional) The iam ID of the entity that created the
-          policy assignment.
-    :param datetime last_modified_at: (optional) The UTC timestamp when the policy
-          assignment was last modified.
-    :param str last_modified_by_id: (optional) The iam ID of the entity that last
-          modified the policy assignment.
-    :param List[PolicyAssignmentResources] resources: (optional) Object for each
-          account assigned.
-    :param str status: The policy assignment status.
-    """
-
-    def __init__(
-        self,
-        template_id: str,
-        template_version: str,
-        assignment_id: str,
-        target_type: str,
-        target: str,
-        options: List['PolicyAssignmentOptions'],
-        status: str,
-        *,
-        id: Optional[str] = None,
-        account_id: Optional[str] = None,
-        href: Optional[str] = None,
-        created_at: Optional[datetime] = None,
-        created_by_id: Optional[str] = None,
-        last_modified_at: Optional[datetime] = None,
-        last_modified_by_id: Optional[str] = None,
-        resources: Optional[List['PolicyAssignmentResources']] = None,
-    ) -> None:
-        """
-        Initialize a PolicyAssignment object.
-
-        :param str template_id: policy template id.
-        :param str template_version: policy template version.
-        :param str assignment_id: Passed in value to correlate with other
-               assignments.
-        :param str target_type: Assignment target type.
-        :param str target: ID of the target account.
-        :param List[PolicyAssignmentOptions] options: List of objects with required
-               properties for a policy assignment.
-        :param str status: The policy assignment status.
-        :param List[PolicyAssignmentResources] resources: (optional) Object for
-               each account assigned.
-        """
-        self.template_id = template_id
-        self.template_version = template_version
-        self.assignment_id = assignment_id
-        self.target_type = target_type
-        self.target = target
-        self.options = options
-        self.id = id
-        self.account_id = account_id
-        self.href = href
-        self.created_at = created_at
-        self.created_by_id = created_by_id
-        self.last_modified_at = last_modified_at
-        self.last_modified_by_id = last_modified_by_id
-        self.resources = resources
-        self.status = status
-
-    @classmethod
-    def from_dict(cls, _dict: Dict) -> 'PolicyAssignment':
-        """Initialize a PolicyAssignment object from a json dictionary."""
-        args = {}
-        if (template_id := _dict.get('template_id')) is not None:
-            args['template_id'] = template_id
-        else:
-            raise ValueError('Required property \'template_id\' not present in PolicyAssignment JSON')
-        if (template_version := _dict.get('template_version')) is not None:
-            args['template_version'] = template_version
-        else:
-            raise ValueError('Required property \'template_version\' not present in PolicyAssignment JSON')
-        if (assignment_id := _dict.get('assignment_id')) is not None:
-            args['assignment_id'] = assignment_id
-        else:
-            raise ValueError('Required property \'assignment_id\' not present in PolicyAssignment JSON')
-        if (target_type := _dict.get('target_type')) is not None:
-            args['target_type'] = target_type
-        else:
-            raise ValueError('Required property \'target_type\' not present in PolicyAssignment JSON')
-        if (target := _dict.get('target')) is not None:
-            args['target'] = target
-        else:
-            raise ValueError('Required property \'target\' not present in PolicyAssignment JSON')
-        if (options := _dict.get('options')) is not None:
-            args['options'] = [PolicyAssignmentOptions.from_dict(v) for v in options]
-        else:
-            raise ValueError('Required property \'options\' not present in PolicyAssignment JSON')
-        if (id := _dict.get('id')) is not None:
-            args['id'] = id
-        if (account_id := _dict.get('account_id')) is not None:
-            args['account_id'] = account_id
-        if (href := _dict.get('href')) is not None:
-            args['href'] = href
-        if (created_at := _dict.get('created_at')) is not None:
-            args['created_at'] = string_to_datetime(created_at)
-        if (created_by_id := _dict.get('created_by_id')) is not None:
-            args['created_by_id'] = created_by_id
-        if (last_modified_at := _dict.get('last_modified_at')) is not None:
-            args['last_modified_at'] = string_to_datetime(last_modified_at)
-        if (last_modified_by_id := _dict.get('last_modified_by_id')) is not None:
-            args['last_modified_by_id'] = last_modified_by_id
-        if (resources := _dict.get('resources')) is not None:
-            args['resources'] = [PolicyAssignmentResources.from_dict(v) for v in resources]
-        if (status := _dict.get('status')) is not None:
-            args['status'] = status
-        else:
-            raise ValueError('Required property \'status\' not present in PolicyAssignment JSON')
-        return cls(**args)
-
-    @classmethod
-    def _from_dict(cls, _dict):
-        """Initialize a PolicyAssignment object from a json dictionary."""
-        return cls.from_dict(_dict)
-
-    def to_dict(self) -> Dict:
-        """Return a json dictionary representing this model."""
-        _dict = {}
-        if hasattr(self, 'template_id') and self.template_id is not None:
-            _dict['template_id'] = self.template_id
-        if hasattr(self, 'template_version') and self.template_version is not None:
-            _dict['template_version'] = self.template_version
-        if hasattr(self, 'assignment_id') and self.assignment_id is not None:
-            _dict['assignment_id'] = self.assignment_id
-        if hasattr(self, 'target_type') and self.target_type is not None:
-            _dict['target_type'] = self.target_type
-        if hasattr(self, 'target') and self.target is not None:
-            _dict['target'] = self.target
-        if hasattr(self, 'options') and self.options is not None:
-            options_list = []
-            for v in self.options:
-                if isinstance(v, dict):
-                    options_list.append(v)
-                else:
-                    options_list.append(v.to_dict())
-            _dict['options'] = options_list
-        if hasattr(self, 'id') and getattr(self, 'id') is not None:
-            _dict['id'] = getattr(self, 'id')
-        if hasattr(self, 'account_id') and getattr(self, 'account_id') is not None:
-            _dict['account_id'] = getattr(self, 'account_id')
-        if hasattr(self, 'href') and getattr(self, 'href') is not None:
-            _dict['href'] = getattr(self, 'href')
-        if hasattr(self, 'created_at') and getattr(self, 'created_at') is not None:
-            _dict['created_at'] = datetime_to_string(getattr(self, 'created_at'))
-        if hasattr(self, 'created_by_id') and getattr(self, 'created_by_id') is not None:
-            _dict['created_by_id'] = getattr(self, 'created_by_id')
-        if hasattr(self, 'last_modified_at') and getattr(self, 'last_modified_at') is not None:
-            _dict['last_modified_at'] = datetime_to_string(getattr(self, 'last_modified_at'))
-        if hasattr(self, 'last_modified_by_id') and getattr(self, 'last_modified_by_id') is not None:
-            _dict['last_modified_by_id'] = getattr(self, 'last_modified_by_id')
-        if hasattr(self, 'resources') and self.resources is not None:
-            resources_list = []
-            for v in self.resources:
-                if isinstance(v, dict):
-                    resources_list.append(v)
-                else:
-                    resources_list.append(v.to_dict())
-            _dict['resources'] = resources_list
-        if hasattr(self, 'status') and self.status is not None:
-            _dict['status'] = self.status
-        return _dict
-
-    def _to_dict(self):
-        """Return a json dictionary representing this model."""
-        return self.to_dict()
-
-    def __str__(self) -> str:
-        """Return a `str` version of this PolicyAssignment object."""
-        return json.dumps(self.to_dict(), indent=2)
-
-    def __eq__(self, other: 'PolicyAssignment') -> bool:
-        """Return `true` when self and other are equal, false otherwise."""
-        if not isinstance(other, self.__class__):
-            return False
-        return self.__dict__ == other.__dict__
-
-    def __ne__(self, other: 'PolicyAssignment') -> bool:
-        """Return `true` when self and other are not equal, false otherwise."""
-        return not self == other
-
-    class TargetTypeEnum(str, Enum):
-        """
-        Assignment target type.
-        """
-
-        ACCOUNT = 'Account'
-
-    class StatusEnum(str, Enum):
-        """
-        The policy assignment status.
-        """
-
-        IN_PROGRESS = 'in_progress'
-        SUCCEEDED = 'succeeded'
-        SUCCEED_WITH_ERRORS = 'succeed_with_errors'
-        FAILED = 'failed'
-
-
 class PolicyAssignmentOptions:
     """
     The set of properties required for a policy assignment.
@@ -4137,6 +4406,627 @@ class PolicyAssignmentResources:
     def __ne__(self, other: 'PolicyAssignmentResources') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
+
+
+class PolicyAssignmentV1:
+    """
+    The set of properties associated with the policy template assignment.
+
+    :param AssignmentTargetDetails target: assignment target account and type.
+    :param PolicyAssignmentV1Options options: The set of properties required for a
+          policy assignment.
+    :param str id: (optional) Policy assignment ID.
+    :param str account_id: (optional) The account GUID that the policies assignments
+          belong to..
+    :param str href: (optional) The href URL that links to the policies assignments
+          API by policy assignment ID.
+    :param datetime created_at: (optional) The UTC timestamp when the policy
+          assignment was created.
+    :param str created_by_id: (optional) The iam ID of the entity that created the
+          policy assignment.
+    :param datetime last_modified_at: (optional) The UTC timestamp when the policy
+          assignment was last modified.
+    :param str last_modified_by_id: (optional) The iam ID of the entity that last
+          modified the policy assignment.
+    :param List[PolicyAssignmentV1Resources] resources: Object for each account
+          assigned.
+    :param PolicyAssignmentV1Subject subject: (optional) subject details of access
+          type assignment.
+    :param AssignmentTemplateDetails template: policy template details.
+    :param str status: The policy assignment status.
+    """
+
+    def __init__(
+        self,
+        target: 'AssignmentTargetDetails',
+        options: 'PolicyAssignmentV1Options',
+        resources: List['PolicyAssignmentV1Resources'],
+        template: 'AssignmentTemplateDetails',
+        status: str,
+        *,
+        id: Optional[str] = None,
+        account_id: Optional[str] = None,
+        href: Optional[str] = None,
+        created_at: Optional[datetime] = None,
+        created_by_id: Optional[str] = None,
+        last_modified_at: Optional[datetime] = None,
+        last_modified_by_id: Optional[str] = None,
+        subject: Optional['PolicyAssignmentV1Subject'] = None,
+    ) -> None:
+        """
+        Initialize a PolicyAssignmentV1 object.
+
+        :param AssignmentTargetDetails target: assignment target account and type.
+        :param PolicyAssignmentV1Options options: The set of properties required
+               for a policy assignment.
+        :param List[PolicyAssignmentV1Resources] resources: Object for each account
+               assigned.
+        :param AssignmentTemplateDetails template: policy template details.
+        :param str status: The policy assignment status.
+        :param PolicyAssignmentV1Subject subject: (optional) subject details of
+               access type assignment.
+        """
+        self.target = target
+        self.options = options
+        self.id = id
+        self.account_id = account_id
+        self.href = href
+        self.created_at = created_at
+        self.created_by_id = created_by_id
+        self.last_modified_at = last_modified_at
+        self.last_modified_by_id = last_modified_by_id
+        self.resources = resources
+        self.subject = subject
+        self.template = template
+        self.status = status
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolicyAssignmentV1':
+        """Initialize a PolicyAssignmentV1 object from a json dictionary."""
+        args = {}
+        if (target := _dict.get('target')) is not None:
+            args['target'] = AssignmentTargetDetails.from_dict(target)
+        else:
+            raise ValueError('Required property \'target\' not present in PolicyAssignmentV1 JSON')
+        if (options := _dict.get('options')) is not None:
+            args['options'] = PolicyAssignmentV1Options.from_dict(options)
+        else:
+            raise ValueError('Required property \'options\' not present in PolicyAssignmentV1 JSON')
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
+        if (account_id := _dict.get('account_id')) is not None:
+            args['account_id'] = account_id
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
+        if (created_at := _dict.get('created_at')) is not None:
+            args['created_at'] = string_to_datetime(created_at)
+        if (created_by_id := _dict.get('created_by_id')) is not None:
+            args['created_by_id'] = created_by_id
+        if (last_modified_at := _dict.get('last_modified_at')) is not None:
+            args['last_modified_at'] = string_to_datetime(last_modified_at)
+        if (last_modified_by_id := _dict.get('last_modified_by_id')) is not None:
+            args['last_modified_by_id'] = last_modified_by_id
+        if (resources := _dict.get('resources')) is not None:
+            args['resources'] = [PolicyAssignmentV1Resources.from_dict(v) for v in resources]
+        else:
+            raise ValueError('Required property \'resources\' not present in PolicyAssignmentV1 JSON')
+        if (subject := _dict.get('subject')) is not None:
+            args['subject'] = PolicyAssignmentV1Subject.from_dict(subject)
+        if (template := _dict.get('template')) is not None:
+            args['template'] = AssignmentTemplateDetails.from_dict(template)
+        else:
+            raise ValueError('Required property \'template\' not present in PolicyAssignmentV1 JSON')
+        if (status := _dict.get('status')) is not None:
+            args['status'] = status
+        else:
+            raise ValueError('Required property \'status\' not present in PolicyAssignmentV1 JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolicyAssignmentV1 object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'target') and self.target is not None:
+            if isinstance(self.target, dict):
+                _dict['target'] = self.target
+            else:
+                _dict['target'] = self.target.to_dict()
+        if hasattr(self, 'options') and self.options is not None:
+            if isinstance(self.options, dict):
+                _dict['options'] = self.options
+            else:
+                _dict['options'] = self.options.to_dict()
+        if hasattr(self, 'id') and getattr(self, 'id') is not None:
+            _dict['id'] = getattr(self, 'id')
+        if hasattr(self, 'account_id') and getattr(self, 'account_id') is not None:
+            _dict['account_id'] = getattr(self, 'account_id')
+        if hasattr(self, 'href') and getattr(self, 'href') is not None:
+            _dict['href'] = getattr(self, 'href')
+        if hasattr(self, 'created_at') and getattr(self, 'created_at') is not None:
+            _dict['created_at'] = datetime_to_string(getattr(self, 'created_at'))
+        if hasattr(self, 'created_by_id') and getattr(self, 'created_by_id') is not None:
+            _dict['created_by_id'] = getattr(self, 'created_by_id')
+        if hasattr(self, 'last_modified_at') and getattr(self, 'last_modified_at') is not None:
+            _dict['last_modified_at'] = datetime_to_string(getattr(self, 'last_modified_at'))
+        if hasattr(self, 'last_modified_by_id') and getattr(self, 'last_modified_by_id') is not None:
+            _dict['last_modified_by_id'] = getattr(self, 'last_modified_by_id')
+        if hasattr(self, 'resources') and self.resources is not None:
+            resources_list = []
+            for v in self.resources:
+                if isinstance(v, dict):
+                    resources_list.append(v)
+                else:
+                    resources_list.append(v.to_dict())
+            _dict['resources'] = resources_list
+        if hasattr(self, 'subject') and self.subject is not None:
+            if isinstance(self.subject, dict):
+                _dict['subject'] = self.subject
+            else:
+                _dict['subject'] = self.subject.to_dict()
+        if hasattr(self, 'template') and self.template is not None:
+            if isinstance(self.template, dict):
+                _dict['template'] = self.template
+            else:
+                _dict['template'] = self.template.to_dict()
+        if hasattr(self, 'status') and self.status is not None:
+            _dict['status'] = self.status
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyAssignmentV1 object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyAssignmentV1') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyAssignmentV1') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class StatusEnum(str, Enum):
+        """
+        The policy assignment status.
+        """
+
+        IN_PROGRESS = 'in_progress'
+        SUCCEEDED = 'succeeded'
+        SUCCEED_WITH_ERRORS = 'succeed_with_errors'
+        FAILED = 'failed'
+
+
+class PolicyAssignmentV1Collection:
+    """
+    Policy assignment response.
+
+    :param List[PolicyAssignmentV1] assignments: (optional) Response of policy
+          assignments.
+    """
+
+    def __init__(
+        self,
+        *,
+        assignments: Optional[List['PolicyAssignmentV1']] = None,
+    ) -> None:
+        """
+        Initialize a PolicyAssignmentV1Collection object.
+
+        :param List[PolicyAssignmentV1] assignments: (optional) Response of policy
+               assignments.
+        """
+        self.assignments = assignments
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolicyAssignmentV1Collection':
+        """Initialize a PolicyAssignmentV1Collection object from a json dictionary."""
+        args = {}
+        if (assignments := _dict.get('assignments')) is not None:
+            args['assignments'] = [PolicyAssignmentV1.from_dict(v) for v in assignments]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolicyAssignmentV1Collection object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'assignments') and self.assignments is not None:
+            assignments_list = []
+            for v in self.assignments:
+                if isinstance(v, dict):
+                    assignments_list.append(v)
+                else:
+                    assignments_list.append(v.to_dict())
+            _dict['assignments'] = assignments_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyAssignmentV1Collection object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyAssignmentV1Collection') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyAssignmentV1Collection') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class PolicyAssignmentV1Options:
+    """
+    The set of properties required for a policy assignment.
+
+    :param PolicyAssignmentV1OptionsRoot root:
+    """
+
+    def __init__(
+        self,
+        root: 'PolicyAssignmentV1OptionsRoot',
+    ) -> None:
+        """
+        Initialize a PolicyAssignmentV1Options object.
+
+        :param PolicyAssignmentV1OptionsRoot root:
+        """
+        self.root = root
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolicyAssignmentV1Options':
+        """Initialize a PolicyAssignmentV1Options object from a json dictionary."""
+        args = {}
+        if (root := _dict.get('root')) is not None:
+            args['root'] = PolicyAssignmentV1OptionsRoot.from_dict(root)
+        else:
+            raise ValueError('Required property \'root\' not present in PolicyAssignmentV1Options JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolicyAssignmentV1Options object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'root') and self.root is not None:
+            if isinstance(self.root, dict):
+                _dict['root'] = self.root
+            else:
+                _dict['root'] = self.root.to_dict()
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyAssignmentV1Options object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyAssignmentV1Options') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyAssignmentV1Options') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class PolicyAssignmentV1OptionsRoot:
+    """
+    PolicyAssignmentV1OptionsRoot.
+
+    :param str requester_id: (optional)
+    :param str assignment_id: (optional) Passed in value to correlate with other
+          assignments.
+    :param PolicyAssignmentV1OptionsRootTemplate template: (optional)
+    """
+
+    def __init__(
+        self,
+        *,
+        requester_id: Optional[str] = None,
+        assignment_id: Optional[str] = None,
+        template: Optional['PolicyAssignmentV1OptionsRootTemplate'] = None,
+    ) -> None:
+        """
+        Initialize a PolicyAssignmentV1OptionsRoot object.
+
+        :param str requester_id: (optional)
+        :param str assignment_id: (optional) Passed in value to correlate with
+               other assignments.
+        :param PolicyAssignmentV1OptionsRootTemplate template: (optional)
+        """
+        self.requester_id = requester_id
+        self.assignment_id = assignment_id
+        self.template = template
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolicyAssignmentV1OptionsRoot':
+        """Initialize a PolicyAssignmentV1OptionsRoot object from a json dictionary."""
+        args = {}
+        if (requester_id := _dict.get('requester_id')) is not None:
+            args['requester_id'] = requester_id
+        if (assignment_id := _dict.get('assignment_id')) is not None:
+            args['assignment_id'] = assignment_id
+        if (template := _dict.get('template')) is not None:
+            args['template'] = PolicyAssignmentV1OptionsRootTemplate.from_dict(template)
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolicyAssignmentV1OptionsRoot object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'requester_id') and self.requester_id is not None:
+            _dict['requester_id'] = self.requester_id
+        if hasattr(self, 'assignment_id') and self.assignment_id is not None:
+            _dict['assignment_id'] = self.assignment_id
+        if hasattr(self, 'template') and self.template is not None:
+            if isinstance(self.template, dict):
+                _dict['template'] = self.template
+            else:
+                _dict['template'] = self.template.to_dict()
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyAssignmentV1OptionsRoot object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyAssignmentV1OptionsRoot') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyAssignmentV1OptionsRoot') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class PolicyAssignmentV1OptionsRootTemplate:
+    """
+    PolicyAssignmentV1OptionsRootTemplate.
+
+    :param str id: (optional) The template id where this policy is being assigned
+          from.
+    :param str version: (optional) The template version where this policy is being
+          assigned from.
+    """
+
+    def __init__(
+        self,
+        *,
+        id: Optional[str] = None,
+        version: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize a PolicyAssignmentV1OptionsRootTemplate object.
+
+        :param str id: (optional) The template id where this policy is being
+               assigned from.
+        :param str version: (optional) The template version where this policy is
+               being assigned from.
+        """
+        self.id = id
+        self.version = version
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolicyAssignmentV1OptionsRootTemplate':
+        """Initialize a PolicyAssignmentV1OptionsRootTemplate object from a json dictionary."""
+        args = {}
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
+        if (version := _dict.get('version')) is not None:
+            args['version'] = version
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolicyAssignmentV1OptionsRootTemplate object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'version') and self.version is not None:
+            _dict['version'] = self.version
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyAssignmentV1OptionsRootTemplate object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyAssignmentV1OptionsRootTemplate') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyAssignmentV1OptionsRootTemplate') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class PolicyAssignmentV1Resources:
+    """
+    The policy assignment resources.
+
+    :param AssignmentTemplateDetails target: (optional) policy template details.
+    :param PolicyAssignmentResourcePolicy policy: (optional) Set of properties for
+          the assigned resource.
+    """
+
+    def __init__(
+        self,
+        *,
+        target: Optional['AssignmentTemplateDetails'] = None,
+        policy: Optional['PolicyAssignmentResourcePolicy'] = None,
+    ) -> None:
+        """
+        Initialize a PolicyAssignmentV1Resources object.
+
+        :param AssignmentTemplateDetails target: (optional) policy template
+               details.
+        :param PolicyAssignmentResourcePolicy policy: (optional) Set of properties
+               for the assigned resource.
+        """
+        self.target = target
+        self.policy = policy
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolicyAssignmentV1Resources':
+        """Initialize a PolicyAssignmentV1Resources object from a json dictionary."""
+        args = {}
+        if (target := _dict.get('target')) is not None:
+            args['target'] = AssignmentTemplateDetails.from_dict(target)
+        if (policy := _dict.get('policy')) is not None:
+            args['policy'] = PolicyAssignmentResourcePolicy.from_dict(policy)
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolicyAssignmentV1Resources object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'target') and self.target is not None:
+            if isinstance(self.target, dict):
+                _dict['target'] = self.target
+            else:
+                _dict['target'] = self.target.to_dict()
+        if hasattr(self, 'policy') and self.policy is not None:
+            if isinstance(self.policy, dict):
+                _dict['policy'] = self.policy
+            else:
+                _dict['policy'] = self.policy.to_dict()
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyAssignmentV1Resources object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyAssignmentV1Resources') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyAssignmentV1Resources') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class PolicyAssignmentV1Subject:
+    """
+    subject details of access type assignment.
+
+    :param str id: (optional)
+    :param str type: (optional)
+    """
+
+    def __init__(
+        self,
+        *,
+        id: Optional[str] = None,
+        type: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize a PolicyAssignmentV1Subject object.
+
+        """
+        self.id = id
+        self.type = type
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolicyAssignmentV1Subject':
+        """Initialize a PolicyAssignmentV1Subject object from a json dictionary."""
+        args = {}
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
+        if (type := _dict.get('type')) is not None:
+            args['type'] = type
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolicyAssignmentV1Subject object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'id') and getattr(self, 'id') is not None:
+            _dict['id'] = getattr(self, 'id')
+        if hasattr(self, 'type') and getattr(self, 'type') is not None:
+            _dict['type'] = getattr(self, 'type')
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyAssignmentV1Subject object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyAssignmentV1Subject') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyAssignmentV1Subject') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class TypeEnum(str, Enum):
+        """
+        type.
+        """
+
+        IAM_ID = 'iam_id'
+        ACCESS_GROUP_ID = 'access_group_id'
 
 
 class PolicyCollection:
@@ -4614,20 +5504,20 @@ class PolicyTemplateAssignmentCollection:
     """
     A collection of policies assignments.
 
-    :param List[PolicyAssignment] assignments: (optional) List of policy
-          assignments.
+    :param List[PolicyTemplateAssignmentItems] assignments: (optional) List of
+          policy assignments.
     """
 
     def __init__(
         self,
         *,
-        assignments: Optional[List['PolicyAssignment']] = None,
+        assignments: Optional[List['PolicyTemplateAssignmentItems']] = None,
     ) -> None:
         """
         Initialize a PolicyTemplateAssignmentCollection object.
 
-        :param List[PolicyAssignment] assignments: (optional) List of policy
-               assignments.
+        :param List[PolicyTemplateAssignmentItems] assignments: (optional) List of
+               policy assignments.
         """
         self.assignments = assignments
 
@@ -4636,7 +5526,7 @@ class PolicyTemplateAssignmentCollection:
         """Initialize a PolicyTemplateAssignmentCollection object from a json dictionary."""
         args = {}
         if (assignments := _dict.get('assignments')) is not None:
-            args['assignments'] = [PolicyAssignment.from_dict(v) for v in assignments]
+            args['assignments'] = assignments
         return cls(**args)
 
     @classmethod
@@ -4674,6 +5564,27 @@ class PolicyTemplateAssignmentCollection:
     def __ne__(self, other: 'PolicyTemplateAssignmentCollection') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
+
+
+class PolicyTemplateAssignmentItems:
+    """
+    PolicyTemplateAssignmentItems.
+
+    """
+
+    def __init__(
+        self,
+    ) -> None:
+        """
+        Initialize a PolicyTemplateAssignmentItems object.
+
+        """
+        msg = "Cannot instantiate base class. Instead, instantiate one of the defined subclasses: {0}".format(
+            ", ".join(
+                ['PolicyTemplateAssignmentItemsPolicyAssignmentV1', 'PolicyTemplateAssignmentItemsPolicyAssignment']
+            )
+        )
+        raise Exception(msg)
 
 
 class PolicyTemplateCollection:
@@ -6038,8 +6949,10 @@ class TemplatePolicy:
     :param str description: (optional) Description of the policy. This is shown in
           child accounts when an access group or trusted profile template uses the policy
           template to assign access.
-    :param V2PolicyResource resource: (optional) The resource attributes to which
-          the policy grants access.
+    :param V2PolicyResource resource: The resource attributes to which the policy
+          grants access.
+    :param V2PolicySubject subject: (optional) The subject attributes for whom the
+          policy grants access.
     :param str pattern: (optional) Indicates pattern of rule, either
           'time-based-conditions:once', 'time-based-conditions:weekly:all-day', or
           'time-based-conditions:weekly:custom-hours'.
@@ -6051,10 +6964,11 @@ class TemplatePolicy:
     def __init__(
         self,
         type: str,
+        resource: 'V2PolicyResource',
         control: 'Control',
         *,
         description: Optional[str] = None,
-        resource: Optional['V2PolicyResource'] = None,
+        subject: Optional['V2PolicySubject'] = None,
         pattern: Optional[str] = None,
         rule: Optional['V2PolicyRule'] = None,
     ) -> None:
@@ -6062,12 +6976,14 @@ class TemplatePolicy:
         Initialize a TemplatePolicy object.
 
         :param str type: The policy type; either 'access' or 'authorization'.
+        :param V2PolicyResource resource: The resource attributes to which the
+               policy grants access.
         :param Control control: Specifies the type of access granted by the policy.
         :param str description: (optional) Description of the policy. This is shown
                in child accounts when an access group or trusted profile template uses the
                policy template to assign access.
-        :param V2PolicyResource resource: (optional) The resource attributes to
-               which the policy grants access.
+        :param V2PolicySubject subject: (optional) The subject attributes for whom
+               the policy grants access.
         :param str pattern: (optional) Indicates pattern of rule, either
                'time-based-conditions:once', 'time-based-conditions:weekly:all-day', or
                'time-based-conditions:weekly:custom-hours'.
@@ -6077,6 +6993,7 @@ class TemplatePolicy:
         self.type = type
         self.description = description
         self.resource = resource
+        self.subject = subject
         self.pattern = pattern
         self.rule = rule
         self.control = control
@@ -6093,6 +7010,10 @@ class TemplatePolicy:
             args['description'] = description
         if (resource := _dict.get('resource')) is not None:
             args['resource'] = V2PolicyResource.from_dict(resource)
+        else:
+            raise ValueError('Required property \'resource\' not present in TemplatePolicy JSON')
+        if (subject := _dict.get('subject')) is not None:
+            args['subject'] = V2PolicySubject.from_dict(subject)
         if (pattern := _dict.get('pattern')) is not None:
             args['pattern'] = pattern
         if (rule := _dict.get('rule')) is not None:
@@ -6120,6 +7041,11 @@ class TemplatePolicy:
                 _dict['resource'] = self.resource
             else:
                 _dict['resource'] = self.resource.to_dict()
+        if hasattr(self, 'subject') and self.subject is not None:
+            if isinstance(self.subject, dict):
+                _dict['subject'] = self.subject
+            else:
+                _dict['subject'] = self.subject.to_dict()
         if hasattr(self, 'pattern') and self.pattern is not None:
             _dict['pattern'] = self.pattern
         if hasattr(self, 'rule') and self.rule is not None:
@@ -7270,6 +8196,419 @@ class ControlResponseControlWithEnrichedRoles(ControlResponse):
         return not self == other
 
 
+class GetPolicyAssignmentResponsePolicyAssignment(GetPolicyAssignmentResponse):
+    """
+    The set of properties associated with the policy template assignment.
+
+    :param str template_id: (optional) policy template id.
+    :param str template_version: (optional) policy template version.
+    :param str assignment_id: (optional) Passed in value to correlate with other
+          assignments.
+    :param str target_type: (optional) Assignment target type.
+    :param str target: (optional) ID of the target account.
+    :param List[PolicyAssignmentOptions] options: (optional) List of objects with
+          required properties for a policy assignment.
+    :param str id: (optional) Policy assignment ID.
+    :param str account_id: (optional) The account GUID that the policies assignments
+          belong to..
+    :param str href: (optional) The href URL that links to the policies assignments
+          API by policy assignment ID.
+    :param datetime created_at: (optional) The UTC timestamp when the policy
+          assignment was created.
+    :param str created_by_id: (optional) The iam ID of the entity that created the
+          policy assignment.
+    :param datetime last_modified_at: (optional) The UTC timestamp when the policy
+          assignment was last modified.
+    :param str last_modified_by_id: (optional) The iam ID of the entity that last
+          modified the policy assignment.
+    :param List[PolicyAssignmentResources] resources: (optional) Object for each
+          account assigned.
+    :param str status: (optional) The policy assignment status.
+    """
+
+    def __init__(
+        self,
+        *,
+        template_id: Optional[str] = None,
+        template_version: Optional[str] = None,
+        assignment_id: Optional[str] = None,
+        target_type: Optional[str] = None,
+        target: Optional[str] = None,
+        options: Optional[List['PolicyAssignmentOptions']] = None,
+        id: Optional[str] = None,
+        account_id: Optional[str] = None,
+        href: Optional[str] = None,
+        created_at: Optional[datetime] = None,
+        created_by_id: Optional[str] = None,
+        last_modified_at: Optional[datetime] = None,
+        last_modified_by_id: Optional[str] = None,
+        resources: Optional[List['PolicyAssignmentResources']] = None,
+        status: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize a GetPolicyAssignmentResponsePolicyAssignment object.
+
+        :param str template_id: (optional) policy template id.
+        :param str template_version: (optional) policy template version.
+        :param str assignment_id: (optional) Passed in value to correlate with
+               other assignments.
+        :param str target_type: (optional) Assignment target type.
+        :param str target: (optional) ID of the target account.
+        :param List[PolicyAssignmentOptions] options: (optional) List of objects
+               with required properties for a policy assignment.
+        :param List[PolicyAssignmentResources] resources: (optional) Object for
+               each account assigned.
+        :param str status: (optional) The policy assignment status.
+        """
+        # pylint: disable=super-init-not-called
+        self.template_id = template_id
+        self.template_version = template_version
+        self.assignment_id = assignment_id
+        self.target_type = target_type
+        self.target = target
+        self.options = options
+        self.id = id
+        self.account_id = account_id
+        self.href = href
+        self.created_at = created_at
+        self.created_by_id = created_by_id
+        self.last_modified_at = last_modified_at
+        self.last_modified_by_id = last_modified_by_id
+        self.resources = resources
+        self.status = status
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'GetPolicyAssignmentResponsePolicyAssignment':
+        """Initialize a GetPolicyAssignmentResponsePolicyAssignment object from a json dictionary."""
+        args = {}
+        if (template_id := _dict.get('template_id')) is not None:
+            args['template_id'] = template_id
+        if (template_version := _dict.get('template_version')) is not None:
+            args['template_version'] = template_version
+        if (assignment_id := _dict.get('assignment_id')) is not None:
+            args['assignment_id'] = assignment_id
+        if (target_type := _dict.get('target_type')) is not None:
+            args['target_type'] = target_type
+        if (target := _dict.get('target')) is not None:
+            args['target'] = target
+        if (options := _dict.get('options')) is not None:
+            args['options'] = [PolicyAssignmentOptions.from_dict(v) for v in options]
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
+        if (account_id := _dict.get('account_id')) is not None:
+            args['account_id'] = account_id
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
+        if (created_at := _dict.get('created_at')) is not None:
+            args['created_at'] = string_to_datetime(created_at)
+        if (created_by_id := _dict.get('created_by_id')) is not None:
+            args['created_by_id'] = created_by_id
+        if (last_modified_at := _dict.get('last_modified_at')) is not None:
+            args['last_modified_at'] = string_to_datetime(last_modified_at)
+        if (last_modified_by_id := _dict.get('last_modified_by_id')) is not None:
+            args['last_modified_by_id'] = last_modified_by_id
+        if (resources := _dict.get('resources')) is not None:
+            args['resources'] = [PolicyAssignmentResources.from_dict(v) for v in resources]
+        if (status := _dict.get('status')) is not None:
+            args['status'] = status
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a GetPolicyAssignmentResponsePolicyAssignment object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'template_id') and self.template_id is not None:
+            _dict['template_id'] = self.template_id
+        if hasattr(self, 'template_version') and self.template_version is not None:
+            _dict['template_version'] = self.template_version
+        if hasattr(self, 'assignment_id') and self.assignment_id is not None:
+            _dict['assignment_id'] = self.assignment_id
+        if hasattr(self, 'target_type') and self.target_type is not None:
+            _dict['target_type'] = self.target_type
+        if hasattr(self, 'target') and self.target is not None:
+            _dict['target'] = self.target
+        if hasattr(self, 'options') and self.options is not None:
+            options_list = []
+            for v in self.options:
+                if isinstance(v, dict):
+                    options_list.append(v)
+                else:
+                    options_list.append(v.to_dict())
+            _dict['options'] = options_list
+        if hasattr(self, 'id') and getattr(self, 'id') is not None:
+            _dict['id'] = getattr(self, 'id')
+        if hasattr(self, 'account_id') and getattr(self, 'account_id') is not None:
+            _dict['account_id'] = getattr(self, 'account_id')
+        if hasattr(self, 'href') and getattr(self, 'href') is not None:
+            _dict['href'] = getattr(self, 'href')
+        if hasattr(self, 'created_at') and getattr(self, 'created_at') is not None:
+            _dict['created_at'] = datetime_to_string(getattr(self, 'created_at'))
+        if hasattr(self, 'created_by_id') and getattr(self, 'created_by_id') is not None:
+            _dict['created_by_id'] = getattr(self, 'created_by_id')
+        if hasattr(self, 'last_modified_at') and getattr(self, 'last_modified_at') is not None:
+            _dict['last_modified_at'] = datetime_to_string(getattr(self, 'last_modified_at'))
+        if hasattr(self, 'last_modified_by_id') and getattr(self, 'last_modified_by_id') is not None:
+            _dict['last_modified_by_id'] = getattr(self, 'last_modified_by_id')
+        if hasattr(self, 'resources') and self.resources is not None:
+            resources_list = []
+            for v in self.resources:
+                if isinstance(v, dict):
+                    resources_list.append(v)
+                else:
+                    resources_list.append(v.to_dict())
+            _dict['resources'] = resources_list
+        if hasattr(self, 'status') and self.status is not None:
+            _dict['status'] = self.status
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this GetPolicyAssignmentResponsePolicyAssignment object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'GetPolicyAssignmentResponsePolicyAssignment') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'GetPolicyAssignmentResponsePolicyAssignment') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class TargetTypeEnum(str, Enum):
+        """
+        Assignment target type.
+        """
+
+        ACCOUNT = 'Account'
+
+    class StatusEnum(str, Enum):
+        """
+        The policy assignment status.
+        """
+
+        IN_PROGRESS = 'in_progress'
+        SUCCEEDED = 'succeeded'
+        SUCCEED_WITH_ERRORS = 'succeed_with_errors'
+        FAILED = 'failed'
+
+
+class GetPolicyAssignmentResponsePolicyAssignmentV1(GetPolicyAssignmentResponse):
+    """
+    The set of properties associated with the policy template assignment.
+
+    :param AssignmentTargetDetails target: assignment target account and type.
+    :param PolicyAssignmentV1Options options: The set of properties required for a
+          policy assignment.
+    :param str id: (optional) Policy assignment ID.
+    :param str account_id: (optional) The account GUID that the policies assignments
+          belong to..
+    :param str href: (optional) The href URL that links to the policies assignments
+          API by policy assignment ID.
+    :param datetime created_at: (optional) The UTC timestamp when the policy
+          assignment was created.
+    :param str created_by_id: (optional) The iam ID of the entity that created the
+          policy assignment.
+    :param datetime last_modified_at: (optional) The UTC timestamp when the policy
+          assignment was last modified.
+    :param str last_modified_by_id: (optional) The iam ID of the entity that last
+          modified the policy assignment.
+    :param List[PolicyAssignmentV1Resources] resources: Object for each account
+          assigned.
+    :param GetPolicyAssignmentResponsePolicyAssignmentV1Subject subject: (optional)
+          subject details of access type assignment.
+    :param AssignmentTemplateDetails template: policy template details.
+    :param str status: The policy assignment status.
+    """
+
+    def __init__(
+        self,
+        target: 'AssignmentTargetDetails',
+        options: 'PolicyAssignmentV1Options',
+        resources: List['PolicyAssignmentV1Resources'],
+        template: 'AssignmentTemplateDetails',
+        status: str,
+        *,
+        id: Optional[str] = None,
+        account_id: Optional[str] = None,
+        href: Optional[str] = None,
+        created_at: Optional[datetime] = None,
+        created_by_id: Optional[str] = None,
+        last_modified_at: Optional[datetime] = None,
+        last_modified_by_id: Optional[str] = None,
+        subject: Optional['GetPolicyAssignmentResponsePolicyAssignmentV1Subject'] = None,
+    ) -> None:
+        """
+        Initialize a GetPolicyAssignmentResponsePolicyAssignmentV1 object.
+
+        :param AssignmentTargetDetails target: assignment target account and type.
+        :param PolicyAssignmentV1Options options: The set of properties required
+               for a policy assignment.
+        :param List[PolicyAssignmentV1Resources] resources: Object for each account
+               assigned.
+        :param AssignmentTemplateDetails template: policy template details.
+        :param str status: The policy assignment status.
+        :param GetPolicyAssignmentResponsePolicyAssignmentV1Subject subject:
+               (optional) subject details of access type assignment.
+        """
+        # pylint: disable=super-init-not-called
+        self.target = target
+        self.options = options
+        self.id = id
+        self.account_id = account_id
+        self.href = href
+        self.created_at = created_at
+        self.created_by_id = created_by_id
+        self.last_modified_at = last_modified_at
+        self.last_modified_by_id = last_modified_by_id
+        self.resources = resources
+        self.subject = subject
+        self.template = template
+        self.status = status
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'GetPolicyAssignmentResponsePolicyAssignmentV1':
+        """Initialize a GetPolicyAssignmentResponsePolicyAssignmentV1 object from a json dictionary."""
+        args = {}
+        if (target := _dict.get('target')) is not None:
+            args['target'] = AssignmentTargetDetails.from_dict(target)
+        else:
+            raise ValueError(
+                'Required property \'target\' not present in GetPolicyAssignmentResponsePolicyAssignmentV1 JSON'
+            )
+        if (options := _dict.get('options')) is not None:
+            args['options'] = PolicyAssignmentV1Options.from_dict(options)
+        else:
+            raise ValueError(
+                'Required property \'options\' not present in GetPolicyAssignmentResponsePolicyAssignmentV1 JSON'
+            )
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
+        if (account_id := _dict.get('account_id')) is not None:
+            args['account_id'] = account_id
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
+        if (created_at := _dict.get('created_at')) is not None:
+            args['created_at'] = string_to_datetime(created_at)
+        if (created_by_id := _dict.get('created_by_id')) is not None:
+            args['created_by_id'] = created_by_id
+        if (last_modified_at := _dict.get('last_modified_at')) is not None:
+            args['last_modified_at'] = string_to_datetime(last_modified_at)
+        if (last_modified_by_id := _dict.get('last_modified_by_id')) is not None:
+            args['last_modified_by_id'] = last_modified_by_id
+        if (resources := _dict.get('resources')) is not None:
+            args['resources'] = [PolicyAssignmentV1Resources.from_dict(v) for v in resources]
+        else:
+            raise ValueError(
+                'Required property \'resources\' not present in GetPolicyAssignmentResponsePolicyAssignmentV1 JSON'
+            )
+        if (subject := _dict.get('subject')) is not None:
+            args['subject'] = GetPolicyAssignmentResponsePolicyAssignmentV1Subject.from_dict(subject)
+        if (template := _dict.get('template')) is not None:
+            args['template'] = AssignmentTemplateDetails.from_dict(template)
+        else:
+            raise ValueError(
+                'Required property \'template\' not present in GetPolicyAssignmentResponsePolicyAssignmentV1 JSON'
+            )
+        if (status := _dict.get('status')) is not None:
+            args['status'] = status
+        else:
+            raise ValueError(
+                'Required property \'status\' not present in GetPolicyAssignmentResponsePolicyAssignmentV1 JSON'
+            )
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a GetPolicyAssignmentResponsePolicyAssignmentV1 object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'target') and self.target is not None:
+            if isinstance(self.target, dict):
+                _dict['target'] = self.target
+            else:
+                _dict['target'] = self.target.to_dict()
+        if hasattr(self, 'options') and self.options is not None:
+            if isinstance(self.options, dict):
+                _dict['options'] = self.options
+            else:
+                _dict['options'] = self.options.to_dict()
+        if hasattr(self, 'id') and getattr(self, 'id') is not None:
+            _dict['id'] = getattr(self, 'id')
+        if hasattr(self, 'account_id') and getattr(self, 'account_id') is not None:
+            _dict['account_id'] = getattr(self, 'account_id')
+        if hasattr(self, 'href') and getattr(self, 'href') is not None:
+            _dict['href'] = getattr(self, 'href')
+        if hasattr(self, 'created_at') and getattr(self, 'created_at') is not None:
+            _dict['created_at'] = datetime_to_string(getattr(self, 'created_at'))
+        if hasattr(self, 'created_by_id') and getattr(self, 'created_by_id') is not None:
+            _dict['created_by_id'] = getattr(self, 'created_by_id')
+        if hasattr(self, 'last_modified_at') and getattr(self, 'last_modified_at') is not None:
+            _dict['last_modified_at'] = datetime_to_string(getattr(self, 'last_modified_at'))
+        if hasattr(self, 'last_modified_by_id') and getattr(self, 'last_modified_by_id') is not None:
+            _dict['last_modified_by_id'] = getattr(self, 'last_modified_by_id')
+        if hasattr(self, 'resources') and self.resources is not None:
+            resources_list = []
+            for v in self.resources:
+                if isinstance(v, dict):
+                    resources_list.append(v)
+                else:
+                    resources_list.append(v.to_dict())
+            _dict['resources'] = resources_list
+        if hasattr(self, 'subject') and self.subject is not None:
+            if isinstance(self.subject, dict):
+                _dict['subject'] = self.subject
+            else:
+                _dict['subject'] = self.subject.to_dict()
+        if hasattr(self, 'template') and self.template is not None:
+            if isinstance(self.template, dict):
+                _dict['template'] = self.template
+            else:
+                _dict['template'] = self.template.to_dict()
+        if hasattr(self, 'status') and self.status is not None:
+            _dict['status'] = self.status
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this GetPolicyAssignmentResponsePolicyAssignmentV1 object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'GetPolicyAssignmentResponsePolicyAssignmentV1') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'GetPolicyAssignmentResponsePolicyAssignmentV1') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class StatusEnum(str, Enum):
+        """
+        The policy assignment status.
+        """
+
+        IN_PROGRESS = 'in_progress'
+        SUCCEEDED = 'succeeded'
+        SUCCEED_WITH_ERRORS = 'succeed_with_errors'
+        FAILED = 'failed'
+
+
 class NestedConditionRuleAttribute(NestedCondition):
     """
     Rule that specifies additional access granted (e.g., time-based condition).
@@ -7467,6 +8806,419 @@ class NestedConditionRuleWithConditions(NestedCondition):
 
         AND = 'and'
         OR = 'or'
+
+
+class PolicyTemplateAssignmentItemsPolicyAssignment(PolicyTemplateAssignmentItems):
+    """
+    The set of properties associated with the policy template assignment.
+
+    :param str template_id: (optional) policy template id.
+    :param str template_version: (optional) policy template version.
+    :param str assignment_id: (optional) Passed in value to correlate with other
+          assignments.
+    :param str target_type: (optional) Assignment target type.
+    :param str target: (optional) ID of the target account.
+    :param List[PolicyAssignmentOptions] options: (optional) List of objects with
+          required properties for a policy assignment.
+    :param str id: (optional) Policy assignment ID.
+    :param str account_id: (optional) The account GUID that the policies assignments
+          belong to..
+    :param str href: (optional) The href URL that links to the policies assignments
+          API by policy assignment ID.
+    :param datetime created_at: (optional) The UTC timestamp when the policy
+          assignment was created.
+    :param str created_by_id: (optional) The iam ID of the entity that created the
+          policy assignment.
+    :param datetime last_modified_at: (optional) The UTC timestamp when the policy
+          assignment was last modified.
+    :param str last_modified_by_id: (optional) The iam ID of the entity that last
+          modified the policy assignment.
+    :param List[PolicyAssignmentResources] resources: (optional) Object for each
+          account assigned.
+    :param str status: (optional) The policy assignment status.
+    """
+
+    def __init__(
+        self,
+        *,
+        template_id: Optional[str] = None,
+        template_version: Optional[str] = None,
+        assignment_id: Optional[str] = None,
+        target_type: Optional[str] = None,
+        target: Optional[str] = None,
+        options: Optional[List['PolicyAssignmentOptions']] = None,
+        id: Optional[str] = None,
+        account_id: Optional[str] = None,
+        href: Optional[str] = None,
+        created_at: Optional[datetime] = None,
+        created_by_id: Optional[str] = None,
+        last_modified_at: Optional[datetime] = None,
+        last_modified_by_id: Optional[str] = None,
+        resources: Optional[List['PolicyAssignmentResources']] = None,
+        status: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize a PolicyTemplateAssignmentItemsPolicyAssignment object.
+
+        :param str template_id: (optional) policy template id.
+        :param str template_version: (optional) policy template version.
+        :param str assignment_id: (optional) Passed in value to correlate with
+               other assignments.
+        :param str target_type: (optional) Assignment target type.
+        :param str target: (optional) ID of the target account.
+        :param List[PolicyAssignmentOptions] options: (optional) List of objects
+               with required properties for a policy assignment.
+        :param List[PolicyAssignmentResources] resources: (optional) Object for
+               each account assigned.
+        :param str status: (optional) The policy assignment status.
+        """
+        # pylint: disable=super-init-not-called
+        self.template_id = template_id
+        self.template_version = template_version
+        self.assignment_id = assignment_id
+        self.target_type = target_type
+        self.target = target
+        self.options = options
+        self.id = id
+        self.account_id = account_id
+        self.href = href
+        self.created_at = created_at
+        self.created_by_id = created_by_id
+        self.last_modified_at = last_modified_at
+        self.last_modified_by_id = last_modified_by_id
+        self.resources = resources
+        self.status = status
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolicyTemplateAssignmentItemsPolicyAssignment':
+        """Initialize a PolicyTemplateAssignmentItemsPolicyAssignment object from a json dictionary."""
+        args = {}
+        if (template_id := _dict.get('template_id')) is not None:
+            args['template_id'] = template_id
+        if (template_version := _dict.get('template_version')) is not None:
+            args['template_version'] = template_version
+        if (assignment_id := _dict.get('assignment_id')) is not None:
+            args['assignment_id'] = assignment_id
+        if (target_type := _dict.get('target_type')) is not None:
+            args['target_type'] = target_type
+        if (target := _dict.get('target')) is not None:
+            args['target'] = target
+        if (options := _dict.get('options')) is not None:
+            args['options'] = [PolicyAssignmentOptions.from_dict(v) for v in options]
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
+        if (account_id := _dict.get('account_id')) is not None:
+            args['account_id'] = account_id
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
+        if (created_at := _dict.get('created_at')) is not None:
+            args['created_at'] = string_to_datetime(created_at)
+        if (created_by_id := _dict.get('created_by_id')) is not None:
+            args['created_by_id'] = created_by_id
+        if (last_modified_at := _dict.get('last_modified_at')) is not None:
+            args['last_modified_at'] = string_to_datetime(last_modified_at)
+        if (last_modified_by_id := _dict.get('last_modified_by_id')) is not None:
+            args['last_modified_by_id'] = last_modified_by_id
+        if (resources := _dict.get('resources')) is not None:
+            args['resources'] = [PolicyAssignmentResources.from_dict(v) for v in resources]
+        if (status := _dict.get('status')) is not None:
+            args['status'] = status
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolicyTemplateAssignmentItemsPolicyAssignment object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'template_id') and self.template_id is not None:
+            _dict['template_id'] = self.template_id
+        if hasattr(self, 'template_version') and self.template_version is not None:
+            _dict['template_version'] = self.template_version
+        if hasattr(self, 'assignment_id') and self.assignment_id is not None:
+            _dict['assignment_id'] = self.assignment_id
+        if hasattr(self, 'target_type') and self.target_type is not None:
+            _dict['target_type'] = self.target_type
+        if hasattr(self, 'target') and self.target is not None:
+            _dict['target'] = self.target
+        if hasattr(self, 'options') and self.options is not None:
+            options_list = []
+            for v in self.options:
+                if isinstance(v, dict):
+                    options_list.append(v)
+                else:
+                    options_list.append(v.to_dict())
+            _dict['options'] = options_list
+        if hasattr(self, 'id') and getattr(self, 'id') is not None:
+            _dict['id'] = getattr(self, 'id')
+        if hasattr(self, 'account_id') and getattr(self, 'account_id') is not None:
+            _dict['account_id'] = getattr(self, 'account_id')
+        if hasattr(self, 'href') and getattr(self, 'href') is not None:
+            _dict['href'] = getattr(self, 'href')
+        if hasattr(self, 'created_at') and getattr(self, 'created_at') is not None:
+            _dict['created_at'] = datetime_to_string(getattr(self, 'created_at'))
+        if hasattr(self, 'created_by_id') and getattr(self, 'created_by_id') is not None:
+            _dict['created_by_id'] = getattr(self, 'created_by_id')
+        if hasattr(self, 'last_modified_at') and getattr(self, 'last_modified_at') is not None:
+            _dict['last_modified_at'] = datetime_to_string(getattr(self, 'last_modified_at'))
+        if hasattr(self, 'last_modified_by_id') and getattr(self, 'last_modified_by_id') is not None:
+            _dict['last_modified_by_id'] = getattr(self, 'last_modified_by_id')
+        if hasattr(self, 'resources') and self.resources is not None:
+            resources_list = []
+            for v in self.resources:
+                if isinstance(v, dict):
+                    resources_list.append(v)
+                else:
+                    resources_list.append(v.to_dict())
+            _dict['resources'] = resources_list
+        if hasattr(self, 'status') and self.status is not None:
+            _dict['status'] = self.status
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyTemplateAssignmentItemsPolicyAssignment object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyTemplateAssignmentItemsPolicyAssignment') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyTemplateAssignmentItemsPolicyAssignment') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class TargetTypeEnum(str, Enum):
+        """
+        Assignment target type.
+        """
+
+        ACCOUNT = 'Account'
+
+    class StatusEnum(str, Enum):
+        """
+        The policy assignment status.
+        """
+
+        IN_PROGRESS = 'in_progress'
+        SUCCEEDED = 'succeeded'
+        SUCCEED_WITH_ERRORS = 'succeed_with_errors'
+        FAILED = 'failed'
+
+
+class PolicyTemplateAssignmentItemsPolicyAssignmentV1(PolicyTemplateAssignmentItems):
+    """
+    The set of properties associated with the policy template assignment.
+
+    :param AssignmentTargetDetails target: assignment target account and type.
+    :param PolicyAssignmentV1Options options: The set of properties required for a
+          policy assignment.
+    :param str id: (optional) Policy assignment ID.
+    :param str account_id: (optional) The account GUID that the policies assignments
+          belong to..
+    :param str href: (optional) The href URL that links to the policies assignments
+          API by policy assignment ID.
+    :param datetime created_at: (optional) The UTC timestamp when the policy
+          assignment was created.
+    :param str created_by_id: (optional) The iam ID of the entity that created the
+          policy assignment.
+    :param datetime last_modified_at: (optional) The UTC timestamp when the policy
+          assignment was last modified.
+    :param str last_modified_by_id: (optional) The iam ID of the entity that last
+          modified the policy assignment.
+    :param List[PolicyAssignmentV1Resources] resources: Object for each account
+          assigned.
+    :param PolicyAssignmentV1Subject subject: (optional) subject details of access
+          type assignment.
+    :param AssignmentTemplateDetails template: policy template details.
+    :param str status: The policy assignment status.
+    """
+
+    def __init__(
+        self,
+        target: 'AssignmentTargetDetails',
+        options: 'PolicyAssignmentV1Options',
+        resources: List['PolicyAssignmentV1Resources'],
+        template: 'AssignmentTemplateDetails',
+        status: str,
+        *,
+        id: Optional[str] = None,
+        account_id: Optional[str] = None,
+        href: Optional[str] = None,
+        created_at: Optional[datetime] = None,
+        created_by_id: Optional[str] = None,
+        last_modified_at: Optional[datetime] = None,
+        last_modified_by_id: Optional[str] = None,
+        subject: Optional['PolicyAssignmentV1Subject'] = None,
+    ) -> None:
+        """
+        Initialize a PolicyTemplateAssignmentItemsPolicyAssignmentV1 object.
+
+        :param AssignmentTargetDetails target: assignment target account and type.
+        :param PolicyAssignmentV1Options options: The set of properties required
+               for a policy assignment.
+        :param List[PolicyAssignmentV1Resources] resources: Object for each account
+               assigned.
+        :param AssignmentTemplateDetails template: policy template details.
+        :param str status: The policy assignment status.
+        :param PolicyAssignmentV1Subject subject: (optional) subject details of
+               access type assignment.
+        """
+        # pylint: disable=super-init-not-called
+        self.target = target
+        self.options = options
+        self.id = id
+        self.account_id = account_id
+        self.href = href
+        self.created_at = created_at
+        self.created_by_id = created_by_id
+        self.last_modified_at = last_modified_at
+        self.last_modified_by_id = last_modified_by_id
+        self.resources = resources
+        self.subject = subject
+        self.template = template
+        self.status = status
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PolicyTemplateAssignmentItemsPolicyAssignmentV1':
+        """Initialize a PolicyTemplateAssignmentItemsPolicyAssignmentV1 object from a json dictionary."""
+        args = {}
+        if (target := _dict.get('target')) is not None:
+            args['target'] = AssignmentTargetDetails.from_dict(target)
+        else:
+            raise ValueError(
+                'Required property \'target\' not present in PolicyTemplateAssignmentItemsPolicyAssignmentV1 JSON'
+            )
+        if (options := _dict.get('options')) is not None:
+            args['options'] = PolicyAssignmentV1Options.from_dict(options)
+        else:
+            raise ValueError(
+                'Required property \'options\' not present in PolicyTemplateAssignmentItemsPolicyAssignmentV1 JSON'
+            )
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
+        if (account_id := _dict.get('account_id')) is not None:
+            args['account_id'] = account_id
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
+        if (created_at := _dict.get('created_at')) is not None:
+            args['created_at'] = string_to_datetime(created_at)
+        if (created_by_id := _dict.get('created_by_id')) is not None:
+            args['created_by_id'] = created_by_id
+        if (last_modified_at := _dict.get('last_modified_at')) is not None:
+            args['last_modified_at'] = string_to_datetime(last_modified_at)
+        if (last_modified_by_id := _dict.get('last_modified_by_id')) is not None:
+            args['last_modified_by_id'] = last_modified_by_id
+        if (resources := _dict.get('resources')) is not None:
+            args['resources'] = [PolicyAssignmentV1Resources.from_dict(v) for v in resources]
+        else:
+            raise ValueError(
+                'Required property \'resources\' not present in PolicyTemplateAssignmentItemsPolicyAssignmentV1 JSON'
+            )
+        if (subject := _dict.get('subject')) is not None:
+            args['subject'] = PolicyAssignmentV1Subject.from_dict(subject)
+        if (template := _dict.get('template')) is not None:
+            args['template'] = AssignmentTemplateDetails.from_dict(template)
+        else:
+            raise ValueError(
+                'Required property \'template\' not present in PolicyTemplateAssignmentItemsPolicyAssignmentV1 JSON'
+            )
+        if (status := _dict.get('status')) is not None:
+            args['status'] = status
+        else:
+            raise ValueError(
+                'Required property \'status\' not present in PolicyTemplateAssignmentItemsPolicyAssignmentV1 JSON'
+            )
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PolicyTemplateAssignmentItemsPolicyAssignmentV1 object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'target') and self.target is not None:
+            if isinstance(self.target, dict):
+                _dict['target'] = self.target
+            else:
+                _dict['target'] = self.target.to_dict()
+        if hasattr(self, 'options') and self.options is not None:
+            if isinstance(self.options, dict):
+                _dict['options'] = self.options
+            else:
+                _dict['options'] = self.options.to_dict()
+        if hasattr(self, 'id') and getattr(self, 'id') is not None:
+            _dict['id'] = getattr(self, 'id')
+        if hasattr(self, 'account_id') and getattr(self, 'account_id') is not None:
+            _dict['account_id'] = getattr(self, 'account_id')
+        if hasattr(self, 'href') and getattr(self, 'href') is not None:
+            _dict['href'] = getattr(self, 'href')
+        if hasattr(self, 'created_at') and getattr(self, 'created_at') is not None:
+            _dict['created_at'] = datetime_to_string(getattr(self, 'created_at'))
+        if hasattr(self, 'created_by_id') and getattr(self, 'created_by_id') is not None:
+            _dict['created_by_id'] = getattr(self, 'created_by_id')
+        if hasattr(self, 'last_modified_at') and getattr(self, 'last_modified_at') is not None:
+            _dict['last_modified_at'] = datetime_to_string(getattr(self, 'last_modified_at'))
+        if hasattr(self, 'last_modified_by_id') and getattr(self, 'last_modified_by_id') is not None:
+            _dict['last_modified_by_id'] = getattr(self, 'last_modified_by_id')
+        if hasattr(self, 'resources') and self.resources is not None:
+            resources_list = []
+            for v in self.resources:
+                if isinstance(v, dict):
+                    resources_list.append(v)
+                else:
+                    resources_list.append(v.to_dict())
+            _dict['resources'] = resources_list
+        if hasattr(self, 'subject') and self.subject is not None:
+            if isinstance(self.subject, dict):
+                _dict['subject'] = self.subject
+            else:
+                _dict['subject'] = self.subject.to_dict()
+        if hasattr(self, 'template') and self.template is not None:
+            if isinstance(self.template, dict):
+                _dict['template'] = self.template
+            else:
+                _dict['template'] = self.template.to_dict()
+        if hasattr(self, 'status') and self.status is not None:
+            _dict['status'] = self.status
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PolicyTemplateAssignmentItemsPolicyAssignmentV1 object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PolicyTemplateAssignmentItemsPolicyAssignmentV1') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PolicyTemplateAssignmentItemsPolicyAssignmentV1') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class StatusEnum(str, Enum):
+        """
+        The policy assignment status.
+        """
+
+        IN_PROGRESS = 'in_progress'
+        SUCCEEDED = 'succeeded'
+        SUCCEED_WITH_ERRORS = 'succeed_with_errors'
+        FAILED = 'failed'
 
 
 class V2PolicyRuleRuleAttribute(V2PolicyRule):

--- a/test/integration/test_iam_policy_management_v1.py
+++ b/test/integration/test_iam_policy_management_v1.py
@@ -751,20 +751,24 @@ class TestIamPolicyManagementV1(unittest.TestCase):
             name="S2STest",
             account_id=self.testAccountId,
             policy=TemplatePolicy(
-            type='authorization',
-            control=Control(grant=Grant(roles=[PolicyRole(role_id="crn:v1:bluemix:public:iam::::serviceRole:Writer")])),
-            resource=V2PolicyResource(
-            attributes=[
-                V2PolicyResourceAttribute(key='serviceName', value='cloud-object-storage', operator='stringEquals'),
-            ],
+                type='authorization',
+                control=Control(
+                    grant=Grant(roles=[PolicyRole(role_id="crn:v1:bluemix:public:iam::::serviceRole:Writer")])
+                ),
+                resource=V2PolicyResource(
+                    attributes=[
+                        V2PolicyResourceAttribute(
+                            key='serviceName', value='cloud-object-storage', operator='stringEquals'
+                        ),
+                    ],
+                ),
+                subject=V2PolicySubject(
+                    attributes=[
+                        V2PolicySubjectAttribute(key='serviceName', value='compliance', operator='stringEquals'),
+                    ],
+                ),
+                description='SDK Test Policy',
             ),
-            subject=V2PolicySubject(
-            attributes=[
-                V2PolicySubjectAttribute(key='serviceName', value='compliance', operator='stringEquals'),
-            ],
-            ),
-             description='SDK Test Policy',
-        ),
             description='SDK Test Policy S2S Template',
             committed=True,
         )
@@ -782,24 +786,26 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         self.__class__.testS2STemplateId = result.id
         self.__class__.testS2SBaseTemplateVersion = result.version
         assert result.state == "active"
-    
+
     def test_25_create_policy_s2s_template_version(self):
         response = self.service.create_policy_template_version(
             policy=TemplatePolicy(
-            type='authorization',
-            control=Control(grant=Grant(roles=[PolicyRole(role_id="crn:v1:bluemix:public:iam::::serviceRole:Reader")])),
-            resource=V2PolicyResource(
-            attributes=[
-                V2PolicyResourceAttribute(key='serviceName', value='kms', operator='stringEquals'),
-            ],
+                type='authorization',
+                control=Control(
+                    grant=Grant(roles=[PolicyRole(role_id="crn:v1:bluemix:public:iam::::serviceRole:Reader")])
+                ),
+                resource=V2PolicyResource(
+                    attributes=[
+                        V2PolicyResourceAttribute(key='serviceName', value='kms', operator='stringEquals'),
+                    ],
+                ),
+                subject=V2PolicySubject(
+                    attributes=[
+                        V2PolicySubjectAttribute(key='serviceName', value='compliance', operator='stringEquals'),
+                    ],
+                ),
+                description='SDK Test Policy',
             ),
-            subject=V2PolicySubject(
-            attributes=[
-                V2PolicySubjectAttribute(key='serviceName', value='compliance', operator='stringEquals'),
-            ],
-            ),
-             description='SDK Test Policy',
-        ),
             description='SDK Test Policy S2S Template',
             committed=True,
             policy_template_id=self.testS2STemplateId,
@@ -819,15 +825,17 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert result.state == "active"
 
     def test_26_create_policy_assignment(self):
-        response=self.service.create_policy_template_assignment(
-        version="1.0",
-        target=AssignmentTargetDetails(
-            type="Account",
-            id=self.testTargetAccountId,
-        ),
-        options=PolicyAssignmentV1Options(root=PolicyAssignmentV1OptionsRoot(requester_id="test_sdk", assignment_id="test")),
-        templates=[AssignmentTemplateDetails(id=self.testS2STemplateId, version=self.testS2SBaseTemplateVersion)],
-         )
+        response = self.service.create_policy_template_assignment(
+            version="1.0",
+            target=AssignmentTargetDetails(
+                type="Account",
+                id=self.testTargetAccountId,
+            ),
+            options=PolicyAssignmentV1Options(
+                root=PolicyAssignmentV1OptionsRoot(requester_id="test_sdk", assignment_id="test")
+            ),
+            templates=[AssignmentTemplateDetails(id=self.testS2STemplateId, version=self.testS2SBaseTemplateVersion)],
+        )
         assert response.get_status_code() == 201
         result_dict = response.get_result()
         assert result_dict is not None
@@ -835,8 +843,8 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         result = PolicyAssignmentV1Collection.from_dict(result_dict)
         print("Policy Assignment Creation: ", result)
         assert result is not None
-        self.__class__.testAssignmentId=result.assignments[0].id
-        self.__class__.testAssignmentPolicyId=result.assignments[0].resources[0].policy.resource_created.id
+        self.__class__.testAssignmentId = result.assignments[0].id
+        self.__class__.testAssignmentPolicyId = result.assignments[0].resources[0].policy.resource_created.id
         self.__class__.testPolicyAssignmentETag = response.get_headers().get(self.etagHeader)
 
     def test_27_list_policy_assignments(self):
@@ -901,7 +909,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         result = V2PolicyTemplateMetaData.from_dict(result_dict)
         assert result is not None
         assert result.template is not None
-    
+
     def test_30_delete_policy_assignment(self):
         response = self.service.delete_policy_assignment(
             assignment_id=self.testAssignmentId,

--- a/test/unit/test_iam_policy_management_v1.py
+++ b/test/unit/test_iam_policy_management_v1.py
@@ -2432,7 +2432,7 @@ class TestListPolicyTemplates:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates')
-        mock_response = '{"policy_templates": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        mock_response = '{"policy_templates": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
         responses.add(
             responses.GET,
             url,
@@ -2445,12 +2445,22 @@ class TestListPolicyTemplates:
         account_id = 'testString'
         accept_language = 'default'
         state = 'active'
+        name = 'testString'
+        policy_service_type = 'service'
+        policy_service_name = 'testString'
+        policy_service_group_id = 'testString'
+        policy_type = 'access'
 
         # Invoke method
         response = _service.list_policy_templates(
             account_id,
             accept_language=accept_language,
             state=state,
+            name=name,
+            policy_service_type=policy_service_type,
+            policy_service_name=policy_service_name,
+            policy_service_group_id=policy_service_group_id,
+            policy_type=policy_type,
             headers={},
         )
 
@@ -2462,6 +2472,11 @@ class TestListPolicyTemplates:
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'account_id={}'.format(account_id) in query_string
         assert 'state={}'.format(state) in query_string
+        assert 'name={}'.format(name) in query_string
+        assert 'policy_service_type={}'.format(policy_service_type) in query_string
+        assert 'policy_service_name={}'.format(policy_service_name) in query_string
+        assert 'policy_service_group_id={}'.format(policy_service_group_id) in query_string
+        assert 'policy_type={}'.format(policy_type) in query_string
 
     def test_list_policy_templates_all_params_with_retries(self):
         # Enable retries and run test_list_policy_templates_all_params.
@@ -2479,7 +2494,7 @@ class TestListPolicyTemplates:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates')
-        mock_response = '{"policy_templates": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        mock_response = '{"policy_templates": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
         responses.add(
             responses.GET,
             url,
@@ -2521,7 +2536,7 @@ class TestListPolicyTemplates:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates')
-        mock_response = '{"policy_templates": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        mock_response = '{"policy_templates": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
         responses.add(
             responses.GET,
             url,
@@ -2564,7 +2579,7 @@ class TestCreatePolicyTemplate:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates')
-        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}'
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}'
         responses.add(
             responses.POST,
             url,
@@ -2590,6 +2605,16 @@ class TestCreatePolicyTemplate:
         v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
         v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
 
+        # Construct a dict representation of a V2PolicySubjectAttribute model
+        v2_policy_subject_attribute_model = {}
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicySubject model
+        v2_policy_subject_model = {}
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
+
         # Construct a dict representation of a V2PolicyRuleRuleAttribute model
         v2_policy_rule_model = {}
         v2_policy_rule_model['key'] = 'testString'
@@ -2613,6 +2638,7 @@ class TestCreatePolicyTemplate:
         template_policy_model['type'] = 'access'
         template_policy_model['description'] = 'testString'
         template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
         template_policy_model['control'] = control_model
@@ -2663,7 +2689,7 @@ class TestCreatePolicyTemplate:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates')
-        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}'
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}'
         responses.add(
             responses.POST,
             url,
@@ -2689,6 +2715,16 @@ class TestCreatePolicyTemplate:
         v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
         v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
 
+        # Construct a dict representation of a V2PolicySubjectAttribute model
+        v2_policy_subject_attribute_model = {}
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicySubject model
+        v2_policy_subject_model = {}
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
+
         # Construct a dict representation of a V2PolicyRuleRuleAttribute model
         v2_policy_rule_model = {}
         v2_policy_rule_model['key'] = 'testString'
@@ -2712,6 +2748,7 @@ class TestCreatePolicyTemplate:
         template_policy_model['type'] = 'access'
         template_policy_model['description'] = 'testString'
         template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
         template_policy_model['control'] = control_model
@@ -2760,7 +2797,7 @@ class TestCreatePolicyTemplate:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates')
-        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}'
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}'
         responses.add(
             responses.POST,
             url,
@@ -2786,6 +2823,16 @@ class TestCreatePolicyTemplate:
         v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
         v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
 
+        # Construct a dict representation of a V2PolicySubjectAttribute model
+        v2_policy_subject_attribute_model = {}
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicySubject model
+        v2_policy_subject_model = {}
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
+
         # Construct a dict representation of a V2PolicyRuleRuleAttribute model
         v2_policy_rule_model = {}
         v2_policy_rule_model['key'] = 'testString'
@@ -2809,6 +2856,7 @@ class TestCreatePolicyTemplate:
         template_policy_model['type'] = 'access'
         template_policy_model['description'] = 'testString'
         template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
         template_policy_model['control'] = control_model
@@ -2853,7 +2901,7 @@ class TestGetPolicyTemplate:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates/testString')
-        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
         responses.add(
             responses.GET,
             url,
@@ -2897,7 +2945,7 @@ class TestGetPolicyTemplate:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates/testString')
-        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
         responses.add(
             responses.GET,
             url,
@@ -2935,7 +2983,7 @@ class TestGetPolicyTemplate:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates/testString')
-        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
         responses.add(
             responses.GET,
             url,
@@ -3053,7 +3101,7 @@ class TestCreatePolicyTemplateVersion:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates/testString/versions')
-        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}'
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}'
         responses.add(
             responses.POST,
             url,
@@ -3079,6 +3127,16 @@ class TestCreatePolicyTemplateVersion:
         v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
         v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
 
+        # Construct a dict representation of a V2PolicySubjectAttribute model
+        v2_policy_subject_attribute_model = {}
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicySubject model
+        v2_policy_subject_model = {}
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
+
         # Construct a dict representation of a V2PolicyRuleRuleAttribute model
         v2_policy_rule_model = {}
         v2_policy_rule_model['key'] = 'testString'
@@ -3102,6 +3160,7 @@ class TestCreatePolicyTemplateVersion:
         template_policy_model['type'] = 'access'
         template_policy_model['description'] = 'testString'
         template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
         template_policy_model['control'] = control_model
@@ -3149,7 +3208,7 @@ class TestCreatePolicyTemplateVersion:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates/testString/versions')
-        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}'
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}'
         responses.add(
             responses.POST,
             url,
@@ -3175,6 +3234,16 @@ class TestCreatePolicyTemplateVersion:
         v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
         v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
 
+        # Construct a dict representation of a V2PolicySubjectAttribute model
+        v2_policy_subject_attribute_model = {}
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicySubject model
+        v2_policy_subject_model = {}
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
+
         # Construct a dict representation of a V2PolicyRuleRuleAttribute model
         v2_policy_rule_model = {}
         v2_policy_rule_model['key'] = 'testString'
@@ -3198,6 +3267,7 @@ class TestCreatePolicyTemplateVersion:
         template_policy_model['type'] = 'access'
         template_policy_model['description'] = 'testString'
         template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
         template_policy_model['control'] = control_model
@@ -3241,7 +3311,7 @@ class TestListPolicyTemplateVersions:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates/testString/versions')
-        mock_response = '{"versions": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        mock_response = '{"versions": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
         responses.add(
             responses.GET,
             url,
@@ -3285,7 +3355,7 @@ class TestListPolicyTemplateVersions:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates/testString/versions')
-        mock_response = '{"versions": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        mock_response = '{"versions": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
         responses.add(
             responses.GET,
             url,
@@ -3323,7 +3393,7 @@ class TestListPolicyTemplateVersions:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates/testString/versions')
-        mock_response = '{"versions": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        mock_response = '{"versions": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
         responses.add(
             responses.GET,
             url,
@@ -3366,7 +3436,7 @@ class TestReplacePolicyTemplate:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates/testString/versions/testString')
-        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
         responses.add(
             responses.PUT,
             url,
@@ -3392,6 +3462,16 @@ class TestReplacePolicyTemplate:
         v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
         v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
 
+        # Construct a dict representation of a V2PolicySubjectAttribute model
+        v2_policy_subject_attribute_model = {}
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicySubject model
+        v2_policy_subject_model = {}
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
+
         # Construct a dict representation of a V2PolicyRuleRuleAttribute model
         v2_policy_rule_model = {}
         v2_policy_rule_model['key'] = 'testString'
@@ -3415,6 +3495,7 @@ class TestReplacePolicyTemplate:
         template_policy_model['type'] = 'access'
         template_policy_model['description'] = 'testString'
         template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
         template_policy_model['control'] = control_model
@@ -3466,7 +3547,7 @@ class TestReplacePolicyTemplate:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates/testString/versions/testString')
-        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
         responses.add(
             responses.PUT,
             url,
@@ -3492,6 +3573,16 @@ class TestReplacePolicyTemplate:
         v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
         v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
 
+        # Construct a dict representation of a V2PolicySubjectAttribute model
+        v2_policy_subject_attribute_model = {}
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
+
+        # Construct a dict representation of a V2PolicySubject model
+        v2_policy_subject_model = {}
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
+
         # Construct a dict representation of a V2PolicyRuleRuleAttribute model
         v2_policy_rule_model = {}
         v2_policy_rule_model['key'] = 'testString'
@@ -3515,6 +3606,7 @@ class TestReplacePolicyTemplate:
         template_policy_model['type'] = 'access'
         template_policy_model['description'] = 'testString'
         template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
         template_policy_model['control'] = control_model
@@ -3641,7 +3733,7 @@ class TestGetPolicyTemplateVersion:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates/testString/versions/testString')
-        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
         responses.add(
             responses.GET,
             url,
@@ -3681,7 +3773,7 @@ class TestGetPolicyTemplateVersion:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates/testString/versions/testString')
-        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
+        mock_response = '{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}'
         responses.add(
             responses.GET,
             url,
@@ -3844,7 +3936,7 @@ class TestListPolicyAssignments:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_assignments')
-        mock_response = '{"assignments": [{"template_id": "template_id", "template_version": "template_version", "assignment_id": "assignment_id", "target_type": "Account", "target": "target", "options": [{"subject_type": "iam_id", "subject_id": "subject_id", "root_requester_id": "root_requester_id", "root_template_id": "root_template_id", "root_template_version": "root_template_version"}], "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": "target", "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "status": "in_progress"}]}'
+        mock_response = '{"assignments": [{"target": {"type": "Account", "id": "id"}, "options": {"root": {"requester_id": "requester_id", "assignment_id": "assignment_id", "template": {"id": "id", "version": "version"}}}, "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": {"id": "id", "version": "version"}, "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "subject": {"id": "id", "type": "iam_id"}, "template": {"id": "id", "version": "version"}, "status": "in_progress"}]}'
         responses.add(
             responses.GET,
             url,
@@ -3854,6 +3946,7 @@ class TestListPolicyAssignments:
         )
 
         # Set up parameter values
+        version = '1.0'
         account_id = 'testString'
         accept_language = 'default'
         template_id = 'testString'
@@ -3861,6 +3954,7 @@ class TestListPolicyAssignments:
 
         # Invoke method
         response = _service.list_policy_assignments(
+            version,
             account_id,
             accept_language=accept_language,
             template_id=template_id,
@@ -3874,6 +3968,7 @@ class TestListPolicyAssignments:
         # Validate query params
         query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
+        assert 'version={}'.format(version) in query_string
         assert 'account_id={}'.format(account_id) in query_string
         assert 'template_id={}'.format(template_id) in query_string
         assert 'template_version={}'.format(template_version) in query_string
@@ -3894,7 +3989,7 @@ class TestListPolicyAssignments:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_assignments')
-        mock_response = '{"assignments": [{"template_id": "template_id", "template_version": "template_version", "assignment_id": "assignment_id", "target_type": "Account", "target": "target", "options": [{"subject_type": "iam_id", "subject_id": "subject_id", "root_requester_id": "root_requester_id", "root_template_id": "root_template_id", "root_template_version": "root_template_version"}], "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": "target", "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "status": "in_progress"}]}'
+        mock_response = '{"assignments": [{"target": {"type": "Account", "id": "id"}, "options": {"root": {"requester_id": "requester_id", "assignment_id": "assignment_id", "template": {"id": "id", "version": "version"}}}, "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": {"id": "id", "version": "version"}, "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "subject": {"id": "id", "type": "iam_id"}, "template": {"id": "id", "version": "version"}, "status": "in_progress"}]}'
         responses.add(
             responses.GET,
             url,
@@ -3904,10 +3999,12 @@ class TestListPolicyAssignments:
         )
 
         # Set up parameter values
+        version = '1.0'
         account_id = 'testString'
 
         # Invoke method
         response = _service.list_policy_assignments(
+            version,
             account_id,
             headers={},
         )
@@ -3918,6 +4015,7 @@ class TestListPolicyAssignments:
         # Validate query params
         query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
+        assert 'version={}'.format(version) in query_string
         assert 'account_id={}'.format(account_id) in query_string
 
     def test_list_policy_assignments_required_params_with_retries(self):
@@ -3936,7 +4034,7 @@ class TestListPolicyAssignments:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_assignments')
-        mock_response = '{"assignments": [{"template_id": "template_id", "template_version": "template_version", "assignment_id": "assignment_id", "target_type": "Account", "target": "target", "options": [{"subject_type": "iam_id", "subject_id": "subject_id", "root_requester_id": "root_requester_id", "root_template_id": "root_template_id", "root_template_version": "root_template_version"}], "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": "target", "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "status": "in_progress"}]}'
+        mock_response = '{"assignments": [{"target": {"type": "Account", "id": "id"}, "options": {"root": {"requester_id": "requester_id", "assignment_id": "assignment_id", "template": {"id": "id", "version": "version"}}}, "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": {"id": "id", "version": "version"}, "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "subject": {"id": "id", "type": "iam_id"}, "template": {"id": "id", "version": "version"}, "status": "in_progress"}]}'
         responses.add(
             responses.GET,
             url,
@@ -3946,10 +4044,12 @@ class TestListPolicyAssignments:
         )
 
         # Set up parameter values
+        version = '1.0'
         account_id = 'testString'
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
+            "version": version,
             "account_id": account_id,
         }
         for param in req_param_dict.keys():
@@ -3967,6 +4067,238 @@ class TestListPolicyAssignments:
         self.test_list_policy_assignments_value_error()
 
 
+class TestCreatePolicyTemplateAssignment:
+    """
+    Test Class for create_policy_template_assignment
+    """
+
+    @responses.activate
+    def test_create_policy_template_assignment_all_params(self):
+        """
+        create_policy_template_assignment()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_assignments')
+        mock_response = '{"assignments": [{"target": {"type": "Account", "id": "id"}, "options": {"root": {"requester_id": "requester_id", "assignment_id": "assignment_id", "template": {"id": "id", "version": "version"}}}, "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": {"id": "id", "version": "version"}, "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "subject": {"id": "id", "type": "iam_id"}, "template": {"id": "id", "version": "version"}, "status": "in_progress"}]}'
+        responses.add(
+            responses.POST,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=201,
+        )
+
+        # Construct a dict representation of a AssignmentTargetDetails model
+        assignment_target_details_model = {}
+        assignment_target_details_model['type'] = 'Account'
+        assignment_target_details_model['id'] = 'testString'
+
+        # Construct a dict representation of a PolicyAssignmentV1OptionsRootTemplate model
+        policy_assignment_v1_options_root_template_model = {}
+        policy_assignment_v1_options_root_template_model['id'] = 'testString'
+        policy_assignment_v1_options_root_template_model['version'] = 'testString'
+
+        # Construct a dict representation of a PolicyAssignmentV1OptionsRoot model
+        policy_assignment_v1_options_root_model = {}
+        policy_assignment_v1_options_root_model['requester_id'] = 'testString'
+        policy_assignment_v1_options_root_model['assignment_id'] = 'testString'
+        policy_assignment_v1_options_root_model['template'] = policy_assignment_v1_options_root_template_model
+
+        # Construct a dict representation of a PolicyAssignmentV1Options model
+        policy_assignment_v1_options_model = {}
+        policy_assignment_v1_options_model['root'] = policy_assignment_v1_options_root_model
+
+        # Construct a dict representation of a AssignmentTemplateDetails model
+        assignment_template_details_model = {}
+        assignment_template_details_model['id'] = 'testString'
+        assignment_template_details_model['version'] = 'testString'
+
+        # Set up parameter values
+        version = '1.0'
+        target = assignment_target_details_model
+        options = policy_assignment_v1_options_model
+        templates = [assignment_template_details_model]
+        accept_language = 'default'
+
+        # Invoke method
+        response = _service.create_policy_template_assignment(
+            version,
+            target,
+            options,
+            templates,
+            accept_language=accept_language,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'version={}'.format(version) in query_string
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['target'] == assignment_target_details_model
+        assert req_body['options'] == policy_assignment_v1_options_model
+        assert req_body['templates'] == [assignment_template_details_model]
+
+    def test_create_policy_template_assignment_all_params_with_retries(self):
+        # Enable retries and run test_create_policy_template_assignment_all_params.
+        _service.enable_retries()
+        self.test_create_policy_template_assignment_all_params()
+
+        # Disable retries and run test_create_policy_template_assignment_all_params.
+        _service.disable_retries()
+        self.test_create_policy_template_assignment_all_params()
+
+    @responses.activate
+    def test_create_policy_template_assignment_required_params(self):
+        """
+        test_create_policy_template_assignment_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_assignments')
+        mock_response = '{"assignments": [{"target": {"type": "Account", "id": "id"}, "options": {"root": {"requester_id": "requester_id", "assignment_id": "assignment_id", "template": {"id": "id", "version": "version"}}}, "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": {"id": "id", "version": "version"}, "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "subject": {"id": "id", "type": "iam_id"}, "template": {"id": "id", "version": "version"}, "status": "in_progress"}]}'
+        responses.add(
+            responses.POST,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=201,
+        )
+
+        # Construct a dict representation of a AssignmentTargetDetails model
+        assignment_target_details_model = {}
+        assignment_target_details_model['type'] = 'Account'
+        assignment_target_details_model['id'] = 'testString'
+
+        # Construct a dict representation of a PolicyAssignmentV1OptionsRootTemplate model
+        policy_assignment_v1_options_root_template_model = {}
+        policy_assignment_v1_options_root_template_model['id'] = 'testString'
+        policy_assignment_v1_options_root_template_model['version'] = 'testString'
+
+        # Construct a dict representation of a PolicyAssignmentV1OptionsRoot model
+        policy_assignment_v1_options_root_model = {}
+        policy_assignment_v1_options_root_model['requester_id'] = 'testString'
+        policy_assignment_v1_options_root_model['assignment_id'] = 'testString'
+        policy_assignment_v1_options_root_model['template'] = policy_assignment_v1_options_root_template_model
+
+        # Construct a dict representation of a PolicyAssignmentV1Options model
+        policy_assignment_v1_options_model = {}
+        policy_assignment_v1_options_model['root'] = policy_assignment_v1_options_root_model
+
+        # Construct a dict representation of a AssignmentTemplateDetails model
+        assignment_template_details_model = {}
+        assignment_template_details_model['id'] = 'testString'
+        assignment_template_details_model['version'] = 'testString'
+
+        # Set up parameter values
+        version = '1.0'
+        target = assignment_target_details_model
+        options = policy_assignment_v1_options_model
+        templates = [assignment_template_details_model]
+
+        # Invoke method
+        response = _service.create_policy_template_assignment(
+            version,
+            target,
+            options,
+            templates,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'version={}'.format(version) in query_string
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['target'] == assignment_target_details_model
+        assert req_body['options'] == policy_assignment_v1_options_model
+        assert req_body['templates'] == [assignment_template_details_model]
+
+    def test_create_policy_template_assignment_required_params_with_retries(self):
+        # Enable retries and run test_create_policy_template_assignment_required_params.
+        _service.enable_retries()
+        self.test_create_policy_template_assignment_required_params()
+
+        # Disable retries and run test_create_policy_template_assignment_required_params.
+        _service.disable_retries()
+        self.test_create_policy_template_assignment_required_params()
+
+    @responses.activate
+    def test_create_policy_template_assignment_value_error(self):
+        """
+        test_create_policy_template_assignment_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_assignments')
+        mock_response = '{"assignments": [{"target": {"type": "Account", "id": "id"}, "options": {"root": {"requester_id": "requester_id", "assignment_id": "assignment_id", "template": {"id": "id", "version": "version"}}}, "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": {"id": "id", "version": "version"}, "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "subject": {"id": "id", "type": "iam_id"}, "template": {"id": "id", "version": "version"}, "status": "in_progress"}]}'
+        responses.add(
+            responses.POST,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=201,
+        )
+
+        # Construct a dict representation of a AssignmentTargetDetails model
+        assignment_target_details_model = {}
+        assignment_target_details_model['type'] = 'Account'
+        assignment_target_details_model['id'] = 'testString'
+
+        # Construct a dict representation of a PolicyAssignmentV1OptionsRootTemplate model
+        policy_assignment_v1_options_root_template_model = {}
+        policy_assignment_v1_options_root_template_model['id'] = 'testString'
+        policy_assignment_v1_options_root_template_model['version'] = 'testString'
+
+        # Construct a dict representation of a PolicyAssignmentV1OptionsRoot model
+        policy_assignment_v1_options_root_model = {}
+        policy_assignment_v1_options_root_model['requester_id'] = 'testString'
+        policy_assignment_v1_options_root_model['assignment_id'] = 'testString'
+        policy_assignment_v1_options_root_model['template'] = policy_assignment_v1_options_root_template_model
+
+        # Construct a dict representation of a PolicyAssignmentV1Options model
+        policy_assignment_v1_options_model = {}
+        policy_assignment_v1_options_model['root'] = policy_assignment_v1_options_root_model
+
+        # Construct a dict representation of a AssignmentTemplateDetails model
+        assignment_template_details_model = {}
+        assignment_template_details_model['id'] = 'testString'
+        assignment_template_details_model['version'] = 'testString'
+
+        # Set up parameter values
+        version = '1.0'
+        target = assignment_target_details_model
+        options = policy_assignment_v1_options_model
+        templates = [assignment_template_details_model]
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "version": version,
+            "target": target,
+            "options": options,
+            "templates": templates,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.create_policy_template_assignment(**req_copy)
+
+    def test_create_policy_template_assignment_value_error_with_retries(self):
+        # Enable retries and run test_create_policy_template_assignment_value_error.
+        _service.enable_retries()
+        self.test_create_policy_template_assignment_value_error()
+
+        # Disable retries and run test_create_policy_template_assignment_value_error.
+        _service.disable_retries()
+        self.test_create_policy_template_assignment_value_error()
+
+
 class TestGetPolicyAssignment:
     """
     Test Class for get_policy_assignment
@@ -3979,7 +4311,7 @@ class TestGetPolicyAssignment:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_assignments/testString')
-        mock_response = '{"template_id": "template_id", "template_version": "template_version", "assignment_id": "assignment_id", "target_type": "Account", "target": "target", "options": [{"subject_type": "iam_id", "subject_id": "subject_id", "root_requester_id": "root_requester_id", "root_template_id": "root_template_id", "root_template_version": "root_template_version"}], "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": "target", "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "status": "in_progress"}'
+        mock_response = '{"target": {"type": "Account", "id": "id"}, "options": {"root": {"requester_id": "requester_id", "assignment_id": "assignment_id", "template": {"id": "id", "version": "version"}}}, "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": {"id": "id", "version": "version"}, "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "subject": {"id": "id", "type": "iam_id"}, "template": {"id": "id", "version": "version"}, "status": "in_progress"}'
         responses.add(
             responses.GET,
             url,
@@ -3990,16 +4322,22 @@ class TestGetPolicyAssignment:
 
         # Set up parameter values
         assignment_id = 'testString'
+        version = '1.0'
 
         # Invoke method
         response = _service.get_policy_assignment(
             assignment_id,
+            version,
             headers={},
         )
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'version={}'.format(version) in query_string
 
     def test_get_policy_assignment_all_params_with_retries(self):
         # Enable retries and run test_get_policy_assignment_all_params.
@@ -4017,7 +4355,7 @@ class TestGetPolicyAssignment:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_assignments/testString')
-        mock_response = '{"template_id": "template_id", "template_version": "template_version", "assignment_id": "assignment_id", "target_type": "Account", "target": "target", "options": [{"subject_type": "iam_id", "subject_id": "subject_id", "root_requester_id": "root_requester_id", "root_template_id": "root_template_id", "root_template_version": "root_template_version"}], "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": "target", "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "status": "in_progress"}'
+        mock_response = '{"target": {"type": "Account", "id": "id"}, "options": {"root": {"requester_id": "requester_id", "assignment_id": "assignment_id", "template": {"id": "id", "version": "version"}}}, "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": {"id": "id", "version": "version"}, "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "subject": {"id": "id", "type": "iam_id"}, "template": {"id": "id", "version": "version"}, "status": "in_progress"}'
         responses.add(
             responses.GET,
             url,
@@ -4028,10 +4366,12 @@ class TestGetPolicyAssignment:
 
         # Set up parameter values
         assignment_id = 'testString'
+        version = '1.0'
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
             "assignment_id": assignment_id,
+            "version": version,
         }
         for param in req_param_dict.keys():
             req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
@@ -4046,6 +4386,181 @@ class TestGetPolicyAssignment:
         # Disable retries and run test_get_policy_assignment_value_error.
         _service.disable_retries()
         self.test_get_policy_assignment_value_error()
+
+
+class TestUpdatePolicyAssignment:
+    """
+    Test Class for update_policy_assignment
+    """
+
+    @responses.activate
+    def test_update_policy_assignment_all_params(self):
+        """
+        update_policy_assignment()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_assignments/testString')
+        mock_response = '{"target": {"type": "Account", "id": "id"}, "options": {"root": {"requester_id": "requester_id", "assignment_id": "assignment_id", "template": {"id": "id", "version": "version"}}}, "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": {"id": "id", "version": "version"}, "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "subject": {"id": "id", "type": "iam_id"}, "template": {"id": "id", "version": "version"}, "status": "in_progress"}'
+        responses.add(
+            responses.PATCH,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+        version = '1.0'
+        if_match = 'testString'
+        template_version = 'testString'
+
+        # Invoke method
+        response = _service.update_policy_assignment(
+            assignment_id,
+            version,
+            if_match,
+            template_version,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'version={}'.format(version) in query_string
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['template_version'] == 'testString'
+
+    def test_update_policy_assignment_all_params_with_retries(self):
+        # Enable retries and run test_update_policy_assignment_all_params.
+        _service.enable_retries()
+        self.test_update_policy_assignment_all_params()
+
+        # Disable retries and run test_update_policy_assignment_all_params.
+        _service.disable_retries()
+        self.test_update_policy_assignment_all_params()
+
+    @responses.activate
+    def test_update_policy_assignment_value_error(self):
+        """
+        test_update_policy_assignment_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_assignments/testString')
+        mock_response = '{"target": {"type": "Account", "id": "id"}, "options": {"root": {"requester_id": "requester_id", "assignment_id": "assignment_id", "template": {"id": "id", "version": "version"}}}, "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": {"id": "id", "version": "version"}, "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "subject": {"id": "id", "type": "iam_id"}, "template": {"id": "id", "version": "version"}, "status": "in_progress"}'
+        responses.add(
+            responses.PATCH,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+        version = '1.0'
+        if_match = 'testString'
+        template_version = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "assignment_id": assignment_id,
+            "version": version,
+            "if_match": if_match,
+            "template_version": template_version,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.update_policy_assignment(**req_copy)
+
+    def test_update_policy_assignment_value_error_with_retries(self):
+        # Enable retries and run test_update_policy_assignment_value_error.
+        _service.enable_retries()
+        self.test_update_policy_assignment_value_error()
+
+        # Disable retries and run test_update_policy_assignment_value_error.
+        _service.disable_retries()
+        self.test_update_policy_assignment_value_error()
+
+
+class TestDeletePolicyAssignment:
+    """
+    Test Class for delete_policy_assignment
+    """
+
+    @responses.activate
+    def test_delete_policy_assignment_all_params(self):
+        """
+        delete_policy_assignment()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_assignments/testString')
+        responses.add(
+            responses.DELETE,
+            url,
+            status=204,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+
+        # Invoke method
+        response = _service.delete_policy_assignment(
+            assignment_id,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_delete_policy_assignment_all_params_with_retries(self):
+        # Enable retries and run test_delete_policy_assignment_all_params.
+        _service.enable_retries()
+        self.test_delete_policy_assignment_all_params()
+
+        # Disable retries and run test_delete_policy_assignment_all_params.
+        _service.disable_retries()
+        self.test_delete_policy_assignment_all_params()
+
+    @responses.activate
+    def test_delete_policy_assignment_value_error(self):
+        """
+        test_delete_policy_assignment_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/policy_assignments/testString')
+        responses.add(
+            responses.DELETE,
+            url,
+            status=204,
+        )
+
+        # Set up parameter values
+        assignment_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "assignment_id": assignment_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_policy_assignment(**req_copy)
+
+    def test_delete_policy_assignment_value_error_with_retries(self):
+        # Enable retries and run test_delete_policy_assignment_value_error.
+        _service.enable_retries()
+        self.test_delete_policy_assignment_value_error()
+
+        # Disable retries and run test_delete_policy_assignment_value_error.
+        _service.disable_retries()
+        self.test_delete_policy_assignment_value_error()
 
 
 # endregion
@@ -4090,6 +4605,72 @@ class TestModel_AssignmentResourceCreated:
         # Convert model instance back to dict and verify no loss of data
         assignment_resource_created_model_json2 = assignment_resource_created_model.to_dict()
         assert assignment_resource_created_model_json2 == assignment_resource_created_model_json
+
+
+class TestModel_AssignmentTargetDetails:
+    """
+    Test Class for AssignmentTargetDetails
+    """
+
+    def test_assignment_target_details_serialization(self):
+        """
+        Test serialization/deserialization for AssignmentTargetDetails
+        """
+
+        # Construct a json representation of a AssignmentTargetDetails model
+        assignment_target_details_model_json = {}
+        assignment_target_details_model_json['type'] = 'Account'
+        assignment_target_details_model_json['id'] = 'testString'
+
+        # Construct a model instance of AssignmentTargetDetails by calling from_dict on the json representation
+        assignment_target_details_model = AssignmentTargetDetails.from_dict(assignment_target_details_model_json)
+        assert assignment_target_details_model != False
+
+        # Construct a model instance of AssignmentTargetDetails by calling from_dict on the json representation
+        assignment_target_details_model_dict = AssignmentTargetDetails.from_dict(
+            assignment_target_details_model_json
+        ).__dict__
+        assignment_target_details_model2 = AssignmentTargetDetails(**assignment_target_details_model_dict)
+
+        # Verify the model instances are equivalent
+        assert assignment_target_details_model == assignment_target_details_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        assignment_target_details_model_json2 = assignment_target_details_model.to_dict()
+        assert assignment_target_details_model_json2 == assignment_target_details_model_json
+
+
+class TestModel_AssignmentTemplateDetails:
+    """
+    Test Class for AssignmentTemplateDetails
+    """
+
+    def test_assignment_template_details_serialization(self):
+        """
+        Test serialization/deserialization for AssignmentTemplateDetails
+        """
+
+        # Construct a json representation of a AssignmentTemplateDetails model
+        assignment_template_details_model_json = {}
+        assignment_template_details_model_json['id'] = 'testString'
+        assignment_template_details_model_json['version'] = 'testString'
+
+        # Construct a model instance of AssignmentTemplateDetails by calling from_dict on the json representation
+        assignment_template_details_model = AssignmentTemplateDetails.from_dict(assignment_template_details_model_json)
+        assert assignment_template_details_model != False
+
+        # Construct a model instance of AssignmentTemplateDetails by calling from_dict on the json representation
+        assignment_template_details_model_dict = AssignmentTemplateDetails.from_dict(
+            assignment_template_details_model_json
+        ).__dict__
+        assignment_template_details_model2 = AssignmentTemplateDetails(**assignment_template_details_model_dict)
+
+        # Verify the model instances are equivalent
+        assert assignment_template_details_model == assignment_template_details_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        assignment_template_details_model_json2 = assignment_template_details_model.to_dict()
+        assert assignment_template_details_model_json2 == assignment_template_details_model_json
 
 
 class TestModel_ConflictsWith:
@@ -4363,6 +4944,55 @@ class TestModel_ErrorResponse:
         assert error_response_model_json2 == error_response_model_json
 
 
+class TestModel_GetPolicyAssignmentResponsePolicyAssignmentV1Subject:
+    """
+    Test Class for GetPolicyAssignmentResponsePolicyAssignmentV1Subject
+    """
+
+    def test_get_policy_assignment_response_policy_assignment_v1_subject_serialization(self):
+        """
+        Test serialization/deserialization for GetPolicyAssignmentResponsePolicyAssignmentV1Subject
+        """
+
+        # Construct a json representation of a GetPolicyAssignmentResponsePolicyAssignmentV1Subject model
+        get_policy_assignment_response_policy_assignment_v1_subject_model_json = {}
+
+        # Construct a model instance of GetPolicyAssignmentResponsePolicyAssignmentV1Subject by calling from_dict on the json representation
+        get_policy_assignment_response_policy_assignment_v1_subject_model = (
+            GetPolicyAssignmentResponsePolicyAssignmentV1Subject.from_dict(
+                get_policy_assignment_response_policy_assignment_v1_subject_model_json
+            )
+        )
+        assert get_policy_assignment_response_policy_assignment_v1_subject_model != False
+
+        # Construct a model instance of GetPolicyAssignmentResponsePolicyAssignmentV1Subject by calling from_dict on the json representation
+        get_policy_assignment_response_policy_assignment_v1_subject_model_dict = (
+            GetPolicyAssignmentResponsePolicyAssignmentV1Subject.from_dict(
+                get_policy_assignment_response_policy_assignment_v1_subject_model_json
+            ).__dict__
+        )
+        get_policy_assignment_response_policy_assignment_v1_subject_model2 = (
+            GetPolicyAssignmentResponsePolicyAssignmentV1Subject(
+                **get_policy_assignment_response_policy_assignment_v1_subject_model_dict
+            )
+        )
+
+        # Verify the model instances are equivalent
+        assert (
+            get_policy_assignment_response_policy_assignment_v1_subject_model
+            == get_policy_assignment_response_policy_assignment_v1_subject_model2
+        )
+
+        # Convert model instance back to dict and verify no loss of data
+        get_policy_assignment_response_policy_assignment_v1_subject_model_json2 = (
+            get_policy_assignment_response_policy_assignment_v1_subject_model.to_dict()
+        )
+        assert (
+            get_policy_assignment_response_policy_assignment_v1_subject_model_json2
+            == get_policy_assignment_response_policy_assignment_v1_subject_model_json
+        )
+
+
 class TestModel_Grant:
     """
     Test Class for Grant
@@ -4531,83 +5161,6 @@ class TestModel_Policy:
         assert policy_model_json2 == policy_model_json
 
 
-class TestModel_PolicyAssignment:
-    """
-    Test Class for PolicyAssignment
-    """
-
-    def test_policy_assignment_serialization(self):
-        """
-        Test serialization/deserialization for PolicyAssignment
-        """
-
-        # Construct dict forms of any model objects needed in order to build this model.
-
-        policy_assignment_options_model = {}  # PolicyAssignmentOptions
-        policy_assignment_options_model['subject_type'] = 'iam_id'
-        policy_assignment_options_model['subject_id'] = 'testString'
-        policy_assignment_options_model['root_requester_id'] = 'testString'
-        policy_assignment_options_model['root_template_id'] = 'testString'
-        policy_assignment_options_model['root_template_version'] = 'testString'
-
-        assignment_resource_created_model = {}  # AssignmentResourceCreated
-        assignment_resource_created_model['id'] = 'testString'
-
-        conflicts_with_model = {}  # ConflictsWith
-        conflicts_with_model['etag'] = 'testString'
-        conflicts_with_model['role'] = 'testString'
-        conflicts_with_model['policy'] = 'testString'
-
-        error_details_model = {}  # ErrorDetails
-        error_details_model['conflicts_with'] = conflicts_with_model
-
-        error_object_model = {}  # ErrorObject
-        error_object_model['code'] = 'insufficent_permissions'
-        error_object_model['message'] = 'testString'
-        error_object_model['details'] = error_details_model
-        error_object_model['more_info'] = 'testString'
-
-        error_response_model = {}  # ErrorResponse
-        error_response_model['trace'] = 'testString'
-        error_response_model['errors'] = [error_object_model]
-        error_response_model['status_code'] = 38
-
-        policy_assignment_resource_policy_model = {}  # PolicyAssignmentResourcePolicy
-        policy_assignment_resource_policy_model['resource_created'] = assignment_resource_created_model
-        policy_assignment_resource_policy_model['status'] = 'testString'
-        policy_assignment_resource_policy_model['error_message'] = error_response_model
-
-        policy_assignment_resources_model = {}  # PolicyAssignmentResources
-        policy_assignment_resources_model['target'] = 'testString'
-        policy_assignment_resources_model['policy'] = policy_assignment_resource_policy_model
-
-        # Construct a json representation of a PolicyAssignment model
-        policy_assignment_model_json = {}
-        policy_assignment_model_json['template_id'] = 'testString'
-        policy_assignment_model_json['template_version'] = 'testString'
-        policy_assignment_model_json['assignment_id'] = 'testString'
-        policy_assignment_model_json['target_type'] = 'Account'
-        policy_assignment_model_json['target'] = 'testString'
-        policy_assignment_model_json['options'] = [policy_assignment_options_model]
-        policy_assignment_model_json['resources'] = [policy_assignment_resources_model]
-        policy_assignment_model_json['status'] = 'in_progress'
-
-        # Construct a model instance of PolicyAssignment by calling from_dict on the json representation
-        policy_assignment_model = PolicyAssignment.from_dict(policy_assignment_model_json)
-        assert policy_assignment_model != False
-
-        # Construct a model instance of PolicyAssignment by calling from_dict on the json representation
-        policy_assignment_model_dict = PolicyAssignment.from_dict(policy_assignment_model_json).__dict__
-        policy_assignment_model2 = PolicyAssignment(**policy_assignment_model_dict)
-
-        # Verify the model instances are equivalent
-        assert policy_assignment_model == policy_assignment_model2
-
-        # Convert model instance back to dict and verify no loss of data
-        policy_assignment_model_json2 = policy_assignment_model.to_dict()
-        assert policy_assignment_model_json2 == policy_assignment_model_json
-
-
 class TestModel_PolicyAssignmentOptions:
     """
     Test Class for PolicyAssignmentOptions
@@ -4766,6 +5319,427 @@ class TestModel_PolicyAssignmentResources:
         # Convert model instance back to dict and verify no loss of data
         policy_assignment_resources_model_json2 = policy_assignment_resources_model.to_dict()
         assert policy_assignment_resources_model_json2 == policy_assignment_resources_model_json
+
+
+class TestModel_PolicyAssignmentV1:
+    """
+    Test Class for PolicyAssignmentV1
+    """
+
+    def test_policy_assignment_v1_serialization(self):
+        """
+        Test serialization/deserialization for PolicyAssignmentV1
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        assignment_target_details_model = {}  # AssignmentTargetDetails
+        assignment_target_details_model['type'] = 'Account'
+        assignment_target_details_model['id'] = 'testString'
+
+        policy_assignment_v1_options_root_template_model = {}  # PolicyAssignmentV1OptionsRootTemplate
+        policy_assignment_v1_options_root_template_model['id'] = 'testString'
+        policy_assignment_v1_options_root_template_model['version'] = 'testString'
+
+        policy_assignment_v1_options_root_model = {}  # PolicyAssignmentV1OptionsRoot
+        policy_assignment_v1_options_root_model['requester_id'] = 'testString'
+        policy_assignment_v1_options_root_model['assignment_id'] = 'testString'
+        policy_assignment_v1_options_root_model['template'] = policy_assignment_v1_options_root_template_model
+
+        policy_assignment_v1_options_model = {}  # PolicyAssignmentV1Options
+        policy_assignment_v1_options_model['root'] = policy_assignment_v1_options_root_model
+
+        assignment_template_details_model = {}  # AssignmentTemplateDetails
+        assignment_template_details_model['id'] = 'testString'
+        assignment_template_details_model['version'] = 'testString'
+
+        assignment_resource_created_model = {}  # AssignmentResourceCreated
+        assignment_resource_created_model['id'] = 'testString'
+
+        conflicts_with_model = {}  # ConflictsWith
+        conflicts_with_model['etag'] = 'testString'
+        conflicts_with_model['role'] = 'testString'
+        conflicts_with_model['policy'] = 'testString'
+
+        error_details_model = {}  # ErrorDetails
+        error_details_model['conflicts_with'] = conflicts_with_model
+
+        error_object_model = {}  # ErrorObject
+        error_object_model['code'] = 'insufficent_permissions'
+        error_object_model['message'] = 'testString'
+        error_object_model['details'] = error_details_model
+        error_object_model['more_info'] = 'testString'
+
+        error_response_model = {}  # ErrorResponse
+        error_response_model['trace'] = 'testString'
+        error_response_model['errors'] = [error_object_model]
+        error_response_model['status_code'] = 38
+
+        policy_assignment_resource_policy_model = {}  # PolicyAssignmentResourcePolicy
+        policy_assignment_resource_policy_model['resource_created'] = assignment_resource_created_model
+        policy_assignment_resource_policy_model['status'] = 'testString'
+        policy_assignment_resource_policy_model['error_message'] = error_response_model
+
+        policy_assignment_v1_resources_model = {}  # PolicyAssignmentV1Resources
+        policy_assignment_v1_resources_model['target'] = assignment_template_details_model
+        policy_assignment_v1_resources_model['policy'] = policy_assignment_resource_policy_model
+
+        policy_assignment_v1_subject_model = {}  # PolicyAssignmentV1Subject
+
+        # Construct a json representation of a PolicyAssignmentV1 model
+        policy_assignment_v1_model_json = {}
+        policy_assignment_v1_model_json['target'] = assignment_target_details_model
+        policy_assignment_v1_model_json['options'] = policy_assignment_v1_options_model
+        policy_assignment_v1_model_json['resources'] = [policy_assignment_v1_resources_model]
+        policy_assignment_v1_model_json['subject'] = policy_assignment_v1_subject_model
+        policy_assignment_v1_model_json['template'] = assignment_template_details_model
+        policy_assignment_v1_model_json['status'] = 'in_progress'
+
+        # Construct a model instance of PolicyAssignmentV1 by calling from_dict on the json representation
+        policy_assignment_v1_model = PolicyAssignmentV1.from_dict(policy_assignment_v1_model_json)
+        assert policy_assignment_v1_model != False
+
+        # Construct a model instance of PolicyAssignmentV1 by calling from_dict on the json representation
+        policy_assignment_v1_model_dict = PolicyAssignmentV1.from_dict(policy_assignment_v1_model_json).__dict__
+        policy_assignment_v1_model2 = PolicyAssignmentV1(**policy_assignment_v1_model_dict)
+
+        # Verify the model instances are equivalent
+        assert policy_assignment_v1_model == policy_assignment_v1_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_assignment_v1_model_json2 = policy_assignment_v1_model.to_dict()
+        assert policy_assignment_v1_model_json2 == policy_assignment_v1_model_json
+
+
+class TestModel_PolicyAssignmentV1Collection:
+    """
+    Test Class for PolicyAssignmentV1Collection
+    """
+
+    def test_policy_assignment_v1_collection_serialization(self):
+        """
+        Test serialization/deserialization for PolicyAssignmentV1Collection
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        assignment_target_details_model = {}  # AssignmentTargetDetails
+        assignment_target_details_model['type'] = 'Account'
+        assignment_target_details_model['id'] = 'testString'
+
+        policy_assignment_v1_options_root_template_model = {}  # PolicyAssignmentV1OptionsRootTemplate
+        policy_assignment_v1_options_root_template_model['id'] = 'testString'
+        policy_assignment_v1_options_root_template_model['version'] = 'testString'
+
+        policy_assignment_v1_options_root_model = {}  # PolicyAssignmentV1OptionsRoot
+        policy_assignment_v1_options_root_model['requester_id'] = 'testString'
+        policy_assignment_v1_options_root_model['assignment_id'] = 'testString'
+        policy_assignment_v1_options_root_model['template'] = policy_assignment_v1_options_root_template_model
+
+        policy_assignment_v1_options_model = {}  # PolicyAssignmentV1Options
+        policy_assignment_v1_options_model['root'] = policy_assignment_v1_options_root_model
+
+        assignment_template_details_model = {}  # AssignmentTemplateDetails
+        assignment_template_details_model['id'] = 'testString'
+        assignment_template_details_model['version'] = 'testString'
+
+        assignment_resource_created_model = {}  # AssignmentResourceCreated
+        assignment_resource_created_model['id'] = 'testString'
+
+        conflicts_with_model = {}  # ConflictsWith
+        conflicts_with_model['etag'] = 'testString'
+        conflicts_with_model['role'] = 'testString'
+        conflicts_with_model['policy'] = 'testString'
+
+        error_details_model = {}  # ErrorDetails
+        error_details_model['conflicts_with'] = conflicts_with_model
+
+        error_object_model = {}  # ErrorObject
+        error_object_model['code'] = 'insufficent_permissions'
+        error_object_model['message'] = 'testString'
+        error_object_model['details'] = error_details_model
+        error_object_model['more_info'] = 'testString'
+
+        error_response_model = {}  # ErrorResponse
+        error_response_model['trace'] = 'testString'
+        error_response_model['errors'] = [error_object_model]
+        error_response_model['status_code'] = 38
+
+        policy_assignment_resource_policy_model = {}  # PolicyAssignmentResourcePolicy
+        policy_assignment_resource_policy_model['resource_created'] = assignment_resource_created_model
+        policy_assignment_resource_policy_model['status'] = 'testString'
+        policy_assignment_resource_policy_model['error_message'] = error_response_model
+
+        policy_assignment_v1_resources_model = {}  # PolicyAssignmentV1Resources
+        policy_assignment_v1_resources_model['target'] = assignment_template_details_model
+        policy_assignment_v1_resources_model['policy'] = policy_assignment_resource_policy_model
+
+        policy_assignment_v1_subject_model = {}  # PolicyAssignmentV1Subject
+
+        policy_assignment_v1_model = {}  # PolicyAssignmentV1
+        policy_assignment_v1_model['target'] = assignment_target_details_model
+        policy_assignment_v1_model['options'] = policy_assignment_v1_options_model
+        policy_assignment_v1_model['resources'] = [policy_assignment_v1_resources_model]
+        policy_assignment_v1_model['subject'] = policy_assignment_v1_subject_model
+        policy_assignment_v1_model['template'] = assignment_template_details_model
+        policy_assignment_v1_model['status'] = 'in_progress'
+
+        # Construct a json representation of a PolicyAssignmentV1Collection model
+        policy_assignment_v1_collection_model_json = {}
+        policy_assignment_v1_collection_model_json['assignments'] = [policy_assignment_v1_model]
+
+        # Construct a model instance of PolicyAssignmentV1Collection by calling from_dict on the json representation
+        policy_assignment_v1_collection_model = PolicyAssignmentV1Collection.from_dict(
+            policy_assignment_v1_collection_model_json
+        )
+        assert policy_assignment_v1_collection_model != False
+
+        # Construct a model instance of PolicyAssignmentV1Collection by calling from_dict on the json representation
+        policy_assignment_v1_collection_model_dict = PolicyAssignmentV1Collection.from_dict(
+            policy_assignment_v1_collection_model_json
+        ).__dict__
+        policy_assignment_v1_collection_model2 = PolicyAssignmentV1Collection(
+            **policy_assignment_v1_collection_model_dict
+        )
+
+        # Verify the model instances are equivalent
+        assert policy_assignment_v1_collection_model == policy_assignment_v1_collection_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_assignment_v1_collection_model_json2 = policy_assignment_v1_collection_model.to_dict()
+        assert policy_assignment_v1_collection_model_json2 == policy_assignment_v1_collection_model_json
+
+
+class TestModel_PolicyAssignmentV1Options:
+    """
+    Test Class for PolicyAssignmentV1Options
+    """
+
+    def test_policy_assignment_v1_options_serialization(self):
+        """
+        Test serialization/deserialization for PolicyAssignmentV1Options
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        policy_assignment_v1_options_root_template_model = {}  # PolicyAssignmentV1OptionsRootTemplate
+        policy_assignment_v1_options_root_template_model['id'] = 'testString'
+        policy_assignment_v1_options_root_template_model['version'] = 'testString'
+
+        policy_assignment_v1_options_root_model = {}  # PolicyAssignmentV1OptionsRoot
+        policy_assignment_v1_options_root_model['requester_id'] = 'testString'
+        policy_assignment_v1_options_root_model['assignment_id'] = 'testString'
+        policy_assignment_v1_options_root_model['template'] = policy_assignment_v1_options_root_template_model
+
+        # Construct a json representation of a PolicyAssignmentV1Options model
+        policy_assignment_v1_options_model_json = {}
+        policy_assignment_v1_options_model_json['root'] = policy_assignment_v1_options_root_model
+
+        # Construct a model instance of PolicyAssignmentV1Options by calling from_dict on the json representation
+        policy_assignment_v1_options_model = PolicyAssignmentV1Options.from_dict(
+            policy_assignment_v1_options_model_json
+        )
+        assert policy_assignment_v1_options_model != False
+
+        # Construct a model instance of PolicyAssignmentV1Options by calling from_dict on the json representation
+        policy_assignment_v1_options_model_dict = PolicyAssignmentV1Options.from_dict(
+            policy_assignment_v1_options_model_json
+        ).__dict__
+        policy_assignment_v1_options_model2 = PolicyAssignmentV1Options(**policy_assignment_v1_options_model_dict)
+
+        # Verify the model instances are equivalent
+        assert policy_assignment_v1_options_model == policy_assignment_v1_options_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_assignment_v1_options_model_json2 = policy_assignment_v1_options_model.to_dict()
+        assert policy_assignment_v1_options_model_json2 == policy_assignment_v1_options_model_json
+
+
+class TestModel_PolicyAssignmentV1OptionsRoot:
+    """
+    Test Class for PolicyAssignmentV1OptionsRoot
+    """
+
+    def test_policy_assignment_v1_options_root_serialization(self):
+        """
+        Test serialization/deserialization for PolicyAssignmentV1OptionsRoot
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        policy_assignment_v1_options_root_template_model = {}  # PolicyAssignmentV1OptionsRootTemplate
+        policy_assignment_v1_options_root_template_model['id'] = 'testString'
+        policy_assignment_v1_options_root_template_model['version'] = 'testString'
+
+        # Construct a json representation of a PolicyAssignmentV1OptionsRoot model
+        policy_assignment_v1_options_root_model_json = {}
+        policy_assignment_v1_options_root_model_json['requester_id'] = 'testString'
+        policy_assignment_v1_options_root_model_json['assignment_id'] = 'testString'
+        policy_assignment_v1_options_root_model_json['template'] = policy_assignment_v1_options_root_template_model
+
+        # Construct a model instance of PolicyAssignmentV1OptionsRoot by calling from_dict on the json representation
+        policy_assignment_v1_options_root_model = PolicyAssignmentV1OptionsRoot.from_dict(
+            policy_assignment_v1_options_root_model_json
+        )
+        assert policy_assignment_v1_options_root_model != False
+
+        # Construct a model instance of PolicyAssignmentV1OptionsRoot by calling from_dict on the json representation
+        policy_assignment_v1_options_root_model_dict = PolicyAssignmentV1OptionsRoot.from_dict(
+            policy_assignment_v1_options_root_model_json
+        ).__dict__
+        policy_assignment_v1_options_root_model2 = PolicyAssignmentV1OptionsRoot(
+            **policy_assignment_v1_options_root_model_dict
+        )
+
+        # Verify the model instances are equivalent
+        assert policy_assignment_v1_options_root_model == policy_assignment_v1_options_root_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_assignment_v1_options_root_model_json2 = policy_assignment_v1_options_root_model.to_dict()
+        assert policy_assignment_v1_options_root_model_json2 == policy_assignment_v1_options_root_model_json
+
+
+class TestModel_PolicyAssignmentV1OptionsRootTemplate:
+    """
+    Test Class for PolicyAssignmentV1OptionsRootTemplate
+    """
+
+    def test_policy_assignment_v1_options_root_template_serialization(self):
+        """
+        Test serialization/deserialization for PolicyAssignmentV1OptionsRootTemplate
+        """
+
+        # Construct a json representation of a PolicyAssignmentV1OptionsRootTemplate model
+        policy_assignment_v1_options_root_template_model_json = {}
+        policy_assignment_v1_options_root_template_model_json['id'] = 'testString'
+        policy_assignment_v1_options_root_template_model_json['version'] = 'testString'
+
+        # Construct a model instance of PolicyAssignmentV1OptionsRootTemplate by calling from_dict on the json representation
+        policy_assignment_v1_options_root_template_model = PolicyAssignmentV1OptionsRootTemplate.from_dict(
+            policy_assignment_v1_options_root_template_model_json
+        )
+        assert policy_assignment_v1_options_root_template_model != False
+
+        # Construct a model instance of PolicyAssignmentV1OptionsRootTemplate by calling from_dict on the json representation
+        policy_assignment_v1_options_root_template_model_dict = PolicyAssignmentV1OptionsRootTemplate.from_dict(
+            policy_assignment_v1_options_root_template_model_json
+        ).__dict__
+        policy_assignment_v1_options_root_template_model2 = PolicyAssignmentV1OptionsRootTemplate(
+            **policy_assignment_v1_options_root_template_model_dict
+        )
+
+        # Verify the model instances are equivalent
+        assert policy_assignment_v1_options_root_template_model == policy_assignment_v1_options_root_template_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_assignment_v1_options_root_template_model_json2 = (
+            policy_assignment_v1_options_root_template_model.to_dict()
+        )
+        assert (
+            policy_assignment_v1_options_root_template_model_json2
+            == policy_assignment_v1_options_root_template_model_json
+        )
+
+
+class TestModel_PolicyAssignmentV1Resources:
+    """
+    Test Class for PolicyAssignmentV1Resources
+    """
+
+    def test_policy_assignment_v1_resources_serialization(self):
+        """
+        Test serialization/deserialization for PolicyAssignmentV1Resources
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        assignment_template_details_model = {}  # AssignmentTemplateDetails
+        assignment_template_details_model['id'] = 'testString'
+        assignment_template_details_model['version'] = 'testString'
+
+        assignment_resource_created_model = {}  # AssignmentResourceCreated
+        assignment_resource_created_model['id'] = 'testString'
+
+        conflicts_with_model = {}  # ConflictsWith
+        conflicts_with_model['etag'] = 'testString'
+        conflicts_with_model['role'] = 'testString'
+        conflicts_with_model['policy'] = 'testString'
+
+        error_details_model = {}  # ErrorDetails
+        error_details_model['conflicts_with'] = conflicts_with_model
+
+        error_object_model = {}  # ErrorObject
+        error_object_model['code'] = 'insufficent_permissions'
+        error_object_model['message'] = 'testString'
+        error_object_model['details'] = error_details_model
+        error_object_model['more_info'] = 'testString'
+
+        error_response_model = {}  # ErrorResponse
+        error_response_model['trace'] = 'testString'
+        error_response_model['errors'] = [error_object_model]
+        error_response_model['status_code'] = 38
+
+        policy_assignment_resource_policy_model = {}  # PolicyAssignmentResourcePolicy
+        policy_assignment_resource_policy_model['resource_created'] = assignment_resource_created_model
+        policy_assignment_resource_policy_model['status'] = 'testString'
+        policy_assignment_resource_policy_model['error_message'] = error_response_model
+
+        # Construct a json representation of a PolicyAssignmentV1Resources model
+        policy_assignment_v1_resources_model_json = {}
+        policy_assignment_v1_resources_model_json['target'] = assignment_template_details_model
+        policy_assignment_v1_resources_model_json['policy'] = policy_assignment_resource_policy_model
+
+        # Construct a model instance of PolicyAssignmentV1Resources by calling from_dict on the json representation
+        policy_assignment_v1_resources_model = PolicyAssignmentV1Resources.from_dict(
+            policy_assignment_v1_resources_model_json
+        )
+        assert policy_assignment_v1_resources_model != False
+
+        # Construct a model instance of PolicyAssignmentV1Resources by calling from_dict on the json representation
+        policy_assignment_v1_resources_model_dict = PolicyAssignmentV1Resources.from_dict(
+            policy_assignment_v1_resources_model_json
+        ).__dict__
+        policy_assignment_v1_resources_model2 = PolicyAssignmentV1Resources(**policy_assignment_v1_resources_model_dict)
+
+        # Verify the model instances are equivalent
+        assert policy_assignment_v1_resources_model == policy_assignment_v1_resources_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_assignment_v1_resources_model_json2 = policy_assignment_v1_resources_model.to_dict()
+        assert policy_assignment_v1_resources_model_json2 == policy_assignment_v1_resources_model_json
+
+
+class TestModel_PolicyAssignmentV1Subject:
+    """
+    Test Class for PolicyAssignmentV1Subject
+    """
+
+    def test_policy_assignment_v1_subject_serialization(self):
+        """
+        Test serialization/deserialization for PolicyAssignmentV1Subject
+        """
+
+        # Construct a json representation of a PolicyAssignmentV1Subject model
+        policy_assignment_v1_subject_model_json = {}
+
+        # Construct a model instance of PolicyAssignmentV1Subject by calling from_dict on the json representation
+        policy_assignment_v1_subject_model = PolicyAssignmentV1Subject.from_dict(
+            policy_assignment_v1_subject_model_json
+        )
+        assert policy_assignment_v1_subject_model != False
+
+        # Construct a model instance of PolicyAssignmentV1Subject by calling from_dict on the json representation
+        policy_assignment_v1_subject_model_dict = PolicyAssignmentV1Subject.from_dict(
+            policy_assignment_v1_subject_model_json
+        ).__dict__
+        policy_assignment_v1_subject_model2 = PolicyAssignmentV1Subject(**policy_assignment_v1_subject_model_dict)
+
+        # Verify the model instances are equivalent
+        assert policy_assignment_v1_subject_model == policy_assignment_v1_subject_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_assignment_v1_subject_model_json2 = policy_assignment_v1_subject_model.to_dict()
+        assert policy_assignment_v1_subject_model_json2 == policy_assignment_v1_subject_model_json
 
 
 class TestModel_PolicyCollection:
@@ -4975,6 +5949,14 @@ class TestModel_PolicyTemplate:
         v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
         v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
 
+        v2_policy_subject_attribute_model = {}  # V2PolicySubjectAttribute
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
+
+        v2_policy_subject_model = {}  # V2PolicySubject
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
+
         v2_policy_rule_model = {}  # V2PolicyRuleRuleAttribute
         v2_policy_rule_model['key'] = 'testString'
         v2_policy_rule_model['operator'] = 'stringEquals'
@@ -4993,6 +5975,7 @@ class TestModel_PolicyTemplate:
         template_policy_model['type'] = 'access'
         template_policy_model['description'] = 'testString'
         template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
         template_policy_model['control'] = control_model
@@ -5035,12 +6018,25 @@ class TestModel_PolicyTemplateAssignmentCollection:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        policy_assignment_options_model = {}  # PolicyAssignmentOptions
-        policy_assignment_options_model['subject_type'] = 'iam_id'
-        policy_assignment_options_model['subject_id'] = 'testString'
-        policy_assignment_options_model['root_requester_id'] = 'testString'
-        policy_assignment_options_model['root_template_id'] = 'testString'
-        policy_assignment_options_model['root_template_version'] = 'testString'
+        assignment_target_details_model = {}  # AssignmentTargetDetails
+        assignment_target_details_model['type'] = 'Account'
+        assignment_target_details_model['id'] = 'testString'
+
+        policy_assignment_v1_options_root_template_model = {}  # PolicyAssignmentV1OptionsRootTemplate
+        policy_assignment_v1_options_root_template_model['id'] = 'testString'
+        policy_assignment_v1_options_root_template_model['version'] = 'testString'
+
+        policy_assignment_v1_options_root_model = {}  # PolicyAssignmentV1OptionsRoot
+        policy_assignment_v1_options_root_model['requester_id'] = 'testString'
+        policy_assignment_v1_options_root_model['assignment_id'] = 'testString'
+        policy_assignment_v1_options_root_model['template'] = policy_assignment_v1_options_root_template_model
+
+        policy_assignment_v1_options_model = {}  # PolicyAssignmentV1Options
+        policy_assignment_v1_options_model['root'] = policy_assignment_v1_options_root_model
+
+        assignment_template_details_model = {}  # AssignmentTemplateDetails
+        assignment_template_details_model['id'] = 'testString'
+        assignment_template_details_model['version'] = 'testString'
 
         assignment_resource_created_model = {}  # AssignmentResourceCreated
         assignment_resource_created_model['id'] = 'testString'
@@ -5069,23 +6065,23 @@ class TestModel_PolicyTemplateAssignmentCollection:
         policy_assignment_resource_policy_model['status'] = 'testString'
         policy_assignment_resource_policy_model['error_message'] = error_response_model
 
-        policy_assignment_resources_model = {}  # PolicyAssignmentResources
-        policy_assignment_resources_model['target'] = 'testString'
-        policy_assignment_resources_model['policy'] = policy_assignment_resource_policy_model
+        policy_assignment_v1_resources_model = {}  # PolicyAssignmentV1Resources
+        policy_assignment_v1_resources_model['target'] = assignment_template_details_model
+        policy_assignment_v1_resources_model['policy'] = policy_assignment_resource_policy_model
 
-        policy_assignment_model = {}  # PolicyAssignment
-        policy_assignment_model['template_id'] = 'testString'
-        policy_assignment_model['template_version'] = 'testString'
-        policy_assignment_model['assignment_id'] = 'testString'
-        policy_assignment_model['target_type'] = 'Account'
-        policy_assignment_model['target'] = 'testString'
-        policy_assignment_model['options'] = [policy_assignment_options_model]
-        policy_assignment_model['resources'] = [policy_assignment_resources_model]
-        policy_assignment_model['status'] = 'in_progress'
+        policy_assignment_v1_subject_model = {}  # PolicyAssignmentV1Subject
+
+        policy_template_assignment_items_model = {}  # PolicyTemplateAssignmentItemsPolicyAssignmentV1
+        policy_template_assignment_items_model['target'] = assignment_target_details_model
+        policy_template_assignment_items_model['options'] = policy_assignment_v1_options_model
+        policy_template_assignment_items_model['resources'] = [policy_assignment_v1_resources_model]
+        policy_template_assignment_items_model['subject'] = policy_assignment_v1_subject_model
+        policy_template_assignment_items_model['template'] = assignment_template_details_model
+        policy_template_assignment_items_model['status'] = 'in_progress'
 
         # Construct a json representation of a PolicyTemplateAssignmentCollection model
         policy_template_assignment_collection_model_json = {}
-        policy_template_assignment_collection_model_json['assignments'] = [policy_assignment_model]
+        policy_template_assignment_collection_model_json['assignments'] = [policy_template_assignment_items_model]
 
         # Construct a model instance of PolicyTemplateAssignmentCollection by calling from_dict on the json representation
         policy_template_assignment_collection_model = PolicyTemplateAssignmentCollection.from_dict(
@@ -5135,6 +6131,14 @@ class TestModel_PolicyTemplateCollection:
         v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
         v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
 
+        v2_policy_subject_attribute_model = {}  # V2PolicySubjectAttribute
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
+
+        v2_policy_subject_model = {}  # V2PolicySubject
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
+
         v2_policy_rule_model = {}  # V2PolicyRuleRuleAttribute
         v2_policy_rule_model['key'] = 'testString'
         v2_policy_rule_model['operator'] = 'stringEquals'
@@ -5153,6 +6157,7 @@ class TestModel_PolicyTemplateCollection:
         template_policy_model['type'] = 'access'
         template_policy_model['description'] = 'testString'
         template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
         template_policy_model['control'] = control_model
@@ -5214,6 +6219,14 @@ class TestModel_PolicyTemplateLimitData:
         v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
         v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
 
+        v2_policy_subject_attribute_model = {}  # V2PolicySubjectAttribute
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
+
+        v2_policy_subject_model = {}  # V2PolicySubject
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
+
         v2_policy_rule_model = {}  # V2PolicyRuleRuleAttribute
         v2_policy_rule_model['key'] = 'testString'
         v2_policy_rule_model['operator'] = 'stringEquals'
@@ -5232,6 +6245,7 @@ class TestModel_PolicyTemplateLimitData:
         template_policy_model['type'] = 'access'
         template_policy_model['description'] = 'testString'
         template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
         template_policy_model['control'] = control_model
@@ -5368,6 +6382,14 @@ class TestModel_PolicyTemplateVersionsCollection:
         v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
         v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
 
+        v2_policy_subject_attribute_model = {}  # V2PolicySubjectAttribute
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
+
+        v2_policy_subject_model = {}  # V2PolicySubject
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
+
         v2_policy_rule_model = {}  # V2PolicyRuleRuleAttribute
         v2_policy_rule_model['key'] = 'testString'
         v2_policy_rule_model['operator'] = 'stringEquals'
@@ -5386,6 +6408,7 @@ class TestModel_PolicyTemplateVersionsCollection:
         template_policy_model['type'] = 'access'
         template_policy_model['description'] = 'testString'
         template_policy_model['resource'] = v2_policy_resource_model
+        template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
         template_policy_model['control'] = control_model
@@ -5788,6 +6811,14 @@ class TestModel_TemplatePolicy:
         v2_policy_resource_model['attributes'] = [v2_policy_resource_attribute_model]
         v2_policy_resource_model['tags'] = [v2_policy_resource_tag_model]
 
+        v2_policy_subject_attribute_model = {}  # V2PolicySubjectAttribute
+        v2_policy_subject_attribute_model['key'] = 'testString'
+        v2_policy_subject_attribute_model['operator'] = 'stringEquals'
+        v2_policy_subject_attribute_model['value'] = 'testString'
+
+        v2_policy_subject_model = {}  # V2PolicySubject
+        v2_policy_subject_model['attributes'] = [v2_policy_subject_attribute_model]
+
         v2_policy_rule_model = {}  # V2PolicyRuleRuleAttribute
         v2_policy_rule_model['key'] = 'testString'
         v2_policy_rule_model['operator'] = 'stringEquals'
@@ -5807,6 +6838,7 @@ class TestModel_TemplatePolicy:
         template_policy_model_json['type'] = 'access'
         template_policy_model_json['description'] = 'testString'
         template_policy_model_json['resource'] = v2_policy_resource_model
+        template_policy_model_json['subject'] = v2_policy_subject_model
         template_policy_model_json['pattern'] = 'testString'
         template_policy_model_json['rule'] = v2_policy_rule_model
         template_policy_model_json['control'] = control_model
@@ -6356,6 +7388,213 @@ class TestModel_ControlResponseControlWithEnrichedRoles:
         )
 
 
+class TestModel_GetPolicyAssignmentResponsePolicyAssignment:
+    """
+    Test Class for GetPolicyAssignmentResponsePolicyAssignment
+    """
+
+    def test_get_policy_assignment_response_policy_assignment_serialization(self):
+        """
+        Test serialization/deserialization for GetPolicyAssignmentResponsePolicyAssignment
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        policy_assignment_options_model = {}  # PolicyAssignmentOptions
+        policy_assignment_options_model['subject_type'] = 'iam_id'
+        policy_assignment_options_model['subject_id'] = 'testString'
+        policy_assignment_options_model['root_requester_id'] = 'testString'
+        policy_assignment_options_model['root_template_id'] = 'testString'
+        policy_assignment_options_model['root_template_version'] = 'testString'
+
+        assignment_resource_created_model = {}  # AssignmentResourceCreated
+        assignment_resource_created_model['id'] = 'testString'
+
+        conflicts_with_model = {}  # ConflictsWith
+        conflicts_with_model['etag'] = 'testString'
+        conflicts_with_model['role'] = 'testString'
+        conflicts_with_model['policy'] = 'testString'
+
+        error_details_model = {}  # ErrorDetails
+        error_details_model['conflicts_with'] = conflicts_with_model
+
+        error_object_model = {}  # ErrorObject
+        error_object_model['code'] = 'insufficent_permissions'
+        error_object_model['message'] = 'testString'
+        error_object_model['details'] = error_details_model
+        error_object_model['more_info'] = 'testString'
+
+        error_response_model = {}  # ErrorResponse
+        error_response_model['trace'] = 'testString'
+        error_response_model['errors'] = [error_object_model]
+        error_response_model['status_code'] = 38
+
+        policy_assignment_resource_policy_model = {}  # PolicyAssignmentResourcePolicy
+        policy_assignment_resource_policy_model['resource_created'] = assignment_resource_created_model
+        policy_assignment_resource_policy_model['status'] = 'testString'
+        policy_assignment_resource_policy_model['error_message'] = error_response_model
+
+        policy_assignment_resources_model = {}  # PolicyAssignmentResources
+        policy_assignment_resources_model['target'] = 'testString'
+        policy_assignment_resources_model['policy'] = policy_assignment_resource_policy_model
+
+        # Construct a json representation of a GetPolicyAssignmentResponsePolicyAssignment model
+        get_policy_assignment_response_policy_assignment_model_json = {}
+        get_policy_assignment_response_policy_assignment_model_json['template_id'] = 'testString'
+        get_policy_assignment_response_policy_assignment_model_json['template_version'] = 'testString'
+        get_policy_assignment_response_policy_assignment_model_json['assignment_id'] = 'testString'
+        get_policy_assignment_response_policy_assignment_model_json['target_type'] = 'Account'
+        get_policy_assignment_response_policy_assignment_model_json['target'] = 'testString'
+        get_policy_assignment_response_policy_assignment_model_json['options'] = [policy_assignment_options_model]
+        get_policy_assignment_response_policy_assignment_model_json['resources'] = [policy_assignment_resources_model]
+        get_policy_assignment_response_policy_assignment_model_json['status'] = 'in_progress'
+
+        # Construct a model instance of GetPolicyAssignmentResponsePolicyAssignment by calling from_dict on the json representation
+        get_policy_assignment_response_policy_assignment_model = GetPolicyAssignmentResponsePolicyAssignment.from_dict(
+            get_policy_assignment_response_policy_assignment_model_json
+        )
+        assert get_policy_assignment_response_policy_assignment_model != False
+
+        # Construct a model instance of GetPolicyAssignmentResponsePolicyAssignment by calling from_dict on the json representation
+        get_policy_assignment_response_policy_assignment_model_dict = (
+            GetPolicyAssignmentResponsePolicyAssignment.from_dict(
+                get_policy_assignment_response_policy_assignment_model_json
+            ).__dict__
+        )
+        get_policy_assignment_response_policy_assignment_model2 = GetPolicyAssignmentResponsePolicyAssignment(
+            **get_policy_assignment_response_policy_assignment_model_dict
+        )
+
+        # Verify the model instances are equivalent
+        assert (
+            get_policy_assignment_response_policy_assignment_model
+            == get_policy_assignment_response_policy_assignment_model2
+        )
+
+        # Convert model instance back to dict and verify no loss of data
+        get_policy_assignment_response_policy_assignment_model_json2 = (
+            get_policy_assignment_response_policy_assignment_model.to_dict()
+        )
+        assert (
+            get_policy_assignment_response_policy_assignment_model_json2
+            == get_policy_assignment_response_policy_assignment_model_json
+        )
+
+
+class TestModel_GetPolicyAssignmentResponsePolicyAssignmentV1:
+    """
+    Test Class for GetPolicyAssignmentResponsePolicyAssignmentV1
+    """
+
+    def test_get_policy_assignment_response_policy_assignment_v1_serialization(self):
+        """
+        Test serialization/deserialization for GetPolicyAssignmentResponsePolicyAssignmentV1
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        assignment_target_details_model = {}  # AssignmentTargetDetails
+        assignment_target_details_model['type'] = 'Account'
+        assignment_target_details_model['id'] = 'testString'
+
+        policy_assignment_v1_options_root_template_model = {}  # PolicyAssignmentV1OptionsRootTemplate
+        policy_assignment_v1_options_root_template_model['id'] = 'testString'
+        policy_assignment_v1_options_root_template_model['version'] = 'testString'
+
+        policy_assignment_v1_options_root_model = {}  # PolicyAssignmentV1OptionsRoot
+        policy_assignment_v1_options_root_model['requester_id'] = 'testString'
+        policy_assignment_v1_options_root_model['assignment_id'] = 'testString'
+        policy_assignment_v1_options_root_model['template'] = policy_assignment_v1_options_root_template_model
+
+        policy_assignment_v1_options_model = {}  # PolicyAssignmentV1Options
+        policy_assignment_v1_options_model['root'] = policy_assignment_v1_options_root_model
+
+        assignment_template_details_model = {}  # AssignmentTemplateDetails
+        assignment_template_details_model['id'] = 'testString'
+        assignment_template_details_model['version'] = 'testString'
+
+        assignment_resource_created_model = {}  # AssignmentResourceCreated
+        assignment_resource_created_model['id'] = 'testString'
+
+        conflicts_with_model = {}  # ConflictsWith
+        conflicts_with_model['etag'] = 'testString'
+        conflicts_with_model['role'] = 'testString'
+        conflicts_with_model['policy'] = 'testString'
+
+        error_details_model = {}  # ErrorDetails
+        error_details_model['conflicts_with'] = conflicts_with_model
+
+        error_object_model = {}  # ErrorObject
+        error_object_model['code'] = 'insufficent_permissions'
+        error_object_model['message'] = 'testString'
+        error_object_model['details'] = error_details_model
+        error_object_model['more_info'] = 'testString'
+
+        error_response_model = {}  # ErrorResponse
+        error_response_model['trace'] = 'testString'
+        error_response_model['errors'] = [error_object_model]
+        error_response_model['status_code'] = 38
+
+        policy_assignment_resource_policy_model = {}  # PolicyAssignmentResourcePolicy
+        policy_assignment_resource_policy_model['resource_created'] = assignment_resource_created_model
+        policy_assignment_resource_policy_model['status'] = 'testString'
+        policy_assignment_resource_policy_model['error_message'] = error_response_model
+
+        policy_assignment_v1_resources_model = {}  # PolicyAssignmentV1Resources
+        policy_assignment_v1_resources_model['target'] = assignment_template_details_model
+        policy_assignment_v1_resources_model['policy'] = policy_assignment_resource_policy_model
+
+        get_policy_assignment_response_policy_assignment_v1_subject_model = (
+            {}
+        )  # GetPolicyAssignmentResponsePolicyAssignmentV1Subject
+
+        # Construct a json representation of a GetPolicyAssignmentResponsePolicyAssignmentV1 model
+        get_policy_assignment_response_policy_assignment_v1_model_json = {}
+        get_policy_assignment_response_policy_assignment_v1_model_json['target'] = assignment_target_details_model
+        get_policy_assignment_response_policy_assignment_v1_model_json['options'] = policy_assignment_v1_options_model
+        get_policy_assignment_response_policy_assignment_v1_model_json['resources'] = [
+            policy_assignment_v1_resources_model
+        ]
+        get_policy_assignment_response_policy_assignment_v1_model_json['subject'] = (
+            get_policy_assignment_response_policy_assignment_v1_subject_model
+        )
+        get_policy_assignment_response_policy_assignment_v1_model_json['template'] = assignment_template_details_model
+        get_policy_assignment_response_policy_assignment_v1_model_json['status'] = 'in_progress'
+
+        # Construct a model instance of GetPolicyAssignmentResponsePolicyAssignmentV1 by calling from_dict on the json representation
+        get_policy_assignment_response_policy_assignment_v1_model = (
+            GetPolicyAssignmentResponsePolicyAssignmentV1.from_dict(
+                get_policy_assignment_response_policy_assignment_v1_model_json
+            )
+        )
+        assert get_policy_assignment_response_policy_assignment_v1_model != False
+
+        # Construct a model instance of GetPolicyAssignmentResponsePolicyAssignmentV1 by calling from_dict on the json representation
+        get_policy_assignment_response_policy_assignment_v1_model_dict = (
+            GetPolicyAssignmentResponsePolicyAssignmentV1.from_dict(
+                get_policy_assignment_response_policy_assignment_v1_model_json
+            ).__dict__
+        )
+        get_policy_assignment_response_policy_assignment_v1_model2 = GetPolicyAssignmentResponsePolicyAssignmentV1(
+            **get_policy_assignment_response_policy_assignment_v1_model_dict
+        )
+
+        # Verify the model instances are equivalent
+        assert (
+            get_policy_assignment_response_policy_assignment_v1_model
+            == get_policy_assignment_response_policy_assignment_v1_model2
+        )
+
+        # Convert model instance back to dict and verify no loss of data
+        get_policy_assignment_response_policy_assignment_v1_model_json2 = (
+            get_policy_assignment_response_policy_assignment_v1_model.to_dict()
+        )
+        assert (
+            get_policy_assignment_response_policy_assignment_v1_model_json2
+            == get_policy_assignment_response_policy_assignment_v1_model_json
+        )
+
+
 class TestModel_NestedConditionRuleAttribute:
     """
     Test Class for NestedConditionRuleAttribute
@@ -6436,6 +7675,211 @@ class TestModel_NestedConditionRuleWithConditions:
         # Convert model instance back to dict and verify no loss of data
         nested_condition_rule_with_conditions_model_json2 = nested_condition_rule_with_conditions_model.to_dict()
         assert nested_condition_rule_with_conditions_model_json2 == nested_condition_rule_with_conditions_model_json
+
+
+class TestModel_PolicyTemplateAssignmentItemsPolicyAssignment:
+    """
+    Test Class for PolicyTemplateAssignmentItemsPolicyAssignment
+    """
+
+    def test_policy_template_assignment_items_policy_assignment_serialization(self):
+        """
+        Test serialization/deserialization for PolicyTemplateAssignmentItemsPolicyAssignment
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        policy_assignment_options_model = {}  # PolicyAssignmentOptions
+        policy_assignment_options_model['subject_type'] = 'iam_id'
+        policy_assignment_options_model['subject_id'] = 'testString'
+        policy_assignment_options_model['root_requester_id'] = 'testString'
+        policy_assignment_options_model['root_template_id'] = 'testString'
+        policy_assignment_options_model['root_template_version'] = 'testString'
+
+        assignment_resource_created_model = {}  # AssignmentResourceCreated
+        assignment_resource_created_model['id'] = 'testString'
+
+        conflicts_with_model = {}  # ConflictsWith
+        conflicts_with_model['etag'] = 'testString'
+        conflicts_with_model['role'] = 'testString'
+        conflicts_with_model['policy'] = 'testString'
+
+        error_details_model = {}  # ErrorDetails
+        error_details_model['conflicts_with'] = conflicts_with_model
+
+        error_object_model = {}  # ErrorObject
+        error_object_model['code'] = 'insufficent_permissions'
+        error_object_model['message'] = 'testString'
+        error_object_model['details'] = error_details_model
+        error_object_model['more_info'] = 'testString'
+
+        error_response_model = {}  # ErrorResponse
+        error_response_model['trace'] = 'testString'
+        error_response_model['errors'] = [error_object_model]
+        error_response_model['status_code'] = 38
+
+        policy_assignment_resource_policy_model = {}  # PolicyAssignmentResourcePolicy
+        policy_assignment_resource_policy_model['resource_created'] = assignment_resource_created_model
+        policy_assignment_resource_policy_model['status'] = 'testString'
+        policy_assignment_resource_policy_model['error_message'] = error_response_model
+
+        policy_assignment_resources_model = {}  # PolicyAssignmentResources
+        policy_assignment_resources_model['target'] = 'testString'
+        policy_assignment_resources_model['policy'] = policy_assignment_resource_policy_model
+
+        # Construct a json representation of a PolicyTemplateAssignmentItemsPolicyAssignment model
+        policy_template_assignment_items_policy_assignment_model_json = {}
+        policy_template_assignment_items_policy_assignment_model_json['template_id'] = 'testString'
+        policy_template_assignment_items_policy_assignment_model_json['template_version'] = 'testString'
+        policy_template_assignment_items_policy_assignment_model_json['assignment_id'] = 'testString'
+        policy_template_assignment_items_policy_assignment_model_json['target_type'] = 'Account'
+        policy_template_assignment_items_policy_assignment_model_json['target'] = 'testString'
+        policy_template_assignment_items_policy_assignment_model_json['options'] = [policy_assignment_options_model]
+        policy_template_assignment_items_policy_assignment_model_json['resources'] = [policy_assignment_resources_model]
+        policy_template_assignment_items_policy_assignment_model_json['status'] = 'in_progress'
+
+        # Construct a model instance of PolicyTemplateAssignmentItemsPolicyAssignment by calling from_dict on the json representation
+        policy_template_assignment_items_policy_assignment_model = (
+            PolicyTemplateAssignmentItemsPolicyAssignment.from_dict(
+                policy_template_assignment_items_policy_assignment_model_json
+            )
+        )
+        assert policy_template_assignment_items_policy_assignment_model != False
+
+        # Construct a model instance of PolicyTemplateAssignmentItemsPolicyAssignment by calling from_dict on the json representation
+        policy_template_assignment_items_policy_assignment_model_dict = (
+            PolicyTemplateAssignmentItemsPolicyAssignment.from_dict(
+                policy_template_assignment_items_policy_assignment_model_json
+            ).__dict__
+        )
+        policy_template_assignment_items_policy_assignment_model2 = PolicyTemplateAssignmentItemsPolicyAssignment(
+            **policy_template_assignment_items_policy_assignment_model_dict
+        )
+
+        # Verify the model instances are equivalent
+        assert (
+            policy_template_assignment_items_policy_assignment_model
+            == policy_template_assignment_items_policy_assignment_model2
+        )
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_template_assignment_items_policy_assignment_model_json2 = (
+            policy_template_assignment_items_policy_assignment_model.to_dict()
+        )
+        assert (
+            policy_template_assignment_items_policy_assignment_model_json2
+            == policy_template_assignment_items_policy_assignment_model_json
+        )
+
+
+class TestModel_PolicyTemplateAssignmentItemsPolicyAssignmentV1:
+    """
+    Test Class for PolicyTemplateAssignmentItemsPolicyAssignmentV1
+    """
+
+    def test_policy_template_assignment_items_policy_assignment_v1_serialization(self):
+        """
+        Test serialization/deserialization for PolicyTemplateAssignmentItemsPolicyAssignmentV1
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        assignment_target_details_model = {}  # AssignmentTargetDetails
+        assignment_target_details_model['type'] = 'Account'
+        assignment_target_details_model['id'] = 'testString'
+
+        policy_assignment_v1_options_root_template_model = {}  # PolicyAssignmentV1OptionsRootTemplate
+        policy_assignment_v1_options_root_template_model['id'] = 'testString'
+        policy_assignment_v1_options_root_template_model['version'] = 'testString'
+
+        policy_assignment_v1_options_root_model = {}  # PolicyAssignmentV1OptionsRoot
+        policy_assignment_v1_options_root_model['requester_id'] = 'testString'
+        policy_assignment_v1_options_root_model['assignment_id'] = 'testString'
+        policy_assignment_v1_options_root_model['template'] = policy_assignment_v1_options_root_template_model
+
+        policy_assignment_v1_options_model = {}  # PolicyAssignmentV1Options
+        policy_assignment_v1_options_model['root'] = policy_assignment_v1_options_root_model
+
+        assignment_template_details_model = {}  # AssignmentTemplateDetails
+        assignment_template_details_model['id'] = 'testString'
+        assignment_template_details_model['version'] = 'testString'
+
+        assignment_resource_created_model = {}  # AssignmentResourceCreated
+        assignment_resource_created_model['id'] = 'testString'
+
+        conflicts_with_model = {}  # ConflictsWith
+        conflicts_with_model['etag'] = 'testString'
+        conflicts_with_model['role'] = 'testString'
+        conflicts_with_model['policy'] = 'testString'
+
+        error_details_model = {}  # ErrorDetails
+        error_details_model['conflicts_with'] = conflicts_with_model
+
+        error_object_model = {}  # ErrorObject
+        error_object_model['code'] = 'insufficent_permissions'
+        error_object_model['message'] = 'testString'
+        error_object_model['details'] = error_details_model
+        error_object_model['more_info'] = 'testString'
+
+        error_response_model = {}  # ErrorResponse
+        error_response_model['trace'] = 'testString'
+        error_response_model['errors'] = [error_object_model]
+        error_response_model['status_code'] = 38
+
+        policy_assignment_resource_policy_model = {}  # PolicyAssignmentResourcePolicy
+        policy_assignment_resource_policy_model['resource_created'] = assignment_resource_created_model
+        policy_assignment_resource_policy_model['status'] = 'testString'
+        policy_assignment_resource_policy_model['error_message'] = error_response_model
+
+        policy_assignment_v1_resources_model = {}  # PolicyAssignmentV1Resources
+        policy_assignment_v1_resources_model['target'] = assignment_template_details_model
+        policy_assignment_v1_resources_model['policy'] = policy_assignment_resource_policy_model
+
+        policy_assignment_v1_subject_model = {}  # PolicyAssignmentV1Subject
+
+        # Construct a json representation of a PolicyTemplateAssignmentItemsPolicyAssignmentV1 model
+        policy_template_assignment_items_policy_assignment_v1_model_json = {}
+        policy_template_assignment_items_policy_assignment_v1_model_json['target'] = assignment_target_details_model
+        policy_template_assignment_items_policy_assignment_v1_model_json['options'] = policy_assignment_v1_options_model
+        policy_template_assignment_items_policy_assignment_v1_model_json['resources'] = [
+            policy_assignment_v1_resources_model
+        ]
+        policy_template_assignment_items_policy_assignment_v1_model_json['subject'] = policy_assignment_v1_subject_model
+        policy_template_assignment_items_policy_assignment_v1_model_json['template'] = assignment_template_details_model
+        policy_template_assignment_items_policy_assignment_v1_model_json['status'] = 'in_progress'
+
+        # Construct a model instance of PolicyTemplateAssignmentItemsPolicyAssignmentV1 by calling from_dict on the json representation
+        policy_template_assignment_items_policy_assignment_v1_model = (
+            PolicyTemplateAssignmentItemsPolicyAssignmentV1.from_dict(
+                policy_template_assignment_items_policy_assignment_v1_model_json
+            )
+        )
+        assert policy_template_assignment_items_policy_assignment_v1_model != False
+
+        # Construct a model instance of PolicyTemplateAssignmentItemsPolicyAssignmentV1 by calling from_dict on the json representation
+        policy_template_assignment_items_policy_assignment_v1_model_dict = (
+            PolicyTemplateAssignmentItemsPolicyAssignmentV1.from_dict(
+                policy_template_assignment_items_policy_assignment_v1_model_json
+            ).__dict__
+        )
+        policy_template_assignment_items_policy_assignment_v1_model2 = PolicyTemplateAssignmentItemsPolicyAssignmentV1(
+            **policy_template_assignment_items_policy_assignment_v1_model_dict
+        )
+
+        # Verify the model instances are equivalent
+        assert (
+            policy_template_assignment_items_policy_assignment_v1_model
+            == policy_template_assignment_items_policy_assignment_v1_model2
+        )
+
+        # Convert model instance back to dict and verify no loss of data
+        policy_template_assignment_items_policy_assignment_v1_model_json2 = (
+            policy_template_assignment_items_policy_assignment_v1_model.to_dict()
+        )
+        assert (
+            policy_template_assignment_items_policy_assignment_v1_model_json2
+            == policy_template_assignment_items_policy_assignment_v1_model_json
+        )
 
 
 class TestModel_V2PolicyRuleRuleAttribute:


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
Authorization policy type support for enterprise accounts
issue: https://github.ibm.com/IAM/AM-issues/issues/2350

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
test results:

example:
```
get_v2_assignment_policy() result:
{
  "id": "032661b9-ac63-4972-ad28-52909db77844",
  "type": "authorization",
  "subject": {
    "attributes": [
      {
        "value": "compliance",
        "operator": "stringEquals",
        "key": "serviceName"
      },
      {
        "value": "0ddc8e9eb0894383b48791ff4ba0b80e",
        "operator": "stringEquals",
        "key": "accountId"
      }
    ]
  },
  "resource": {
    "attributes": [
      {
        "value": "appid",
        "operator": "stringEquals",
        "key": "serviceName"
      },
      {
        "value": "0ddc8e9eb0894383b48791ff4ba0b80e",
        "operator": "stringEquals",
        "key": "accountId"
      }
    ]
  },
  "control": {
    "grant": {
      "roles": [
        {
          "role_id": "crn:v1:bluemix:public:iam::::serviceRole:Reader"
        }
      ]
    }
  },
  "href": "https://iam.test.cloud.ibm.com/v1/policies/032661b9-ac63-4972-ad28-52909db77844",
  "created_at": "2024-04-16T12:24:16.904Z",
  "created_by_id": "test_sdk",
  "last_modified_at": "2024-04-16T12:24:17.493Z",
  "last_modified_by_id": "test_sdk",
  "state": "active",
  "version": "v1.0",
  "template": {
    "id": "policyTemplate-5b44c0c7-eed5-4b8d-8de1-e881a1b9115d",
    "version": "2",
    "assignment_id": "policyAssignment-004f64b3-c5df-4d93-8e87-e099b7a443e3"
  }
}
.
delete_policy_assignment() response status code:  204
.
delete_policy_template() response status code:  204
.

================================================================================================================ warnings summary =================================================================================================================
../../../venv/lib/python3.9/site-packages/urllib3/__init__.py:34
  /Users/rajesh/venv/lib/python3.9/site-packages/urllib3/__init__.py:34: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================= 31 passed, 1 warning in 24.34s ==========================================================================================================
```

integration tests
```
=============================================================================================================== test session starts ===============================================================================================================
platform darwin -- Python 3.9.6, pytest-7.4.4, pluggy-1.3.0
rootdir: /Users/rajesh/iam-project/platform-sdk/platform-services-python-sdk
plugins: cov-4.1.0
collected 33 items                                                                                                                                                                                                                                

test/integration/test_iam_policy_management_v1.py .................................                                                                                                                                                         [100%]

================================================================================================================ warnings summary =================================================================================================================
../../../venv/lib/python3.9/site-packages/urllib3/__init__.py:34
  /Users/rajesh/venv/lib/python3.9/site-packages/urllib3/__init__.py:34: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================= 33 passed, 1 warning in 22.37s =======================================================================================================
```