### PR TITLE
fix: remove unused setuptools import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ibm_cloud_sdk_core>=3.20.3,<4.0.0
+ibm_cloud_sdk_core>=3.20.4,<4.0.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
 import os
 import sys
 import pkg_resources


### PR DESCRIPTION
## PR summary
This commit removes an unused `setuptools` import from the `setup.py`
file. More details about the `setuptools` mess can be found in the following
PR: https://github.com/IBM/python-sdk-core/pull/203 


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->