### PR TITLE
feat(IAM Policy Management): add access management account settings API

### DIFF
--- a/examples/test_iam_policy_management_v1_examples.py
+++ b/examples/test_iam_policy_management_v1_examples.py
@@ -60,6 +60,7 @@ example_assignment_policy_id = None
 example_updated_policy_etag = None
 example_target_account_id = None
 example_assignment_etag = None
+example_account_settings_etag = None
 
 ##############################################################################
 # Start of Examples for Service: IamPolicyManagementV1
@@ -999,6 +1000,66 @@ class TestIamPolicyManagementV1Examples:
 
             # end-delete_policy_template
             print('\ndelete_policy_template() response status code: ', response.get_status_code())
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_get_access_management_account_settings_example(self):
+        """
+        get_access_management_account_settings request example
+        """
+        try:
+            # begin-get_access_management_account_settings
+
+            response = iam_policy_management_service.get_settings(
+                account_id=example_account_id,
+                accept_language='default',
+            )
+
+            # end-get_access_management_account_settings
+            print('\nget_settings() response status code: ', response.get_status_code())
+            result = response.get_result()
+            assert result is not None
+            global example_account_settings_etag
+            example_account_settings_etag = response.get_headers().get("Etag")
+            print(json.dumps(result, indent=2))
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_update_access_management_account_settings_example(self):
+        """
+        update_access_management_account_settings request example
+        """
+        try:
+            # Construct a dict representation of a IdentityTypesBase model
+            identity_types_base_model = {'state': 'monitor', 'external_allowed_accounts': []}
+
+            # Construct a dict representation of a IdentityTypesPatch model
+            identity_types_patch_model = {
+                'user': identity_types_base_model,
+                'service_id': identity_types_base_model,
+                'service': identity_types_base_model,
+            }
+
+            # Construct a dict representation of a ExternalAccountIdentityInteractionPatch model
+            external_account_identity_interaction_patch_model = {'identity_types': identity_types_patch_model}
+            # begin-update_access_management_account_settings
+
+            response = iam_policy_management_service.update_settings(
+                account_id=example_account_id,
+                accept_language='default',
+                if_match=example_account_settings_etag,
+                external_account_identity_interaction=external_account_identity_interaction_patch_model,
+            )
+
+            # end-update_access_management_account_settings
+            print('\nupdate_settings() response status code: ', response.get_status_code())
+            result = response.get_result()
+            assert result is not None
+            print(json.dumps(result, indent=2))
 
         except ApiException as e:
             pytest.fail(str(e))

--- a/ibm_platform_services/iam_policy_management_v1.py
+++ b/ibm_platform_services/iam_policy_management_v1.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# (C) Copyright IBM Corp. 2024.
+# (C) Copyright IBM Corp. 2025.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# IBM OpenAPI SDK Code Generator Version: 3.90.1-64fd3296-20240515-180710
+# IBM OpenAPI SDK Code Generator Version: 3.102.0-615ec964-20250307-203034
 
 """
 IAM Policy Management API
@@ -90,6 +90,8 @@ class IamPolicyManagementV1(BaseService):
         sort: Optional[str] = None,
         format: Optional[str] = None,
         state: Optional[str] = None,
+        limit: Optional[int] = None,
+        start: Optional[str] = None,
         **kwargs,
     ) -> DetailedResponse:
         """
@@ -135,6 +137,10 @@ class IamPolicyManagementV1(BaseService):
         :param str state: (optional) The state of the policy.
                * `active` - returns active policies
                * `deleted` - returns non-active policies.
+        :param int limit: (optional) The number of documents to include in
+               collection.
+        :param str start: (optional) Page token that refers to the page of
+               collection to return.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `PolicyCollection` object
@@ -163,6 +169,8 @@ class IamPolicyManagementV1(BaseService):
             'sort': sort,
             'format': format,
             'state': state,
+            'limit': limit,
+            'start': start,
         }
 
         if 'headers' in kwargs:
@@ -963,6 +971,8 @@ class IamPolicyManagementV1(BaseService):
         sort: Optional[str] = None,
         format: Optional[str] = None,
         state: Optional[str] = None,
+        limit: Optional[int] = None,
+        start: Optional[str] = None,
         **kwargs,
     ) -> DetailedResponse:
         """
@@ -1019,6 +1029,10 @@ class IamPolicyManagementV1(BaseService):
         :param str state: (optional) The state of the policy.
                * `active` - returns active policies
                * `deleted` - returns non-active policies.
+        :param int limit: (optional) The number of documents to include in
+               collection.
+        :param str start: (optional) Page token that refers to the page of
+               collection to return.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `V2PolicyCollection` object
@@ -1047,6 +1061,8 @@ class IamPolicyManagementV1(BaseService):
             'sort': sort,
             'format': format,
             'state': state,
+            'limit': limit,
+            'start': start,
         }
 
         if 'headers' in kwargs:
@@ -1624,6 +1640,8 @@ class IamPolicyManagementV1(BaseService):
         policy_service_name: Optional[str] = None,
         policy_service_group_id: Optional[str] = None,
         policy_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        start: Optional[str] = None,
         **kwargs,
     ) -> DetailedResponse:
         """
@@ -1659,6 +1677,10 @@ class IamPolicyManagementV1(BaseService):
         :param str policy_service_name: (optional) Service name, Optional.
         :param str policy_service_group_id: (optional) Service group id, Optional.
         :param str policy_type: (optional) Policy type, Optional.
+        :param int limit: (optional) The number of documents to include in
+               collection.
+        :param str start: (optional) Page token that refers to the page of
+               collection to return.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `PolicyTemplateCollection` object
@@ -1684,6 +1706,8 @@ class IamPolicyManagementV1(BaseService):
             'policy_service_name': policy_service_name,
             'policy_service_group_id': policy_service_group_id,
             'policy_type': policy_type,
+            'limit': limit,
+            'start': start,
         }
 
         if 'headers' in kwargs:
@@ -1970,6 +1994,8 @@ class IamPolicyManagementV1(BaseService):
         policy_template_id: str,
         *,
         state: Optional[str] = None,
+        limit: Optional[int] = None,
+        start: Optional[str] = None,
         **kwargs,
     ) -> DetailedResponse:
         """
@@ -1979,6 +2005,10 @@ class IamPolicyManagementV1(BaseService):
 
         :param str policy_template_id: The policy template ID.
         :param str state: (optional) The policy template state.
+        :param int limit: (optional) The number of documents to include in
+               collection.
+        :param str start: (optional) Page token that refers to the page of
+               collection to return.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `PolicyTemplateVersionsCollection` object
@@ -1996,6 +2026,8 @@ class IamPolicyManagementV1(BaseService):
 
         params = {
             'state': state,
+            'limit': limit,
+            'start': start,
         }
 
         if 'headers' in kwargs:
@@ -2263,6 +2295,8 @@ class IamPolicyManagementV1(BaseService):
         accept_language: Optional[str] = None,
         template_id: Optional[str] = None,
         template_version: Optional[str] = None,
+        limit: Optional[int] = None,
+        start: Optional[str] = None,
         **kwargs,
     ) -> DetailedResponse:
         """
@@ -2292,6 +2326,10 @@ class IamPolicyManagementV1(BaseService):
                * `zh-tw` - (Chinese, Taiwan).
         :param str template_id: (optional) Optional template id.
         :param str template_version: (optional) Optional policy template version.
+        :param int limit: (optional) The number of documents to include in
+               collection.
+        :param str start: (optional) Page token that refers to the page of
+               collection to return.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `PolicyTemplateAssignmentCollection` object
@@ -2316,6 +2354,8 @@ class IamPolicyManagementV1(BaseService):
             'account_id': account_id,
             'template_id': template_id,
             'template_version': template_version,
+            'limit': limit,
+            'start': start,
         }
 
         if 'headers' in kwargs:
@@ -2432,7 +2472,7 @@ class IamPolicyManagementV1(BaseService):
         :param str version: specify version of response body format.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
-        :rtype: DetailedResponse with `dict` result representing a `GetPolicyAssignmentResponse` object
+        :rtype: DetailedResponse with `dict` result representing a `PolicyTemplateAssignmentItems` object
         """
 
         if not assignment_id:
@@ -2583,6 +2623,181 @@ class IamPolicyManagementV1(BaseService):
             method='DELETE',
             url=url,
             headers=headers,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    #########################
+    # Access Management Settings
+    #########################
+
+    def get_settings(
+        self,
+        account_id: str,
+        *,
+        accept_language: Optional[str] = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Retrieve Access Management account settings by account ID.
+
+        Retrieve Access Management settings for an account by providing the account ID.
+
+        :param str account_id: The account GUID that the settings belong to.
+        :param str accept_language: (optional) Language code for translations
+               * `default` - English
+               * `de` -  German (Standard)
+               * `en` - English
+               * `es` - Spanish (Spain)
+               * `fr` - French (Standard)
+               * `it` - Italian (Standard)
+               * `ja` - Japanese
+               * `ko` - Korean
+               * `pt-br` - Portuguese (Brazil)
+               * `zh-cn` - Chinese (Simplified, PRC)
+               * `zh-tw` - (Chinese, Taiwan).
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `AccountSettingsAccessManagement` object
+        """
+
+        if not account_id:
+            raise ValueError('account_id must be provided')
+        headers = {
+            'Accept-Language': accept_language,
+        }
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='get_settings',
+        )
+        headers.update(sdk_headers)
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['account_id']
+        path_param_values = self.encode_path_vars(account_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/accounts/{account_id}/settings/access_management'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='GET',
+            url=url,
+            headers=headers,
+        )
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def update_settings(
+        self,
+        account_id: str,
+        if_match: str,
+        *,
+        external_account_identity_interaction: Optional['ExternalAccountIdentityInteractionPatch'] = None,
+        accept_language: Optional[str] = None,
+        **kwargs,
+    ) -> DetailedResponse:
+        """
+        Update Access Management account settings by account ID.
+
+        Update access management settings for an account.
+        ### External Account Identity Interaction
+        Update the way identities within an external account are allowed to interact with
+        the requested account by providing:
+        * the `account_id` as a parameter
+        * the external account ID(s) and state for the specific identity in the request
+        body
+        External account identity interaction includes the following `identity_types`:
+        `user` (user identities defined as
+        [IBMid's](https://test.cloud.ibm.com/docs/account?topic=account-identity-overview#users-bestpract)),
+        `service_id` (defined as [IAM
+        ServiceIds](https://test.cloud.ibm.com/docs/account?topic=account-identity-overview#serviceid-bestpract)),
+        `service` (defined by a service’s
+        [CRN](https://test.cloud.ibm.com/docs/account?topic=account-crn)). To update an
+        Identity’s setting, the `state` and `external_allowed_accounts` fields are
+        required.
+        Different identity states are:
+        * "enabled": An identity type is allowed to access resources in the account
+        provided it has access policies on those resources.
+        * "limited": An identity type is allowed to access resources in the account
+        provided it has access policies on those resources AND it is associated with
+        either the account the resources are in or one of the allowed accounts. This
+        setting leverages the "external_allowed_accounts" list.
+        * "monitor": Has no direct impact on an Identity’s access. Instead, it creates AT
+        events for access decisions as if the account were in a limited “state”.
+        **Note**: The state "enabled" is a special case. In this case, access is given to
+        all accounts and there is no need to specify a particular list. Therefore, when
+        updating "state" to "enabled" for an identity type "external_allowed_accounts"
+        should be left empty.
+
+        :param str account_id: The account GUID that the settings belong to.
+        :param str if_match: The revision number for updating Access Management
+               Account Settings and must match the ETag value of the existing Access
+               Management Account Settings. The Etag can be retrieved using the GET
+               /v1/accounts/{account_id}/settings/access_management API and looking at the
+               ETag response header.
+        :param ExternalAccountIdentityInteractionPatch
+               external_account_identity_interaction: (optional) Update to how external
+               accounts can interact in relation to the requested account.
+        :param str accept_language: (optional) Language code for translations
+               * `default` - English
+               * `de` -  German (Standard)
+               * `en` - English
+               * `es` - Spanish (Spain)
+               * `fr` - French (Standard)
+               * `it` - Italian (Standard)
+               * `ja` - Japanese
+               * `ko` - Korean
+               * `pt-br` - Portuguese (Brazil)
+               * `zh-cn` - Chinese (Simplified, PRC)
+               * `zh-tw` - (Chinese, Taiwan).
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `AccountSettingsAccessManagement` object
+        """
+
+        if not account_id:
+            raise ValueError('account_id must be provided')
+        if not if_match:
+            raise ValueError('if_match must be provided')
+        if external_account_identity_interaction is not None:
+            external_account_identity_interaction = convert_model(external_account_identity_interaction)
+        headers = {
+            'If-Match': if_match,
+            'Accept-Language': accept_language,
+        }
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V1',
+            operation_id='update_settings',
+        )
+        headers.update(sdk_headers)
+
+        data = {
+            'external_account_identity_interaction': external_account_identity_interaction,
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['account_id']
+        path_param_values = self.encode_path_vars(account_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v1/accounts/{account_id}/settings/access_management'.format(**path_param_dict)
+        request = self.prepare_request(
+            method='PATCH',
+            url=url,
+            headers=headers,
+            data=data,
         )
 
         response = self.send(request, **kwargs)
@@ -2771,6 +2986,79 @@ class ListPolicyTemplateVersionsEnums:
 ##############################################################################
 # Models
 ##############################################################################
+
+
+class AccountSettingsAccessManagement:
+    """
+    The Access Management Account Settings that are currently set for the requested
+    account.
+
+    :param ExternalAccountIdentityInteraction external_account_identity_interaction:
+          How external accounts can interact in relation to the requested account.
+    """
+
+    def __init__(
+        self,
+        external_account_identity_interaction: 'ExternalAccountIdentityInteraction',
+    ) -> None:
+        """
+        Initialize a AccountSettingsAccessManagement object.
+
+        :param ExternalAccountIdentityInteraction
+               external_account_identity_interaction: How external accounts can interact
+               in relation to the requested account.
+        """
+        self.external_account_identity_interaction = external_account_identity_interaction
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'AccountSettingsAccessManagement':
+        """Initialize a AccountSettingsAccessManagement object from a json dictionary."""
+        args = {}
+        if (external_account_identity_interaction := _dict.get('external_account_identity_interaction')) is not None:
+            args['external_account_identity_interaction'] = ExternalAccountIdentityInteraction.from_dict(
+                external_account_identity_interaction
+            )
+        else:
+            raise ValueError(
+                'Required property \'external_account_identity_interaction\' not present in AccountSettingsAccessManagement JSON'
+            )
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a AccountSettingsAccessManagement object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if (
+            hasattr(self, 'external_account_identity_interaction')
+            and self.external_account_identity_interaction is not None
+        ):
+            if isinstance(self.external_account_identity_interaction, dict):
+                _dict['external_account_identity_interaction'] = self.external_account_identity_interaction
+            else:
+                _dict['external_account_identity_interaction'] = self.external_account_identity_interaction.to_dict()
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this AccountSettingsAccessManagement object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'AccountSettingsAccessManagement') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'AccountSettingsAccessManagement') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
 
 
 class AssignmentResourceCreated:
@@ -3566,6 +3854,7 @@ class ErrorObject:
         POLICY_TEMPLATE_NOT_FOUND = 'policy_template_not_found'
         POLICY_ASSIGNMENT_NOT_FOUND = 'policy_assignment_not_found'
         POLICY_ASSIGNMENT_CONFLICT_ERROR = 'policy_assignment_conflict_error'
+        RESOURCE_NOT_FOUND = 'resource_not_found'
 
 
 class ErrorResponse:
@@ -3650,68 +3939,49 @@ class ErrorResponse:
         return not self == other
 
 
-class GetPolicyAssignmentResponse:
+class ExternalAccountIdentityInteraction:
     """
-    GetPolicyAssignmentResponse.
+    How external accounts can interact in relation to the requested account.
 
-    """
-
-    def __init__(
-        self,
-    ) -> None:
-        """
-        Initialize a GetPolicyAssignmentResponse object.
-
-        """
-        msg = "Cannot instantiate base class. Instead, instantiate one of the defined subclasses: {0}".format(
-            ", ".join(['GetPolicyAssignmentResponsePolicyAssignmentV1', 'GetPolicyAssignmentResponsePolicyAssignment'])
-        )
-        raise Exception(msg)
-
-
-class GetPolicyAssignmentResponsePolicyAssignmentV1Subject:
-    """
-    subject details of access type assignment.
-
-    :param str id: (optional)
-    :param str type: (optional)
+    :param IdentityTypes identity_types: The settings for each identity type.
     """
 
     def __init__(
         self,
-        *,
-        id: Optional[str] = None,
-        type: Optional[str] = None,
+        identity_types: 'IdentityTypes',
     ) -> None:
         """
-        Initialize a GetPolicyAssignmentResponsePolicyAssignmentV1Subject object.
+        Initialize a ExternalAccountIdentityInteraction object.
 
+        :param IdentityTypes identity_types: The settings for each identity type.
         """
-        self.id = id
-        self.type = type
+        self.identity_types = identity_types
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> 'GetPolicyAssignmentResponsePolicyAssignmentV1Subject':
-        """Initialize a GetPolicyAssignmentResponsePolicyAssignmentV1Subject object from a json dictionary."""
+    def from_dict(cls, _dict: Dict) -> 'ExternalAccountIdentityInteraction':
+        """Initialize a ExternalAccountIdentityInteraction object from a json dictionary."""
         args = {}
-        if (id := _dict.get('id')) is not None:
-            args['id'] = id
-        if (type := _dict.get('type')) is not None:
-            args['type'] = type
+        if (identity_types := _dict.get('identity_types')) is not None:
+            args['identity_types'] = IdentityTypes.from_dict(identity_types)
+        else:
+            raise ValueError(
+                'Required property \'identity_types\' not present in ExternalAccountIdentityInteraction JSON'
+            )
         return cls(**args)
 
     @classmethod
     def _from_dict(cls, _dict):
-        """Initialize a GetPolicyAssignmentResponsePolicyAssignmentV1Subject object from a json dictionary."""
+        """Initialize a ExternalAccountIdentityInteraction object from a json dictionary."""
         return cls.from_dict(_dict)
 
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, 'id') and getattr(self, 'id') is not None:
-            _dict['id'] = getattr(self, 'id')
-        if hasattr(self, 'type') and getattr(self, 'type') is not None:
-            _dict['type'] = getattr(self, 'type')
+        if hasattr(self, 'identity_types') and self.identity_types is not None:
+            if isinstance(self.identity_types, dict):
+                _dict['identity_types'] = self.identity_types
+            else:
+                _dict['identity_types'] = self.identity_types.to_dict()
         return _dict
 
     def _to_dict(self):
@@ -3719,26 +3989,139 @@ class GetPolicyAssignmentResponsePolicyAssignmentV1Subject:
         return self.to_dict()
 
     def __str__(self) -> str:
-        """Return a `str` version of this GetPolicyAssignmentResponsePolicyAssignmentV1Subject object."""
+        """Return a `str` version of this ExternalAccountIdentityInteraction object."""
         return json.dumps(self.to_dict(), indent=2)
 
-    def __eq__(self, other: 'GetPolicyAssignmentResponsePolicyAssignmentV1Subject') -> bool:
+    def __eq__(self, other: 'ExternalAccountIdentityInteraction') -> bool:
         """Return `true` when self and other are equal, false otherwise."""
         if not isinstance(other, self.__class__):
             return False
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: 'GetPolicyAssignmentResponsePolicyAssignmentV1Subject') -> bool:
+    def __ne__(self, other: 'ExternalAccountIdentityInteraction') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
-    class TypeEnum(str, Enum):
-        """
-        type.
-        """
 
-        IAM_ID = 'iam_id'
-        ACCESS_GROUP_ID = 'access_group_id'
+class ExternalAccountIdentityInteractionPatch:
+    """
+    Update to how external accounts can interact in relation to the requested account.
+
+    :param IdentityTypesPatch identity_types: (optional) The settings to apply for
+          each identity type for a request.
+    """
+
+    def __init__(
+        self,
+        *,
+        identity_types: Optional['IdentityTypesPatch'] = None,
+    ) -> None:
+        """
+        Initialize a ExternalAccountIdentityInteractionPatch object.
+
+        :param IdentityTypesPatch identity_types: (optional) The settings to apply
+               for each identity type for a request.
+        """
+        self.identity_types = identity_types
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'ExternalAccountIdentityInteractionPatch':
+        """Initialize a ExternalAccountIdentityInteractionPatch object from a json dictionary."""
+        args = {}
+        if (identity_types := _dict.get('identity_types')) is not None:
+            args['identity_types'] = IdentityTypesPatch.from_dict(identity_types)
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a ExternalAccountIdentityInteractionPatch object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'identity_types') and self.identity_types is not None:
+            if isinstance(self.identity_types, dict):
+                _dict['identity_types'] = self.identity_types
+            else:
+                _dict['identity_types'] = self.identity_types.to_dict()
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this ExternalAccountIdentityInteractionPatch object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'ExternalAccountIdentityInteractionPatch') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'ExternalAccountIdentityInteractionPatch') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class First:
+    """
+    Details with href linking to first page of requested collection.
+
+    :param str href: (optional) The href linking to the page of requested
+          collection.
+    """
+
+    def __init__(
+        self,
+        *,
+        href: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize a First object.
+
+        """
+        self.href = href
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'First':
+        """Initialize a First object from a json dictionary."""
+        args = {}
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a First object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'href') and getattr(self, 'href') is not None:
+            _dict['href'] = getattr(self, 'href')
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this First object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'First') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'First') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
 
 
 class Grant:
@@ -3874,6 +4257,269 @@ class GrantWithEnrichedRoles:
         return not self == other
 
 
+class IdentityTypes:
+    """
+    The settings for each identity type.
+
+    :param IdentityTypesBase user: The core set of properties associated with an
+          identity type.
+    :param IdentityTypesBase service_id: The core set of properties associated with
+          an identity type.
+    :param IdentityTypesBase service: The core set of properties associated with an
+          identity type.
+    """
+
+    def __init__(
+        self,
+        user: 'IdentityTypesBase',
+        service_id: 'IdentityTypesBase',
+        service: 'IdentityTypesBase',
+    ) -> None:
+        """
+        Initialize a IdentityTypes object.
+
+        :param IdentityTypesBase user: The core set of properties associated with
+               an identity type.
+        :param IdentityTypesBase service_id: The core set of properties associated
+               with an identity type.
+        :param IdentityTypesBase service: The core set of properties associated
+               with an identity type.
+        """
+        self.user = user
+        self.service_id = service_id
+        self.service = service
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'IdentityTypes':
+        """Initialize a IdentityTypes object from a json dictionary."""
+        args = {}
+        if (user := _dict.get('user')) is not None:
+            args['user'] = IdentityTypesBase.from_dict(user)
+        else:
+            raise ValueError('Required property \'user\' not present in IdentityTypes JSON')
+        if (service_id := _dict.get('service_id')) is not None:
+            args['service_id'] = IdentityTypesBase.from_dict(service_id)
+        else:
+            raise ValueError('Required property \'service_id\' not present in IdentityTypes JSON')
+        if (service := _dict.get('service')) is not None:
+            args['service'] = IdentityTypesBase.from_dict(service)
+        else:
+            raise ValueError('Required property \'service\' not present in IdentityTypes JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a IdentityTypes object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'user') and self.user is not None:
+            if isinstance(self.user, dict):
+                _dict['user'] = self.user
+            else:
+                _dict['user'] = self.user.to_dict()
+        if hasattr(self, 'service_id') and self.service_id is not None:
+            if isinstance(self.service_id, dict):
+                _dict['service_id'] = self.service_id
+            else:
+                _dict['service_id'] = self.service_id.to_dict()
+        if hasattr(self, 'service') and self.service is not None:
+            if isinstance(self.service, dict):
+                _dict['service'] = self.service
+            else:
+                _dict['service'] = self.service.to_dict()
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this IdentityTypes object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'IdentityTypes') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'IdentityTypes') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class IdentityTypesBase:
+    """
+    The core set of properties associated with an identity type.
+
+    :param str state: The state of the identity type.
+    :param List[str] external_allowed_accounts: List of accounts that the state
+          applies to for a given identity.
+    """
+
+    def __init__(
+        self,
+        state: str,
+        external_allowed_accounts: List[str],
+    ) -> None:
+        """
+        Initialize a IdentityTypesBase object.
+
+        :param str state: The state of the identity type.
+        :param List[str] external_allowed_accounts: List of accounts that the state
+               applies to for a given identity.
+        """
+        self.state = state
+        self.external_allowed_accounts = external_allowed_accounts
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'IdentityTypesBase':
+        """Initialize a IdentityTypesBase object from a json dictionary."""
+        args = {}
+        if (state := _dict.get('state')) is not None:
+            args['state'] = state
+        else:
+            raise ValueError('Required property \'state\' not present in IdentityTypesBase JSON')
+        if (external_allowed_accounts := _dict.get('external_allowed_accounts')) is not None:
+            args['external_allowed_accounts'] = external_allowed_accounts
+        else:
+            raise ValueError('Required property \'external_allowed_accounts\' not present in IdentityTypesBase JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a IdentityTypesBase object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'state') and self.state is not None:
+            _dict['state'] = self.state
+        if hasattr(self, 'external_allowed_accounts') and self.external_allowed_accounts is not None:
+            _dict['external_allowed_accounts'] = self.external_allowed_accounts
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this IdentityTypesBase object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'IdentityTypesBase') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'IdentityTypesBase') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class StateEnum(str, Enum):
+        """
+        The state of the identity type.
+        """
+
+        ENABLED = 'enabled'
+        MONITOR = 'monitor'
+        LIMITED = 'limited'
+
+
+class IdentityTypesPatch:
+    """
+    The settings to apply for each identity type for a request.
+
+    :param IdentityTypesBase user: (optional) The core set of properties associated
+          with an identity type.
+    :param IdentityTypesBase service_id: (optional) The core set of properties
+          associated with an identity type.
+    :param IdentityTypesBase service: (optional) The core set of properties
+          associated with an identity type.
+    """
+
+    def __init__(
+        self,
+        *,
+        user: Optional['IdentityTypesBase'] = None,
+        service_id: Optional['IdentityTypesBase'] = None,
+        service: Optional['IdentityTypesBase'] = None,
+    ) -> None:
+        """
+        Initialize a IdentityTypesPatch object.
+
+        :param IdentityTypesBase user: (optional) The core set of properties
+               associated with an identity type.
+        :param IdentityTypesBase service_id: (optional) The core set of properties
+               associated with an identity type.
+        :param IdentityTypesBase service: (optional) The core set of properties
+               associated with an identity type.
+        """
+        self.user = user
+        self.service_id = service_id
+        self.service = service
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'IdentityTypesPatch':
+        """Initialize a IdentityTypesPatch object from a json dictionary."""
+        args = {}
+        if (user := _dict.get('user')) is not None:
+            args['user'] = IdentityTypesBase.from_dict(user)
+        if (service_id := _dict.get('service_id')) is not None:
+            args['service_id'] = IdentityTypesBase.from_dict(service_id)
+        if (service := _dict.get('service')) is not None:
+            args['service'] = IdentityTypesBase.from_dict(service)
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a IdentityTypesPatch object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'user') and self.user is not None:
+            if isinstance(self.user, dict):
+                _dict['user'] = self.user
+            else:
+                _dict['user'] = self.user.to_dict()
+        if hasattr(self, 'service_id') and self.service_id is not None:
+            if isinstance(self.service_id, dict):
+                _dict['service_id'] = self.service_id
+            else:
+                _dict['service_id'] = self.service_id.to_dict()
+        if hasattr(self, 'service') and self.service is not None:
+            if isinstance(self.service, dict):
+                _dict['service'] = self.service
+            else:
+                _dict['service'] = self.service.to_dict()
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this IdentityTypesPatch object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'IdentityTypesPatch') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'IdentityTypesPatch') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class LimitData:
     """
     policy template current and limit details with in an account.
@@ -3955,6 +4601,73 @@ class NestedCondition:
             ", ".join(['NestedConditionRuleAttribute', 'NestedConditionRuleWithConditions'])
         )
         raise Exception(msg)
+
+
+class Next:
+    """
+    Details with href linking to following page of requested collection.
+
+    :param str href: (optional) The href linking to the page of requested
+          collection.
+    :param str start: (optional) Page token that refers to the page of collection.
+    """
+
+    def __init__(
+        self,
+        *,
+        href: Optional[str] = None,
+        start: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize a Next object.
+
+        :param str start: (optional) Page token that refers to the page of
+               collection.
+        """
+        self.href = href
+        self.start = start
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'Next':
+        """Initialize a Next object from a json dictionary."""
+        args = {}
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
+        if (start := _dict.get('start')) is not None:
+            args['start'] = start
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a Next object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'href') and getattr(self, 'href') is not None:
+            _dict['href'] = getattr(self, 'href')
+        if hasattr(self, 'start') and self.start is not None:
+            _dict['start'] = self.start
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this Next object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'Next') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'Next') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
 
 
 class Policy:
@@ -4619,8 +5332,9 @@ class PolicyAssignmentV1Subject:
     """
     subject details of access type assignment.
 
-    :param str id: (optional)
-    :param str type: (optional)
+    :param str id: (optional) The unique identifier of the subject of the
+          assignment.
+    :param str type: (optional) The identity type of the subject of the assignment.
     """
 
     def __init__(
@@ -4680,7 +5394,7 @@ class PolicyAssignmentV1Subject:
 
     class TypeEnum(str, Enum):
         """
-        type.
+        The identity type of the subject of the assignment.
         """
 
         IAM_ID = 'iam_id'
@@ -4691,25 +5405,57 @@ class PolicyCollection:
     """
     A collection of policies.
 
+    :param int limit: (optional) The number of documents to include per each page of
+          collection.
+    :param First first: (optional) Details with href linking to first page of
+          requested collection.
+    :param Next next: (optional) Details with href linking to following page of
+          requested collection.
+    :param Previous previous: (optional) Details with href linking to previous page
+          of requested collection.
     :param List[PolicyTemplateMetaData] policies: (optional) List of policies.
     """
 
     def __init__(
         self,
         *,
+        limit: Optional[int] = None,
+        first: Optional['First'] = None,
+        next: Optional['Next'] = None,
+        previous: Optional['Previous'] = None,
         policies: Optional[List['PolicyTemplateMetaData']] = None,
     ) -> None:
         """
         Initialize a PolicyCollection object.
 
+        :param int limit: (optional) The number of documents to include per each
+               page of collection.
+        :param First first: (optional) Details with href linking to first page of
+               requested collection.
+        :param Next next: (optional) Details with href linking to following page of
+               requested collection.
+        :param Previous previous: (optional) Details with href linking to previous
+               page of requested collection.
         :param List[PolicyTemplateMetaData] policies: (optional) List of policies.
         """
+        self.limit = limit
+        self.first = first
+        self.next = next
+        self.previous = previous
         self.policies = policies
 
     @classmethod
     def from_dict(cls, _dict: Dict) -> 'PolicyCollection':
         """Initialize a PolicyCollection object from a json dictionary."""
         args = {}
+        if (limit := _dict.get('limit')) is not None:
+            args['limit'] = limit
+        if (first := _dict.get('first')) is not None:
+            args['first'] = First.from_dict(first)
+        if (next := _dict.get('next')) is not None:
+            args['next'] = Next.from_dict(next)
+        if (previous := _dict.get('previous')) is not None:
+            args['previous'] = Previous.from_dict(previous)
         if (policies := _dict.get('policies')) is not None:
             args['policies'] = [PolicyTemplateMetaData.from_dict(v) for v in policies]
         return cls(**args)
@@ -4722,6 +5468,23 @@ class PolicyCollection:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
+        if hasattr(self, 'limit') and self.limit is not None:
+            _dict['limit'] = self.limit
+        if hasattr(self, 'first') and self.first is not None:
+            if isinstance(self.first, dict):
+                _dict['first'] = self.first
+            else:
+                _dict['first'] = self.first.to_dict()
+        if hasattr(self, 'next') and self.next is not None:
+            if isinstance(self.next, dict):
+                _dict['next'] = self.next
+            else:
+                _dict['next'] = self.next.to_dict()
+        if hasattr(self, 'previous') and self.previous is not None:
+            if isinstance(self.previous, dict):
+                _dict['previous'] = self.previous
+            else:
+                _dict['previous'] = self.previous.to_dict()
         if hasattr(self, 'policies') and self.policies is not None:
             policies_list = []
             for v in self.policies:
@@ -5162,6 +5925,14 @@ class PolicyTemplateAssignmentCollection:
     """
     A collection of policies assignments.
 
+    :param int limit: (optional) The number of documents to include per each page of
+          collection.
+    :param First first: (optional) Details with href linking to first page of
+          requested collection.
+    :param Next next: (optional) Details with href linking to following page of
+          requested collection.
+    :param Previous previous: (optional) Details with href linking to previous page
+          of requested collection.
     :param List[PolicyTemplateAssignmentItems] assignments: (optional) List of
           policy assignments.
     """
@@ -5169,20 +5940,44 @@ class PolicyTemplateAssignmentCollection:
     def __init__(
         self,
         *,
+        limit: Optional[int] = None,
+        first: Optional['First'] = None,
+        next: Optional['Next'] = None,
+        previous: Optional['Previous'] = None,
         assignments: Optional[List['PolicyTemplateAssignmentItems']] = None,
     ) -> None:
         """
         Initialize a PolicyTemplateAssignmentCollection object.
 
+        :param int limit: (optional) The number of documents to include per each
+               page of collection.
+        :param First first: (optional) Details with href linking to first page of
+               requested collection.
+        :param Next next: (optional) Details with href linking to following page of
+               requested collection.
+        :param Previous previous: (optional) Details with href linking to previous
+               page of requested collection.
         :param List[PolicyTemplateAssignmentItems] assignments: (optional) List of
                policy assignments.
         """
+        self.limit = limit
+        self.first = first
+        self.next = next
+        self.previous = previous
         self.assignments = assignments
 
     @classmethod
     def from_dict(cls, _dict: Dict) -> 'PolicyTemplateAssignmentCollection':
         """Initialize a PolicyTemplateAssignmentCollection object from a json dictionary."""
         args = {}
+        if (limit := _dict.get('limit')) is not None:
+            args['limit'] = limit
+        if (first := _dict.get('first')) is not None:
+            args['first'] = First.from_dict(first)
+        if (next := _dict.get('next')) is not None:
+            args['next'] = Next.from_dict(next)
+        if (previous := _dict.get('previous')) is not None:
+            args['previous'] = Previous.from_dict(previous)
         if (assignments := _dict.get('assignments')) is not None:
             args['assignments'] = assignments
         return cls(**args)
@@ -5195,6 +5990,23 @@ class PolicyTemplateAssignmentCollection:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
+        if hasattr(self, 'limit') and self.limit is not None:
+            _dict['limit'] = self.limit
+        if hasattr(self, 'first') and self.first is not None:
+            if isinstance(self.first, dict):
+                _dict['first'] = self.first
+            else:
+                _dict['first'] = self.first.to_dict()
+        if hasattr(self, 'next') and self.next is not None:
+            if isinstance(self.next, dict):
+                _dict['next'] = self.next
+            else:
+                _dict['next'] = self.next.to_dict()
+        if hasattr(self, 'previous') and self.previous is not None:
+            if isinstance(self.previous, dict):
+                _dict['previous'] = self.previous
+            else:
+                _dict['previous'] = self.previous.to_dict()
         if hasattr(self, 'assignments') and self.assignments is not None:
             assignments_list = []
             for v in self.assignments:
@@ -5249,6 +6061,14 @@ class PolicyTemplateCollection:
     """
     A collection of policy Templates.
 
+    :param int limit: (optional) The number of documents to include per each page of
+          collection.
+    :param First first: (optional) Details with href linking to first page of
+          requested collection.
+    :param Next next: (optional) Details with href linking to following page of
+          requested collection.
+    :param Previous previous: (optional) Details with href linking to previous page
+          of requested collection.
     :param List[PolicyTemplate] policy_templates: (optional) List of policy
           templates.
     """
@@ -5256,20 +6076,44 @@ class PolicyTemplateCollection:
     def __init__(
         self,
         *,
+        limit: Optional[int] = None,
+        first: Optional['First'] = None,
+        next: Optional['Next'] = None,
+        previous: Optional['Previous'] = None,
         policy_templates: Optional[List['PolicyTemplate']] = None,
     ) -> None:
         """
         Initialize a PolicyTemplateCollection object.
 
+        :param int limit: (optional) The number of documents to include per each
+               page of collection.
+        :param First first: (optional) Details with href linking to first page of
+               requested collection.
+        :param Next next: (optional) Details with href linking to following page of
+               requested collection.
+        :param Previous previous: (optional) Details with href linking to previous
+               page of requested collection.
         :param List[PolicyTemplate] policy_templates: (optional) List of policy
                templates.
         """
+        self.limit = limit
+        self.first = first
+        self.next = next
+        self.previous = previous
         self.policy_templates = policy_templates
 
     @classmethod
     def from_dict(cls, _dict: Dict) -> 'PolicyTemplateCollection':
         """Initialize a PolicyTemplateCollection object from a json dictionary."""
         args = {}
+        if (limit := _dict.get('limit')) is not None:
+            args['limit'] = limit
+        if (first := _dict.get('first')) is not None:
+            args['first'] = First.from_dict(first)
+        if (next := _dict.get('next')) is not None:
+            args['next'] = Next.from_dict(next)
+        if (previous := _dict.get('previous')) is not None:
+            args['previous'] = Previous.from_dict(previous)
         if (policy_templates := _dict.get('policy_templates')) is not None:
             args['policy_templates'] = [PolicyTemplate.from_dict(v) for v in policy_templates]
         return cls(**args)
@@ -5282,6 +6126,23 @@ class PolicyTemplateCollection:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
+        if hasattr(self, 'limit') and self.limit is not None:
+            _dict['limit'] = self.limit
+        if hasattr(self, 'first') and self.first is not None:
+            if isinstance(self.first, dict):
+                _dict['first'] = self.first
+            else:
+                _dict['first'] = self.first.to_dict()
+        if hasattr(self, 'next') and self.next is not None:
+            if isinstance(self.next, dict):
+                _dict['next'] = self.next
+            else:
+                _dict['next'] = self.next.to_dict()
+        if hasattr(self, 'previous') and self.previous is not None:
+            if isinstance(self.previous, dict):
+                _dict['previous'] = self.previous
+            else:
+                _dict['previous'] = self.previous.to_dict()
         if hasattr(self, 'policy_templates') and self.policy_templates is not None:
             policy_templates_list = []
             for v in self.policy_templates:
@@ -5709,6 +6570,14 @@ class PolicyTemplateVersionsCollection:
     """
     A collection of versions for a specific policy template.
 
+    :param int limit: (optional) The number of documents to include per each page of
+          collection.
+    :param First first: (optional) Details with href linking to first page of
+          requested collection.
+    :param Next next: (optional) Details with href linking to following page of
+          requested collection.
+    :param Previous previous: (optional) Details with href linking to previous page
+          of requested collection.
     :param List[PolicyTemplate] versions: (optional) List of policy templates
           versions.
     """
@@ -5716,20 +6585,44 @@ class PolicyTemplateVersionsCollection:
     def __init__(
         self,
         *,
+        limit: Optional[int] = None,
+        first: Optional['First'] = None,
+        next: Optional['Next'] = None,
+        previous: Optional['Previous'] = None,
         versions: Optional[List['PolicyTemplate']] = None,
     ) -> None:
         """
         Initialize a PolicyTemplateVersionsCollection object.
 
+        :param int limit: (optional) The number of documents to include per each
+               page of collection.
+        :param First first: (optional) Details with href linking to first page of
+               requested collection.
+        :param Next next: (optional) Details with href linking to following page of
+               requested collection.
+        :param Previous previous: (optional) Details with href linking to previous
+               page of requested collection.
         :param List[PolicyTemplate] versions: (optional) List of policy templates
                versions.
         """
+        self.limit = limit
+        self.first = first
+        self.next = next
+        self.previous = previous
         self.versions = versions
 
     @classmethod
     def from_dict(cls, _dict: Dict) -> 'PolicyTemplateVersionsCollection':
         """Initialize a PolicyTemplateVersionsCollection object from a json dictionary."""
         args = {}
+        if (limit := _dict.get('limit')) is not None:
+            args['limit'] = limit
+        if (first := _dict.get('first')) is not None:
+            args['first'] = First.from_dict(first)
+        if (next := _dict.get('next')) is not None:
+            args['next'] = Next.from_dict(next)
+        if (previous := _dict.get('previous')) is not None:
+            args['previous'] = Previous.from_dict(previous)
         if (versions := _dict.get('versions')) is not None:
             args['versions'] = [PolicyTemplate.from_dict(v) for v in versions]
         return cls(**args)
@@ -5742,6 +6635,23 @@ class PolicyTemplateVersionsCollection:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
+        if hasattr(self, 'limit') and self.limit is not None:
+            _dict['limit'] = self.limit
+        if hasattr(self, 'first') and self.first is not None:
+            if isinstance(self.first, dict):
+                _dict['first'] = self.first
+            else:
+                _dict['first'] = self.first.to_dict()
+        if hasattr(self, 'next') and self.next is not None:
+            if isinstance(self.next, dict):
+                _dict['next'] = self.next
+            else:
+                _dict['next'] = self.next.to_dict()
+        if hasattr(self, 'previous') and self.previous is not None:
+            if isinstance(self.previous, dict):
+                _dict['previous'] = self.previous
+            else:
+                _dict['previous'] = self.previous.to_dict()
         if hasattr(self, 'versions') and self.versions is not None:
             versions_list = []
             for v in self.versions:
@@ -5767,6 +6677,73 @@ class PolicyTemplateVersionsCollection:
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other: 'PolicyTemplateVersionsCollection') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class Previous:
+    """
+    Details with href linking to previous page of requested collection.
+
+    :param str href: (optional) The href linking to the page of requested
+          collection.
+    :param str start: (optional) Page token that refers to the page of collection.
+    """
+
+    def __init__(
+        self,
+        *,
+        href: Optional[str] = None,
+        start: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize a Previous object.
+
+        :param str start: (optional) Page token that refers to the page of
+               collection.
+        """
+        self.href = href
+        self.start = start
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'Previous':
+        """Initialize a Previous object from a json dictionary."""
+        args = {}
+        if (href := _dict.get('href')) is not None:
+            args['href'] = href
+        if (start := _dict.get('start')) is not None:
+            args['start'] = start
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a Previous object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'href') and getattr(self, 'href') is not None:
+            _dict['href'] = getattr(self, 'href')
+        if hasattr(self, 'start') and self.start is not None:
+            _dict['start'] = self.start
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this Previous object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'Previous') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'Previous') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -6974,26 +7951,58 @@ class V2PolicyCollection:
     """
     A collection of policies.
 
+    :param int limit: (optional) The number of documents to include per each page of
+          collection.
+    :param First first: (optional) Details with href linking to first page of
+          requested collection.
+    :param Next next: (optional) Details with href linking to following page of
+          requested collection.
+    :param Previous previous: (optional) Details with href linking to previous page
+          of requested collection.
     :param List[V2PolicyTemplateMetaData] policies: (optional) List of policies.
     """
 
     def __init__(
         self,
         *,
+        limit: Optional[int] = None,
+        first: Optional['First'] = None,
+        next: Optional['Next'] = None,
+        previous: Optional['Previous'] = None,
         policies: Optional[List['V2PolicyTemplateMetaData']] = None,
     ) -> None:
         """
         Initialize a V2PolicyCollection object.
 
+        :param int limit: (optional) The number of documents to include per each
+               page of collection.
+        :param First first: (optional) Details with href linking to first page of
+               requested collection.
+        :param Next next: (optional) Details with href linking to following page of
+               requested collection.
+        :param Previous previous: (optional) Details with href linking to previous
+               page of requested collection.
         :param List[V2PolicyTemplateMetaData] policies: (optional) List of
                policies.
         """
+        self.limit = limit
+        self.first = first
+        self.next = next
+        self.previous = previous
         self.policies = policies
 
     @classmethod
     def from_dict(cls, _dict: Dict) -> 'V2PolicyCollection':
         """Initialize a V2PolicyCollection object from a json dictionary."""
         args = {}
+        if (limit := _dict.get('limit')) is not None:
+            args['limit'] = limit
+        if (first := _dict.get('first')) is not None:
+            args['first'] = First.from_dict(first)
+        if (next := _dict.get('next')) is not None:
+            args['next'] = Next.from_dict(next)
+        if (previous := _dict.get('previous')) is not None:
+            args['previous'] = Previous.from_dict(previous)
         if (policies := _dict.get('policies')) is not None:
             args['policies'] = [V2PolicyTemplateMetaData.from_dict(v) for v in policies]
         return cls(**args)
@@ -7006,6 +8015,23 @@ class V2PolicyCollection:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
+        if hasattr(self, 'limit') and self.limit is not None:
+            _dict['limit'] = self.limit
+        if hasattr(self, 'first') and self.first is not None:
+            if isinstance(self.first, dict):
+                _dict['first'] = self.first
+            else:
+                _dict['first'] = self.first.to_dict()
+        if hasattr(self, 'next') and self.next is not None:
+            if isinstance(self.next, dict):
+                _dict['next'] = self.next
+            else:
+                _dict['next'] = self.next.to_dict()
+        if hasattr(self, 'previous') and self.previous is not None:
+            if isinstance(self.previous, dict):
+                _dict['previous'] = self.previous
+            else:
+                _dict['previous'] = self.previous.to_dict()
         if hasattr(self, 'policies') and self.policies is not None:
             policies_list = []
             for v in self.policies:
@@ -7852,388 +8878,6 @@ class ControlResponseControlWithEnrichedRoles(ControlResponse):
         return not self == other
 
 
-class GetPolicyAssignmentResponsePolicyAssignment(GetPolicyAssignmentResponse):
-    """
-    The set of properties associated with the policy template assignment.
-
-    :param str template_id: (optional) policy template id.
-    :param str template_version: (optional) policy template version.
-    :param str assignment_id: (optional) Passed in value to correlate with other
-          assignments.
-    :param str target_type: (optional) Assignment target type.
-    :param str target: (optional) ID of the target account.
-    :param str id: (optional) Policy assignment ID.
-    :param str account_id: (optional) The account GUID that the policies assignments
-          belong to..
-    :param str href: (optional) The href URL that links to the policies assignments
-          API by policy assignment ID.
-    :param datetime created_at: (optional) The UTC timestamp when the policy
-          assignment was created.
-    :param str created_by_id: (optional) The iam ID of the entity that created the
-          policy assignment.
-    :param datetime last_modified_at: (optional) The UTC timestamp when the policy
-          assignment was last modified.
-    :param str last_modified_by_id: (optional) The iam ID of the entity that last
-          modified the policy assignment.
-    :param List[PolicyAssignmentResources] resources: (optional) Object for each
-          account assigned.
-    :param str status: (optional) The policy assignment status.
-    """
-
-    def __init__(
-        self,
-        *,
-        template_id: Optional[str] = None,
-        template_version: Optional[str] = None,
-        assignment_id: Optional[str] = None,
-        target_type: Optional[str] = None,
-        target: Optional[str] = None,
-        id: Optional[str] = None,
-        account_id: Optional[str] = None,
-        href: Optional[str] = None,
-        created_at: Optional[datetime] = None,
-        created_by_id: Optional[str] = None,
-        last_modified_at: Optional[datetime] = None,
-        last_modified_by_id: Optional[str] = None,
-        resources: Optional[List['PolicyAssignmentResources']] = None,
-        status: Optional[str] = None,
-    ) -> None:
-        """
-        Initialize a GetPolicyAssignmentResponsePolicyAssignment object.
-
-        :param str template_id: (optional) policy template id.
-        :param str template_version: (optional) policy template version.
-        :param str assignment_id: (optional) Passed in value to correlate with
-               other assignments.
-        :param str target_type: (optional) Assignment target type.
-        :param str target: (optional) ID of the target account.
-        :param List[PolicyAssignmentResources] resources: (optional) Object for
-               each account assigned.
-        :param str status: (optional) The policy assignment status.
-        """
-        # pylint: disable=super-init-not-called
-        self.template_id = template_id
-        self.template_version = template_version
-        self.assignment_id = assignment_id
-        self.target_type = target_type
-        self.target = target
-        self.id = id
-        self.account_id = account_id
-        self.href = href
-        self.created_at = created_at
-        self.created_by_id = created_by_id
-        self.last_modified_at = last_modified_at
-        self.last_modified_by_id = last_modified_by_id
-        self.resources = resources
-        self.status = status
-
-    @classmethod
-    def from_dict(cls, _dict: Dict) -> 'GetPolicyAssignmentResponsePolicyAssignment':
-        """Initialize a GetPolicyAssignmentResponsePolicyAssignment object from a json dictionary."""
-        args = {}
-        if (template_id := _dict.get('template_id')) is not None:
-            args['template_id'] = template_id
-        if (template_version := _dict.get('template_version')) is not None:
-            args['template_version'] = template_version
-        if (assignment_id := _dict.get('assignment_id')) is not None:
-            args['assignment_id'] = assignment_id
-        if (target_type := _dict.get('target_type')) is not None:
-            args['target_type'] = target_type
-        if (target := _dict.get('target')) is not None:
-            args['target'] = target
-        if (id := _dict.get('id')) is not None:
-            args['id'] = id
-        if (account_id := _dict.get('account_id')) is not None:
-            args['account_id'] = account_id
-        if (href := _dict.get('href')) is not None:
-            args['href'] = href
-        if (created_at := _dict.get('created_at')) is not None:
-            args['created_at'] = string_to_datetime(created_at)
-        if (created_by_id := _dict.get('created_by_id')) is not None:
-            args['created_by_id'] = created_by_id
-        if (last_modified_at := _dict.get('last_modified_at')) is not None:
-            args['last_modified_at'] = string_to_datetime(last_modified_at)
-        if (last_modified_by_id := _dict.get('last_modified_by_id')) is not None:
-            args['last_modified_by_id'] = last_modified_by_id
-        if (resources := _dict.get('resources')) is not None:
-            args['resources'] = [PolicyAssignmentResources.from_dict(v) for v in resources]
-        if (status := _dict.get('status')) is not None:
-            args['status'] = status
-        return cls(**args)
-
-    @classmethod
-    def _from_dict(cls, _dict):
-        """Initialize a GetPolicyAssignmentResponsePolicyAssignment object from a json dictionary."""
-        return cls.from_dict(_dict)
-
-    def to_dict(self) -> Dict:
-        """Return a json dictionary representing this model."""
-        _dict = {}
-        if hasattr(self, 'template_id') and self.template_id is not None:
-            _dict['template_id'] = self.template_id
-        if hasattr(self, 'template_version') and self.template_version is not None:
-            _dict['template_version'] = self.template_version
-        if hasattr(self, 'assignment_id') and self.assignment_id is not None:
-            _dict['assignment_id'] = self.assignment_id
-        if hasattr(self, 'target_type') and self.target_type is not None:
-            _dict['target_type'] = self.target_type
-        if hasattr(self, 'target') and self.target is not None:
-            _dict['target'] = self.target
-        if hasattr(self, 'id') and getattr(self, 'id') is not None:
-            _dict['id'] = getattr(self, 'id')
-        if hasattr(self, 'account_id') and getattr(self, 'account_id') is not None:
-            _dict['account_id'] = getattr(self, 'account_id')
-        if hasattr(self, 'href') and getattr(self, 'href') is not None:
-            _dict['href'] = getattr(self, 'href')
-        if hasattr(self, 'created_at') and getattr(self, 'created_at') is not None:
-            _dict['created_at'] = datetime_to_string(getattr(self, 'created_at'))
-        if hasattr(self, 'created_by_id') and getattr(self, 'created_by_id') is not None:
-            _dict['created_by_id'] = getattr(self, 'created_by_id')
-        if hasattr(self, 'last_modified_at') and getattr(self, 'last_modified_at') is not None:
-            _dict['last_modified_at'] = datetime_to_string(getattr(self, 'last_modified_at'))
-        if hasattr(self, 'last_modified_by_id') and getattr(self, 'last_modified_by_id') is not None:
-            _dict['last_modified_by_id'] = getattr(self, 'last_modified_by_id')
-        if hasattr(self, 'resources') and self.resources is not None:
-            resources_list = []
-            for v in self.resources:
-                if isinstance(v, dict):
-                    resources_list.append(v)
-                else:
-                    resources_list.append(v.to_dict())
-            _dict['resources'] = resources_list
-        if hasattr(self, 'status') and self.status is not None:
-            _dict['status'] = self.status
-        return _dict
-
-    def _to_dict(self):
-        """Return a json dictionary representing this model."""
-        return self.to_dict()
-
-    def __str__(self) -> str:
-        """Return a `str` version of this GetPolicyAssignmentResponsePolicyAssignment object."""
-        return json.dumps(self.to_dict(), indent=2)
-
-    def __eq__(self, other: 'GetPolicyAssignmentResponsePolicyAssignment') -> bool:
-        """Return `true` when self and other are equal, false otherwise."""
-        if not isinstance(other, self.__class__):
-            return False
-        return self.__dict__ == other.__dict__
-
-    def __ne__(self, other: 'GetPolicyAssignmentResponsePolicyAssignment') -> bool:
-        """Return `true` when self and other are not equal, false otherwise."""
-        return not self == other
-
-    class TargetTypeEnum(str, Enum):
-        """
-        Assignment target type.
-        """
-
-        ACCOUNT = 'Account'
-        ACCOUNTGROUP = 'AccountGroup'
-        ENTERPRISE = 'Enterprise'
-
-    class StatusEnum(str, Enum):
-        """
-        The policy assignment status.
-        """
-
-        IN_PROGRESS = 'in_progress'
-        SUCCEEDED = 'succeeded'
-        SUCCEED_WITH_ERRORS = 'succeed_with_errors'
-        FAILED = 'failed'
-
-
-class GetPolicyAssignmentResponsePolicyAssignmentV1(GetPolicyAssignmentResponse):
-    """
-    The set of properties associated with the policy template assignment.
-
-    :param AssignmentTargetDetails target: assignment target account and type.
-    :param str id: (optional) Policy assignment ID.
-    :param str account_id: (optional) The account GUID that the policies assignments
-          belong to..
-    :param str href: (optional) The href URL that links to the policies assignments
-          API by policy assignment ID.
-    :param datetime created_at: (optional) The UTC timestamp when the policy
-          assignment was created.
-    :param str created_by_id: (optional) The iam ID of the entity that created the
-          policy assignment.
-    :param datetime last_modified_at: (optional) The UTC timestamp when the policy
-          assignment was last modified.
-    :param str last_modified_by_id: (optional) The iam ID of the entity that last
-          modified the policy assignment.
-    :param List[PolicyAssignmentV1Resources] resources: Object for each account
-          assigned.
-    :param GetPolicyAssignmentResponsePolicyAssignmentV1Subject subject: (optional)
-          subject details of access type assignment.
-    :param AssignmentTemplateDetails template: policy template details.
-    :param str status: The policy assignment status.
-    """
-
-    def __init__(
-        self,
-        target: 'AssignmentTargetDetails',
-        resources: List['PolicyAssignmentV1Resources'],
-        template: 'AssignmentTemplateDetails',
-        status: str,
-        *,
-        id: Optional[str] = None,
-        account_id: Optional[str] = None,
-        href: Optional[str] = None,
-        created_at: Optional[datetime] = None,
-        created_by_id: Optional[str] = None,
-        last_modified_at: Optional[datetime] = None,
-        last_modified_by_id: Optional[str] = None,
-        subject: Optional['GetPolicyAssignmentResponsePolicyAssignmentV1Subject'] = None,
-    ) -> None:
-        """
-        Initialize a GetPolicyAssignmentResponsePolicyAssignmentV1 object.
-
-        :param AssignmentTargetDetails target: assignment target account and type.
-        :param List[PolicyAssignmentV1Resources] resources: Object for each account
-               assigned.
-        :param AssignmentTemplateDetails template: policy template details.
-        :param str status: The policy assignment status.
-        :param GetPolicyAssignmentResponsePolicyAssignmentV1Subject subject:
-               (optional) subject details of access type assignment.
-        """
-        # pylint: disable=super-init-not-called
-        self.target = target
-        self.id = id
-        self.account_id = account_id
-        self.href = href
-        self.created_at = created_at
-        self.created_by_id = created_by_id
-        self.last_modified_at = last_modified_at
-        self.last_modified_by_id = last_modified_by_id
-        self.resources = resources
-        self.subject = subject
-        self.template = template
-        self.status = status
-
-    @classmethod
-    def from_dict(cls, _dict: Dict) -> 'GetPolicyAssignmentResponsePolicyAssignmentV1':
-        """Initialize a GetPolicyAssignmentResponsePolicyAssignmentV1 object from a json dictionary."""
-        args = {}
-        if (target := _dict.get('target')) is not None:
-            args['target'] = AssignmentTargetDetails.from_dict(target)
-        else:
-            raise ValueError(
-                'Required property \'target\' not present in GetPolicyAssignmentResponsePolicyAssignmentV1 JSON'
-            )
-        if (id := _dict.get('id')) is not None:
-            args['id'] = id
-        if (account_id := _dict.get('account_id')) is not None:
-            args['account_id'] = account_id
-        if (href := _dict.get('href')) is not None:
-            args['href'] = href
-        if (created_at := _dict.get('created_at')) is not None:
-            args['created_at'] = string_to_datetime(created_at)
-        if (created_by_id := _dict.get('created_by_id')) is not None:
-            args['created_by_id'] = created_by_id
-        if (last_modified_at := _dict.get('last_modified_at')) is not None:
-            args['last_modified_at'] = string_to_datetime(last_modified_at)
-        if (last_modified_by_id := _dict.get('last_modified_by_id')) is not None:
-            args['last_modified_by_id'] = last_modified_by_id
-        if (resources := _dict.get('resources')) is not None:
-            args['resources'] = [PolicyAssignmentV1Resources.from_dict(v) for v in resources]
-        else:
-            raise ValueError(
-                'Required property \'resources\' not present in GetPolicyAssignmentResponsePolicyAssignmentV1 JSON'
-            )
-        if (subject := _dict.get('subject')) is not None:
-            args['subject'] = GetPolicyAssignmentResponsePolicyAssignmentV1Subject.from_dict(subject)
-        if (template := _dict.get('template')) is not None:
-            args['template'] = AssignmentTemplateDetails.from_dict(template)
-        else:
-            raise ValueError(
-                'Required property \'template\' not present in GetPolicyAssignmentResponsePolicyAssignmentV1 JSON'
-            )
-        if (status := _dict.get('status')) is not None:
-            args['status'] = status
-        else:
-            raise ValueError(
-                'Required property \'status\' not present in GetPolicyAssignmentResponsePolicyAssignmentV1 JSON'
-            )
-        return cls(**args)
-
-    @classmethod
-    def _from_dict(cls, _dict):
-        """Initialize a GetPolicyAssignmentResponsePolicyAssignmentV1 object from a json dictionary."""
-        return cls.from_dict(_dict)
-
-    def to_dict(self) -> Dict:
-        """Return a json dictionary representing this model."""
-        _dict = {}
-        if hasattr(self, 'target') and self.target is not None:
-            if isinstance(self.target, dict):
-                _dict['target'] = self.target
-            else:
-                _dict['target'] = self.target.to_dict()
-        if hasattr(self, 'id') and getattr(self, 'id') is not None:
-            _dict['id'] = getattr(self, 'id')
-        if hasattr(self, 'account_id') and getattr(self, 'account_id') is not None:
-            _dict['account_id'] = getattr(self, 'account_id')
-        if hasattr(self, 'href') and getattr(self, 'href') is not None:
-            _dict['href'] = getattr(self, 'href')
-        if hasattr(self, 'created_at') and getattr(self, 'created_at') is not None:
-            _dict['created_at'] = datetime_to_string(getattr(self, 'created_at'))
-        if hasattr(self, 'created_by_id') and getattr(self, 'created_by_id') is not None:
-            _dict['created_by_id'] = getattr(self, 'created_by_id')
-        if hasattr(self, 'last_modified_at') and getattr(self, 'last_modified_at') is not None:
-            _dict['last_modified_at'] = datetime_to_string(getattr(self, 'last_modified_at'))
-        if hasattr(self, 'last_modified_by_id') and getattr(self, 'last_modified_by_id') is not None:
-            _dict['last_modified_by_id'] = getattr(self, 'last_modified_by_id')
-        if hasattr(self, 'resources') and self.resources is not None:
-            resources_list = []
-            for v in self.resources:
-                if isinstance(v, dict):
-                    resources_list.append(v)
-                else:
-                    resources_list.append(v.to_dict())
-            _dict['resources'] = resources_list
-        if hasattr(self, 'subject') and self.subject is not None:
-            if isinstance(self.subject, dict):
-                _dict['subject'] = self.subject
-            else:
-                _dict['subject'] = self.subject.to_dict()
-        if hasattr(self, 'template') and self.template is not None:
-            if isinstance(self.template, dict):
-                _dict['template'] = self.template
-            else:
-                _dict['template'] = self.template.to_dict()
-        if hasattr(self, 'status') and self.status is not None:
-            _dict['status'] = self.status
-        return _dict
-
-    def _to_dict(self):
-        """Return a json dictionary representing this model."""
-        return self.to_dict()
-
-    def __str__(self) -> str:
-        """Return a `str` version of this GetPolicyAssignmentResponsePolicyAssignmentV1 object."""
-        return json.dumps(self.to_dict(), indent=2)
-
-    def __eq__(self, other: 'GetPolicyAssignmentResponsePolicyAssignmentV1') -> bool:
-        """Return `true` when self and other are equal, false otherwise."""
-        if not isinstance(other, self.__class__):
-            return False
-        return self.__dict__ == other.__dict__
-
-    def __ne__(self, other: 'GetPolicyAssignmentResponsePolicyAssignmentV1') -> bool:
-        """Return `true` when self and other are not equal, false otherwise."""
-        return not self == other
-
-    class StatusEnum(str, Enum):
-        """
-        The policy assignment status.
-        """
-
-        IN_PROGRESS = 'in_progress'
-        SUCCEEDED = 'succeeded'
-        SUCCEED_WITH_ERRORS = 'succeed_with_errors'
-        FAILED = 'failed'
-
-
 class NestedConditionRuleAttribute(NestedCondition):
     """
     Rule that specifies additional access granted (e.g., time-based condition).
@@ -8610,8 +9254,6 @@ class PolicyTemplateAssignmentItemsPolicyAssignment(PolicyTemplateAssignmentItem
         """
 
         ACCOUNT = 'Account'
-        ACCOUNTGROUP = 'AccountGroup'
-        ENTERPRISE = 'Enterprise'
 
     class StatusEnum(str, Enum):
         """
@@ -9014,3 +9656,557 @@ class V2PolicyRuleRuleWithNestedConditions(V2PolicyRule):
 
         AND = 'and'
         OR = 'or'
+
+
+##############################################################################
+# Pagers
+##############################################################################
+
+
+class PoliciesPager:
+    """
+    PoliciesPager can be used to simplify the use of the "list_policies" method.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: IamPolicyManagementV1,
+        account_id: str,
+        accept_language: str = None,
+        iam_id: str = None,
+        access_group_id: str = None,
+        type: str = None,
+        service_type: str = None,
+        tag_name: str = None,
+        tag_value: str = None,
+        sort: str = None,
+        format: str = None,
+        state: str = None,
+        limit: int = None,
+    ) -> None:
+        """
+        Initialize a PoliciesPager object.
+        :param str account_id: The account GUID that the policies belong to.
+        :param str accept_language: (optional) Language code for translations
+               * `default` - English
+               * `de` -  German (Standard)
+               * `en` - English
+               * `es` - Spanish (Spain)
+               * `fr` - French (Standard)
+               * `it` - Italian (Standard)
+               * `ja` - Japanese
+               * `ko` - Korean
+               * `pt-br` - Portuguese (Brazil)
+               * `zh-cn` - Chinese (Simplified, PRC)
+               * `zh-tw` - (Chinese, Taiwan).
+        :param str iam_id: (optional) Optional IAM ID used to identify the subject.
+        :param str access_group_id: (optional) Optional access group id.
+        :param str type: (optional) Optional type of policy.
+        :param str service_type: (optional) Optional type of service.
+        :param str tag_name: (optional) Optional name of the access tag in the
+               policy.
+        :param str tag_value: (optional) Optional value of the access tag in the
+               policy.
+        :param str sort: (optional) Optional top level policy field to sort
+               results. Ascending sort is default. Descending sort available by prepending
+               '-' to field. Example '-last_modified_at'.
+        :param str format: (optional) Include additional data per policy returned
+               * `include_last_permit` - returns details of when the policy last granted a
+               permit decision and the number of times it has done so
+               * `display` - returns the list of all actions included in each of the
+               policy roles.
+        :param str state: (optional) The state of the policy.
+               * `active` - returns active policies
+               * `deleted` - returns non-active policies.
+        :param int limit: (optional) The number of documents to include in
+               collection.
+        """
+        self._has_next = True
+        self._client = client
+        self._page_context = {'next': None}
+        self._account_id = account_id
+        self._accept_language = accept_language
+        self._iam_id = iam_id
+        self._access_group_id = access_group_id
+        self._type = type
+        self._service_type = service_type
+        self._tag_name = tag_name
+        self._tag_value = tag_value
+        self._sort = sort
+        self._format = format
+        self._state = state
+        self._limit = limit
+
+    def has_next(self) -> bool:
+        """
+        Returns true if there are potentially more results to be retrieved.
+        """
+        return self._has_next
+
+    def get_next(self) -> List[dict]:
+        """
+        Returns the next page of results.
+        :return: A List[dict], where each element is a dict that represents an instance of PolicyTemplateMetaData.
+        :rtype: List[dict]
+        """
+        if not self.has_next():
+            raise StopIteration(message='No more results available')
+
+        result = self._client.list_policies(
+            account_id=self._account_id,
+            accept_language=self._accept_language,
+            iam_id=self._iam_id,
+            access_group_id=self._access_group_id,
+            type=self._type,
+            service_type=self._service_type,
+            tag_name=self._tag_name,
+            tag_value=self._tag_value,
+            sort=self._sort,
+            format=self._format,
+            state=self._state,
+            limit=self._limit,
+            start=self._page_context.get('next'),
+        ).get_result()
+
+        next = None
+        next_page_link = result.get('next')
+        if next_page_link is not None:
+            next = next_page_link.get('start')
+        self._page_context['next'] = next
+        if next is None:
+            self._has_next = False
+
+        return result.get('policies')
+
+    def get_all(self) -> List[dict]:
+        """
+        Returns all results by invoking get_next() repeatedly
+        until all pages of results have been retrieved.
+        :return: A List[dict], where each element is a dict that represents an instance of PolicyTemplateMetaData.
+        :rtype: List[dict]
+        """
+        results = []
+        while self.has_next():
+            next_page = self.get_next()
+            results.extend(next_page)
+        return results
+
+
+class V2PoliciesPager:
+    """
+    V2PoliciesPager can be used to simplify the use of the "list_v2_policies" method.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: IamPolicyManagementV1,
+        account_id: str,
+        accept_language: str = None,
+        iam_id: str = None,
+        access_group_id: str = None,
+        type: str = None,
+        service_type: str = None,
+        service_name: str = None,
+        service_group_id: str = None,
+        sort: str = None,
+        format: str = None,
+        state: str = None,
+        limit: int = None,
+    ) -> None:
+        """
+        Initialize a V2PoliciesPager object.
+        :param str account_id: The account GUID in which the policies belong to.
+        :param str accept_language: (optional) Language code for translations
+               * `default` - English
+               * `de` -  German (Standard)
+               * `en` - English
+               * `es` - Spanish (Spain)
+               * `fr` - French (Standard)
+               * `it` - Italian (Standard)
+               * `ja` - Japanese
+               * `ko` - Korean
+               * `pt-br` - Portuguese (Brazil)
+               * `zh-cn` - Chinese (Simplified, PRC)
+               * `zh-tw` - (Chinese, Taiwan).
+        :param str iam_id: (optional) Optional IAM ID used to identify the subject.
+        :param str access_group_id: (optional) Optional access group id.
+        :param str type: (optional) Optional type of policy.
+        :param str service_type: (optional) Optional type of service.
+        :param str service_name: (optional) Optional name of service.
+        :param str service_group_id: (optional) Optional ID of service group.
+        :param str sort: (optional) Optional top level policy field to sort
+               results. Ascending sort is default. Descending sort available by prepending
+               '-' to field, for example, '-last_modified_at'. Note that last permit
+               information is only included when 'format=include_last_permit', for
+               example, "format=include_last_permit&sort=last_permit_at" Example fields
+               that can be sorted on:
+                 - 'id'
+                 - 'type'
+                 - 'href'
+                 - 'created_at'
+                 - 'created_by_id'
+                 - 'last_modified_at'
+                 - 'last_modified_by_id'
+                 - 'state'
+                 - 'last_permit_at'
+                 - 'last_permit_frequency'.
+        :param str format: (optional) Include additional data per policy returned
+               * `include_last_permit` - returns details of when the policy last granted a
+               permit decision and the number of times it has done so
+               * `display` - returns the list of all actions included in each of the
+               policy roles and translations for all relevant fields.
+        :param str state: (optional) The state of the policy.
+               * `active` - returns active policies
+               * `deleted` - returns non-active policies.
+        :param int limit: (optional) The number of documents to include in
+               collection.
+        """
+        self._has_next = True
+        self._client = client
+        self._page_context = {'next': None}
+        self._account_id = account_id
+        self._accept_language = accept_language
+        self._iam_id = iam_id
+        self._access_group_id = access_group_id
+        self._type = type
+        self._service_type = service_type
+        self._service_name = service_name
+        self._service_group_id = service_group_id
+        self._sort = sort
+        self._format = format
+        self._state = state
+        self._limit = limit
+
+    def has_next(self) -> bool:
+        """
+        Returns true if there are potentially more results to be retrieved.
+        """
+        return self._has_next
+
+    def get_next(self) -> List[dict]:
+        """
+        Returns the next page of results.
+        :return: A List[dict], where each element is a dict that represents an instance of V2PolicyTemplateMetaData.
+        :rtype: List[dict]
+        """
+        if not self.has_next():
+            raise StopIteration(message='No more results available')
+
+        result = self._client.list_v2_policies(
+            account_id=self._account_id,
+            accept_language=self._accept_language,
+            iam_id=self._iam_id,
+            access_group_id=self._access_group_id,
+            type=self._type,
+            service_type=self._service_type,
+            service_name=self._service_name,
+            service_group_id=self._service_group_id,
+            sort=self._sort,
+            format=self._format,
+            state=self._state,
+            limit=self._limit,
+            start=self._page_context.get('next'),
+        ).get_result()
+
+        next = None
+        next_page_link = result.get('next')
+        if next_page_link is not None:
+            next = next_page_link.get('start')
+        self._page_context['next'] = next
+        if next is None:
+            self._has_next = False
+
+        return result.get('policies')
+
+    def get_all(self) -> List[dict]:
+        """
+        Returns all results by invoking get_next() repeatedly
+        until all pages of results have been retrieved.
+        :return: A List[dict], where each element is a dict that represents an instance of V2PolicyTemplateMetaData.
+        :rtype: List[dict]
+        """
+        results = []
+        while self.has_next():
+            next_page = self.get_next()
+            results.extend(next_page)
+        return results
+
+
+class PolicyTemplatesPager:
+    """
+    PolicyTemplatesPager can be used to simplify the use of the "list_policy_templates" method.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: IamPolicyManagementV1,
+        account_id: str,
+        accept_language: str = None,
+        state: str = None,
+        name: str = None,
+        policy_service_type: str = None,
+        policy_service_name: str = None,
+        policy_service_group_id: str = None,
+        policy_type: str = None,
+        limit: int = None,
+    ) -> None:
+        """
+        Initialize a PolicyTemplatesPager object.
+        :param str account_id: The account GUID that the policy templates belong
+               to.
+        :param str accept_language: (optional) Language code for translations
+               * `default` - English
+               * `de` -  German (Standard)
+               * `en` - English
+               * `es` - Spanish (Spain)
+               * `fr` - French (Standard)
+               * `it` - Italian (Standard)
+               * `ja` - Japanese
+               * `ko` - Korean
+               * `pt-br` - Portuguese (Brazil)
+               * `zh-cn` - Chinese (Simplified, PRC)
+               * `zh-tw` - (Chinese, Taiwan).
+        :param str state: (optional) The policy template state.
+        :param str name: (optional) The policy template name.
+        :param str policy_service_type: (optional) Service type, Optional.
+        :param str policy_service_name: (optional) Service name, Optional.
+        :param str policy_service_group_id: (optional) Service group id, Optional.
+        :param str policy_type: (optional) Policy type, Optional.
+        :param int limit: (optional) The number of documents to include in
+               collection.
+        """
+        self._has_next = True
+        self._client = client
+        self._page_context = {'next': None}
+        self._account_id = account_id
+        self._accept_language = accept_language
+        self._state = state
+        self._name = name
+        self._policy_service_type = policy_service_type
+        self._policy_service_name = policy_service_name
+        self._policy_service_group_id = policy_service_group_id
+        self._policy_type = policy_type
+        self._limit = limit
+
+    def has_next(self) -> bool:
+        """
+        Returns true if there are potentially more results to be retrieved.
+        """
+        return self._has_next
+
+    def get_next(self) -> List[dict]:
+        """
+        Returns the next page of results.
+        :return: A List[dict], where each element is a dict that represents an instance of PolicyTemplate.
+        :rtype: List[dict]
+        """
+        if not self.has_next():
+            raise StopIteration(message='No more results available')
+
+        result = self._client.list_policy_templates(
+            account_id=self._account_id,
+            accept_language=self._accept_language,
+            state=self._state,
+            name=self._name,
+            policy_service_type=self._policy_service_type,
+            policy_service_name=self._policy_service_name,
+            policy_service_group_id=self._policy_service_group_id,
+            policy_type=self._policy_type,
+            limit=self._limit,
+            start=self._page_context.get('next'),
+        ).get_result()
+
+        next = None
+        next_page_link = result.get('next')
+        if next_page_link is not None:
+            next = next_page_link.get('start')
+        self._page_context['next'] = next
+        if next is None:
+            self._has_next = False
+
+        return result.get('policy_templates')
+
+    def get_all(self) -> List[dict]:
+        """
+        Returns all results by invoking get_next() repeatedly
+        until all pages of results have been retrieved.
+        :return: A List[dict], where each element is a dict that represents an instance of PolicyTemplate.
+        :rtype: List[dict]
+        """
+        results = []
+        while self.has_next():
+            next_page = self.get_next()
+            results.extend(next_page)
+        return results
+
+
+class PolicyTemplateVersionsPager:
+    """
+    PolicyTemplateVersionsPager can be used to simplify the use of the "list_policy_template_versions" method.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: IamPolicyManagementV1,
+        policy_template_id: str,
+        state: str = None,
+        limit: int = None,
+    ) -> None:
+        """
+        Initialize a PolicyTemplateVersionsPager object.
+        :param str policy_template_id: The policy template ID.
+        :param str state: (optional) The policy template state.
+        :param int limit: (optional) The number of documents to include in
+               collection.
+        """
+        self._has_next = True
+        self._client = client
+        self._page_context = {'next': None}
+        self._policy_template_id = policy_template_id
+        self._state = state
+        self._limit = limit
+
+    def has_next(self) -> bool:
+        """
+        Returns true if there are potentially more results to be retrieved.
+        """
+        return self._has_next
+
+    def get_next(self) -> List[dict]:
+        """
+        Returns the next page of results.
+        :return: A List[dict], where each element is a dict that represents an instance of PolicyTemplate.
+        :rtype: List[dict]
+        """
+        if not self.has_next():
+            raise StopIteration(message='No more results available')
+
+        result = self._client.list_policy_template_versions(
+            policy_template_id=self._policy_template_id,
+            state=self._state,
+            limit=self._limit,
+            start=self._page_context.get('next'),
+        ).get_result()
+
+        next = None
+        next_page_link = result.get('next')
+        if next_page_link is not None:
+            next = next_page_link.get('start')
+        self._page_context['next'] = next
+        if next is None:
+            self._has_next = False
+
+        return result.get('versions')
+
+    def get_all(self) -> List[dict]:
+        """
+        Returns all results by invoking get_next() repeatedly
+        until all pages of results have been retrieved.
+        :return: A List[dict], where each element is a dict that represents an instance of PolicyTemplate.
+        :rtype: List[dict]
+        """
+        results = []
+        while self.has_next():
+            next_page = self.get_next()
+            results.extend(next_page)
+        return results
+
+
+class PolicyAssignmentsPager:
+    """
+    PolicyAssignmentsPager can be used to simplify the use of the "list_policy_assignments" method.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: IamPolicyManagementV1,
+        version: str,
+        account_id: str,
+        accept_language: str = None,
+        template_id: str = None,
+        template_version: str = None,
+        limit: int = None,
+    ) -> None:
+        """
+        Initialize a PolicyAssignmentsPager object.
+        :param str version: specify version of response body format.
+        :param str account_id: The account GUID in which the policies belong to.
+        :param str accept_language: (optional) Language code for translations
+               * `default` - English
+               * `de` -  German (Standard)
+               * `en` - English
+               * `es` - Spanish (Spain)
+               * `fr` - French (Standard)
+               * `it` - Italian (Standard)
+               * `ja` - Japanese
+               * `ko` - Korean
+               * `pt-br` - Portuguese (Brazil)
+               * `zh-cn` - Chinese (Simplified, PRC)
+               * `zh-tw` - (Chinese, Taiwan).
+        :param str template_id: (optional) Optional template id.
+        :param str template_version: (optional) Optional policy template version.
+        :param int limit: (optional) The number of documents to include in
+               collection.
+        """
+        self._has_next = True
+        self._client = client
+        self._page_context = {'next': None}
+        self._version = version
+        self._account_id = account_id
+        self._accept_language = accept_language
+        self._template_id = template_id
+        self._template_version = template_version
+        self._limit = limit
+
+    def has_next(self) -> bool:
+        """
+        Returns true if there are potentially more results to be retrieved.
+        """
+        return self._has_next
+
+    def get_next(self) -> List[dict]:
+        """
+        Returns the next page of results.
+        :return: A List[dict], where each element is a dict that represents an instance of PolicyTemplateAssignmentItems.
+        :rtype: List[dict]
+        """
+        if not self.has_next():
+            raise StopIteration(message='No more results available')
+
+        result = self._client.list_policy_assignments(
+            version=self._version,
+            account_id=self._account_id,
+            accept_language=self._accept_language,
+            template_id=self._template_id,
+            template_version=self._template_version,
+            limit=self._limit,
+            start=self._page_context.get('next'),
+        ).get_result()
+
+        next = None
+        next_page_link = result.get('next')
+        if next_page_link is not None:
+            next = next_page_link.get('start')
+        self._page_context['next'] = next
+        if next is None:
+            self._has_next = False
+
+        return result.get('assignments')
+
+    def get_all(self) -> List[dict]:
+        """
+        Returns all results by invoking get_next() repeatedly
+        until all pages of results have been retrieved.
+        :return: A List[dict], where each element is a dict that represents an instance of PolicyTemplateAssignmentItems.
+        :rtype: List[dict]
+        """
+        results = []
+        while self.has_next():
+            next_page = self.get_next()
+            results.extend(next_page)
+        return results

--- a/test/unit/test_iam_policy_management_v1.py
+++ b/test/unit/test_iam_policy_management_v1.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (C) Copyright IBM Corp. 2024.
+# (C) Copyright IBM Corp. 2025.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,15 +44,8 @@ def preprocess_url(operation_path: str):
     The returned request URL is used to register the mock response so it needs
     to match the request URL that is formed by the requests library.
     """
-    # First, unquote the path since it might have some quoted/escaped characters in it
-    # due to how the generator inserts the operation paths into the unit test code.
-    operation_path = urllib.parse.unquote(operation_path)
 
-    # Next, quote the path using urllib so that we approximate what will
-    # happen during request processing.
-    operation_path = urllib.parse.quote(operation_path, safe='/')
-
-    # Finally, form the request URL from the base URL and operation path.
+    # Form the request URL from the base URL and operation path.
     request_url = _base_url + operation_path
 
     # If the request url does NOT end with a /, then just return it as-is.
@@ -108,7 +101,7 @@ class TestListPolicies:
         """
         # Set up mock
         url = preprocess_url('/v1/policies')
-        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"id": "id", "version": "version", "assignment_id": "assignment_id", "root_id": "root_id", "root_version": "root_version"}}]}'
+        mock_response = '{"limit": 1, "first": {"href": "href"}, "next": {"href": "href", "start": "start"}, "previous": {"href": "href", "start": "start"}, "policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"id": "id", "version": "version", "assignment_id": "assignment_id", "root_id": "root_id", "root_version": "root_version"}}]}'
         responses.add(
             responses.GET,
             url,
@@ -129,6 +122,8 @@ class TestListPolicies:
         sort = 'id'
         format = 'include_last_permit'
         state = 'active'
+        limit = 50
+        start = 'testString'
 
         # Invoke method
         response = _service.list_policies(
@@ -143,6 +138,8 @@ class TestListPolicies:
             sort=sort,
             format=format,
             state=state,
+            limit=limit,
+            start=start,
             headers={},
         )
 
@@ -162,6 +159,8 @@ class TestListPolicies:
         assert 'sort={}'.format(sort) in query_string
         assert 'format={}'.format(format) in query_string
         assert 'state={}'.format(state) in query_string
+        assert 'limit={}'.format(limit) in query_string
+        assert 'start={}'.format(start) in query_string
 
     def test_list_policies_all_params_with_retries(self):
         # Enable retries and run test_list_policies_all_params.
@@ -179,7 +178,7 @@ class TestListPolicies:
         """
         # Set up mock
         url = preprocess_url('/v1/policies')
-        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"id": "id", "version": "version", "assignment_id": "assignment_id", "root_id": "root_id", "root_version": "root_version"}}]}'
+        mock_response = '{"limit": 1, "first": {"href": "href"}, "next": {"href": "href", "start": "start"}, "previous": {"href": "href", "start": "start"}, "policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"id": "id", "version": "version", "assignment_id": "assignment_id", "root_id": "root_id", "root_version": "root_version"}}]}'
         responses.add(
             responses.GET,
             url,
@@ -221,7 +220,7 @@ class TestListPolicies:
         """
         # Set up mock
         url = preprocess_url('/v1/policies')
-        mock_response = '{"policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"id": "id", "version": "version", "assignment_id": "assignment_id", "root_id": "root_id", "root_version": "root_version"}}]}'
+        mock_response = '{"limit": 1, "first": {"href": "href"}, "next": {"href": "href", "start": "start"}, "previous": {"href": "href", "start": "start"}, "policies": [{"id": "id", "type": "type", "description": "description", "subjects": [{"attributes": [{"name": "name", "value": "value"}]}], "roles": [{"role_id": "role_id", "display_name": "display_name", "description": "description"}], "resources": [{"attributes": [{"name": "name", "value": "value", "operator": "operator"}], "tags": [{"name": "name", "value": "value", "operator": "operator"}]}], "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "template": {"id": "id", "version": "version", "assignment_id": "assignment_id", "root_id": "root_id", "root_version": "root_version"}}]}'
         responses.add(
             responses.GET,
             url,
@@ -250,6 +249,97 @@ class TestListPolicies:
         # Disable retries and run test_list_policies_value_error.
         _service.disable_retries()
         self.test_list_policies_value_error()
+
+    @responses.activate
+    def test_list_policies_with_pager_get_next(self):
+        """
+        test_list_policies_with_pager_get_next()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v1/policies')
+        mock_response1 = '{"next":{"start":"1"},"total_count":2,"limit":1,"policies":[{"id":"id","type":"type","description":"description","subjects":[{"attributes":[{"name":"name","value":"value"}]}],"roles":[{"role_id":"role_id","display_name":"display_name","description":"description"}],"resources":[{"attributes":[{"name":"name","value":"value","operator":"operator"}],"tags":[{"name":"name","value":"value","operator":"operator"}]}],"href":"href","created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id","state":"active","template":{"id":"id","version":"version","assignment_id":"assignment_id","root_id":"root_id","root_version":"root_version"}}]}'
+        mock_response2 = '{"total_count":2,"limit":1,"policies":[{"id":"id","type":"type","description":"description","subjects":[{"attributes":[{"name":"name","value":"value"}]}],"roles":[{"role_id":"role_id","display_name":"display_name","description":"description"}],"resources":[{"attributes":[{"name":"name","value":"value","operator":"operator"}],"tags":[{"name":"name","value":"value","operator":"operator"}]}],"href":"href","created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id","state":"active","template":{"id":"id","version":"version","assignment_id":"assignment_id","root_id":"root_id","root_version":"root_version"}}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response1,
+            content_type='application/json',
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response2,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Exercise the pager class for this operation
+        all_results = []
+        pager = PoliciesPager(
+            client=_service,
+            account_id='testString',
+            accept_language='default',
+            iam_id='testString',
+            access_group_id='testString',
+            type='access',
+            service_type='service',
+            tag_name='testString',
+            tag_value='testString',
+            sort='id',
+            format='include_last_permit',
+            state='active',
+            limit=10,
+        )
+        while pager.has_next():
+            next_page = pager.get_next()
+            assert next_page is not None
+            all_results.extend(next_page)
+        assert len(all_results) == 2
+
+    @responses.activate
+    def test_list_policies_with_pager_get_all(self):
+        """
+        test_list_policies_with_pager_get_all()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v1/policies')
+        mock_response1 = '{"next":{"start":"1"},"total_count":2,"limit":1,"policies":[{"id":"id","type":"type","description":"description","subjects":[{"attributes":[{"name":"name","value":"value"}]}],"roles":[{"role_id":"role_id","display_name":"display_name","description":"description"}],"resources":[{"attributes":[{"name":"name","value":"value","operator":"operator"}],"tags":[{"name":"name","value":"value","operator":"operator"}]}],"href":"href","created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id","state":"active","template":{"id":"id","version":"version","assignment_id":"assignment_id","root_id":"root_id","root_version":"root_version"}}]}'
+        mock_response2 = '{"total_count":2,"limit":1,"policies":[{"id":"id","type":"type","description":"description","subjects":[{"attributes":[{"name":"name","value":"value"}]}],"roles":[{"role_id":"role_id","display_name":"display_name","description":"description"}],"resources":[{"attributes":[{"name":"name","value":"value","operator":"operator"}],"tags":[{"name":"name","value":"value","operator":"operator"}]}],"href":"href","created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id","state":"active","template":{"id":"id","version":"version","assignment_id":"assignment_id","root_id":"root_id","root_version":"root_version"}}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response1,
+            content_type='application/json',
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response2,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Exercise the pager class for this operation
+        pager = PoliciesPager(
+            client=_service,
+            account_id='testString',
+            accept_language='default',
+            iam_id='testString',
+            access_group_id='testString',
+            type='access',
+            service_type='service',
+            tag_name='testString',
+            tag_value='testString',
+            sort='id',
+            format='include_last_permit',
+            state='active',
+            limit=10,
+        )
+        all_results = pager.get_all()
+        assert all_results is not None
+        assert len(all_results) == 2
 
 
 class TestCreatePolicy:
@@ -1525,7 +1615,7 @@ class TestListV2Policies:
         """
         # Set up mock
         url = preprocess_url('/v2/policies')
-        mock_response = '{"policies": [{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"id": "id", "version": "version", "assignment_id": "assignment_id", "root_id": "root_id", "root_version": "root_version"}}]}'
+        mock_response = '{"limit": 1, "first": {"href": "href"}, "next": {"href": "href", "start": "start"}, "previous": {"href": "href", "start": "start"}, "policies": [{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"id": "id", "version": "version", "assignment_id": "assignment_id", "root_id": "root_id", "root_version": "root_version"}}]}'
         responses.add(
             responses.GET,
             url,
@@ -1546,6 +1636,8 @@ class TestListV2Policies:
         sort = 'testString'
         format = 'include_last_permit'
         state = 'active'
+        limit = 50
+        start = 'testString'
 
         # Invoke method
         response = _service.list_v2_policies(
@@ -1560,6 +1652,8 @@ class TestListV2Policies:
             sort=sort,
             format=format,
             state=state,
+            limit=limit,
+            start=start,
             headers={},
         )
 
@@ -1579,6 +1673,8 @@ class TestListV2Policies:
         assert 'sort={}'.format(sort) in query_string
         assert 'format={}'.format(format) in query_string
         assert 'state={}'.format(state) in query_string
+        assert 'limit={}'.format(limit) in query_string
+        assert 'start={}'.format(start) in query_string
 
     def test_list_v2_policies_all_params_with_retries(self):
         # Enable retries and run test_list_v2_policies_all_params.
@@ -1596,7 +1692,7 @@ class TestListV2Policies:
         """
         # Set up mock
         url = preprocess_url('/v2/policies')
-        mock_response = '{"policies": [{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"id": "id", "version": "version", "assignment_id": "assignment_id", "root_id": "root_id", "root_version": "root_version"}}]}'
+        mock_response = '{"limit": 1, "first": {"href": "href"}, "next": {"href": "href", "start": "start"}, "previous": {"href": "href", "start": "start"}, "policies": [{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"id": "id", "version": "version", "assignment_id": "assignment_id", "root_id": "root_id", "root_version": "root_version"}}]}'
         responses.add(
             responses.GET,
             url,
@@ -1638,7 +1734,7 @@ class TestListV2Policies:
         """
         # Set up mock
         url = preprocess_url('/v2/policies')
-        mock_response = '{"policies": [{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"id": "id", "version": "version", "assignment_id": "assignment_id", "root_id": "root_id", "root_version": "root_version"}}]}'
+        mock_response = '{"limit": 1, "first": {"href": "href"}, "next": {"href": "href", "start": "start"}, "previous": {"href": "href", "start": "start"}, "policies": [{"type": "access", "description": "description", "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "id": "id", "href": "href", "control": {"grant": {"roles": [{"role_id": "role_id"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "state": "active", "last_permit_at": "last_permit_at", "last_permit_frequency": 21, "template": {"id": "id", "version": "version", "assignment_id": "assignment_id", "root_id": "root_id", "root_version": "root_version"}}]}'
         responses.add(
             responses.GET,
             url,
@@ -1667,6 +1763,97 @@ class TestListV2Policies:
         # Disable retries and run test_list_v2_policies_value_error.
         _service.disable_retries()
         self.test_list_v2_policies_value_error()
+
+    @responses.activate
+    def test_list_v2_policies_with_pager_get_next(self):
+        """
+        test_list_v2_policies_with_pager_get_next()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v2/policies')
+        mock_response1 = '{"next":{"start":"1"},"total_count":2,"limit":1,"policies":[{"type":"access","description":"description","subject":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}]},"resource":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}],"tags":[{"key":"key","value":"value","operator":"stringEquals"}]},"pattern":"pattern","rule":{"key":"key","operator":"stringEquals","value":"anyValue"},"id":"id","href":"href","control":{"grant":{"roles":[{"role_id":"role_id"}]}},"created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id","state":"active","last_permit_at":"last_permit_at","last_permit_frequency":21,"template":{"id":"id","version":"version","assignment_id":"assignment_id","root_id":"root_id","root_version":"root_version"}}]}'
+        mock_response2 = '{"total_count":2,"limit":1,"policies":[{"type":"access","description":"description","subject":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}]},"resource":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}],"tags":[{"key":"key","value":"value","operator":"stringEquals"}]},"pattern":"pattern","rule":{"key":"key","operator":"stringEquals","value":"anyValue"},"id":"id","href":"href","control":{"grant":{"roles":[{"role_id":"role_id"}]}},"created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id","state":"active","last_permit_at":"last_permit_at","last_permit_frequency":21,"template":{"id":"id","version":"version","assignment_id":"assignment_id","root_id":"root_id","root_version":"root_version"}}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response1,
+            content_type='application/json',
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response2,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Exercise the pager class for this operation
+        all_results = []
+        pager = V2PoliciesPager(
+            client=_service,
+            account_id='testString',
+            accept_language='default',
+            iam_id='testString',
+            access_group_id='testString',
+            type='access',
+            service_type='service',
+            service_name='testString',
+            service_group_id='testString',
+            sort='testString',
+            format='include_last_permit',
+            state='active',
+            limit=10,
+        )
+        while pager.has_next():
+            next_page = pager.get_next()
+            assert next_page is not None
+            all_results.extend(next_page)
+        assert len(all_results) == 2
+
+    @responses.activate
+    def test_list_v2_policies_with_pager_get_all(self):
+        """
+        test_list_v2_policies_with_pager_get_all()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v2/policies')
+        mock_response1 = '{"next":{"start":"1"},"total_count":2,"limit":1,"policies":[{"type":"access","description":"description","subject":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}]},"resource":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}],"tags":[{"key":"key","value":"value","operator":"stringEquals"}]},"pattern":"pattern","rule":{"key":"key","operator":"stringEquals","value":"anyValue"},"id":"id","href":"href","control":{"grant":{"roles":[{"role_id":"role_id"}]}},"created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id","state":"active","last_permit_at":"last_permit_at","last_permit_frequency":21,"template":{"id":"id","version":"version","assignment_id":"assignment_id","root_id":"root_id","root_version":"root_version"}}]}'
+        mock_response2 = '{"total_count":2,"limit":1,"policies":[{"type":"access","description":"description","subject":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}]},"resource":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}],"tags":[{"key":"key","value":"value","operator":"stringEquals"}]},"pattern":"pattern","rule":{"key":"key","operator":"stringEquals","value":"anyValue"},"id":"id","href":"href","control":{"grant":{"roles":[{"role_id":"role_id"}]}},"created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id","state":"active","last_permit_at":"last_permit_at","last_permit_frequency":21,"template":{"id":"id","version":"version","assignment_id":"assignment_id","root_id":"root_id","root_version":"root_version"}}]}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response1,
+            content_type='application/json',
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response2,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Exercise the pager class for this operation
+        pager = V2PoliciesPager(
+            client=_service,
+            account_id='testString',
+            accept_language='default',
+            iam_id='testString',
+            access_group_id='testString',
+            type='access',
+            service_type='service',
+            service_name='testString',
+            service_group_id='testString',
+            sort='testString',
+            format='include_last_permit',
+            state='active',
+            limit=10,
+        )
+        all_results = pager.get_all()
+        assert all_results is not None
+        assert len(all_results) == 2
 
 
 class TestCreateV2Policy:
@@ -2432,7 +2619,7 @@ class TestListPolicyTemplates:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates')
-        mock_response = '{"policy_templates": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        mock_response = '{"limit": 1, "first": {"href": "href"}, "next": {"href": "href", "start": "start"}, "previous": {"href": "href", "start": "start"}, "policy_templates": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
         responses.add(
             responses.GET,
             url,
@@ -2450,6 +2637,8 @@ class TestListPolicyTemplates:
         policy_service_name = 'testString'
         policy_service_group_id = 'testString'
         policy_type = 'access'
+        limit = 50
+        start = 'testString'
 
         # Invoke method
         response = _service.list_policy_templates(
@@ -2461,6 +2650,8 @@ class TestListPolicyTemplates:
             policy_service_name=policy_service_name,
             policy_service_group_id=policy_service_group_id,
             policy_type=policy_type,
+            limit=limit,
+            start=start,
             headers={},
         )
 
@@ -2477,6 +2668,8 @@ class TestListPolicyTemplates:
         assert 'policy_service_name={}'.format(policy_service_name) in query_string
         assert 'policy_service_group_id={}'.format(policy_service_group_id) in query_string
         assert 'policy_type={}'.format(policy_type) in query_string
+        assert 'limit={}'.format(limit) in query_string
+        assert 'start={}'.format(start) in query_string
 
     def test_list_policy_templates_all_params_with_retries(self):
         # Enable retries and run test_list_policy_templates_all_params.
@@ -2494,7 +2687,7 @@ class TestListPolicyTemplates:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates')
-        mock_response = '{"policy_templates": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        mock_response = '{"limit": 1, "first": {"href": "href"}, "next": {"href": "href", "start": "start"}, "previous": {"href": "href", "start": "start"}, "policy_templates": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
         responses.add(
             responses.GET,
             url,
@@ -2536,7 +2729,7 @@ class TestListPolicyTemplates:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates')
-        mock_response = '{"policy_templates": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        mock_response = '{"limit": 1, "first": {"href": "href"}, "next": {"href": "href", "start": "start"}, "previous": {"href": "href", "start": "start"}, "policy_templates": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
         responses.add(
             responses.GET,
             url,
@@ -2565,6 +2758,91 @@ class TestListPolicyTemplates:
         # Disable retries and run test_list_policy_templates_value_error.
         _service.disable_retries()
         self.test_list_policy_templates_value_error()
+
+    @responses.activate
+    def test_list_policy_templates_with_pager_get_next(self):
+        """
+        test_list_policy_templates_with_pager_get_next()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v1/policy_templates')
+        mock_response1 = '{"next":{"start":"1"},"policy_templates":[{"name":"name","description":"description","account_id":"account_id","version":"version","committed":false,"policy":{"type":"access","description":"description","resource":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}],"tags":[{"key":"key","value":"value","operator":"stringEquals"}]},"subject":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}]},"pattern":"pattern","rule":{"key":"key","operator":"stringEquals","value":"anyValue"},"control":{"grant":{"roles":[{"role_id":"role_id"}]}}},"state":"active","id":"id","href":"href","created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id"}],"total_count":2,"limit":1}'
+        mock_response2 = '{"policy_templates":[{"name":"name","description":"description","account_id":"account_id","version":"version","committed":false,"policy":{"type":"access","description":"description","resource":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}],"tags":[{"key":"key","value":"value","operator":"stringEquals"}]},"subject":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}]},"pattern":"pattern","rule":{"key":"key","operator":"stringEquals","value":"anyValue"},"control":{"grant":{"roles":[{"role_id":"role_id"}]}}},"state":"active","id":"id","href":"href","created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id"}],"total_count":2,"limit":1}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response1,
+            content_type='application/json',
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response2,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Exercise the pager class for this operation
+        all_results = []
+        pager = PolicyTemplatesPager(
+            client=_service,
+            account_id='testString',
+            accept_language='default',
+            state='active',
+            name='testString',
+            policy_service_type='service',
+            policy_service_name='testString',
+            policy_service_group_id='testString',
+            policy_type='access',
+            limit=10,
+        )
+        while pager.has_next():
+            next_page = pager.get_next()
+            assert next_page is not None
+            all_results.extend(next_page)
+        assert len(all_results) == 2
+
+    @responses.activate
+    def test_list_policy_templates_with_pager_get_all(self):
+        """
+        test_list_policy_templates_with_pager_get_all()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v1/policy_templates')
+        mock_response1 = '{"next":{"start":"1"},"policy_templates":[{"name":"name","description":"description","account_id":"account_id","version":"version","committed":false,"policy":{"type":"access","description":"description","resource":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}],"tags":[{"key":"key","value":"value","operator":"stringEquals"}]},"subject":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}]},"pattern":"pattern","rule":{"key":"key","operator":"stringEquals","value":"anyValue"},"control":{"grant":{"roles":[{"role_id":"role_id"}]}}},"state":"active","id":"id","href":"href","created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id"}],"total_count":2,"limit":1}'
+        mock_response2 = '{"policy_templates":[{"name":"name","description":"description","account_id":"account_id","version":"version","committed":false,"policy":{"type":"access","description":"description","resource":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}],"tags":[{"key":"key","value":"value","operator":"stringEquals"}]},"subject":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}]},"pattern":"pattern","rule":{"key":"key","operator":"stringEquals","value":"anyValue"},"control":{"grant":{"roles":[{"role_id":"role_id"}]}}},"state":"active","id":"id","href":"href","created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id"}],"total_count":2,"limit":1}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response1,
+            content_type='application/json',
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response2,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Exercise the pager class for this operation
+        pager = PolicyTemplatesPager(
+            client=_service,
+            account_id='testString',
+            accept_language='default',
+            state='active',
+            name='testString',
+            policy_service_type='service',
+            policy_service_name='testString',
+            policy_service_group_id='testString',
+            policy_type='access',
+            limit=10,
+        )
+        all_results = pager.get_all()
+        assert all_results is not None
+        assert len(all_results) == 2
 
 
 class TestCreatePolicyTemplate:
@@ -3311,7 +3589,7 @@ class TestListPolicyTemplateVersions:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates/testString/versions')
-        mock_response = '{"versions": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        mock_response = '{"limit": 1, "first": {"href": "href"}, "next": {"href": "href", "start": "start"}, "previous": {"href": "href", "start": "start"}, "versions": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
         responses.add(
             responses.GET,
             url,
@@ -3323,11 +3601,15 @@ class TestListPolicyTemplateVersions:
         # Set up parameter values
         policy_template_id = 'testString'
         state = 'active'
+        limit = 50
+        start = 'testString'
 
         # Invoke method
         response = _service.list_policy_template_versions(
             policy_template_id,
             state=state,
+            limit=limit,
+            start=start,
             headers={},
         )
 
@@ -3338,6 +3620,8 @@ class TestListPolicyTemplateVersions:
         query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'state={}'.format(state) in query_string
+        assert 'limit={}'.format(limit) in query_string
+        assert 'start={}'.format(start) in query_string
 
     def test_list_policy_template_versions_all_params_with_retries(self):
         # Enable retries and run test_list_policy_template_versions_all_params.
@@ -3355,7 +3639,7 @@ class TestListPolicyTemplateVersions:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates/testString/versions')
-        mock_response = '{"versions": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        mock_response = '{"limit": 1, "first": {"href": "href"}, "next": {"href": "href", "start": "start"}, "previous": {"href": "href", "start": "start"}, "versions": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
         responses.add(
             responses.GET,
             url,
@@ -3393,7 +3677,7 @@ class TestListPolicyTemplateVersions:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_templates/testString/versions')
-        mock_response = '{"versions": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
+        mock_response = '{"limit": 1, "first": {"href": "href"}, "next": {"href": "href", "start": "start"}, "previous": {"href": "href", "start": "start"}, "versions": [{"name": "name", "description": "description", "account_id": "account_id", "version": "version", "committed": false, "policy": {"type": "access", "description": "description", "resource": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "key", "value": "value", "operator": "stringEquals"}]}, "subject": {"attributes": [{"key": "key", "operator": "stringEquals", "value": "anyValue"}]}, "pattern": "pattern", "rule": {"key": "key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "role_id"}]}}}, "state": "active", "id": "id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id"}]}'
         responses.add(
             responses.GET,
             url,
@@ -3422,6 +3706,79 @@ class TestListPolicyTemplateVersions:
         # Disable retries and run test_list_policy_template_versions_value_error.
         _service.disable_retries()
         self.test_list_policy_template_versions_value_error()
+
+    @responses.activate
+    def test_list_policy_template_versions_with_pager_get_next(self):
+        """
+        test_list_policy_template_versions_with_pager_get_next()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v1/policy_templates/testString/versions')
+        mock_response1 = '{"next":{"start":"1"},"versions":[{"name":"name","description":"description","account_id":"account_id","version":"version","committed":false,"policy":{"type":"access","description":"description","resource":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}],"tags":[{"key":"key","value":"value","operator":"stringEquals"}]},"subject":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}]},"pattern":"pattern","rule":{"key":"key","operator":"stringEquals","value":"anyValue"},"control":{"grant":{"roles":[{"role_id":"role_id"}]}}},"state":"active","id":"id","href":"href","created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id"}],"total_count":2,"limit":1}'
+        mock_response2 = '{"versions":[{"name":"name","description":"description","account_id":"account_id","version":"version","committed":false,"policy":{"type":"access","description":"description","resource":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}],"tags":[{"key":"key","value":"value","operator":"stringEquals"}]},"subject":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}]},"pattern":"pattern","rule":{"key":"key","operator":"stringEquals","value":"anyValue"},"control":{"grant":{"roles":[{"role_id":"role_id"}]}}},"state":"active","id":"id","href":"href","created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id"}],"total_count":2,"limit":1}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response1,
+            content_type='application/json',
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response2,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Exercise the pager class for this operation
+        all_results = []
+        pager = PolicyTemplateVersionsPager(
+            client=_service,
+            policy_template_id='testString',
+            state='active',
+            limit=10,
+        )
+        while pager.has_next():
+            next_page = pager.get_next()
+            assert next_page is not None
+            all_results.extend(next_page)
+        assert len(all_results) == 2
+
+    @responses.activate
+    def test_list_policy_template_versions_with_pager_get_all(self):
+        """
+        test_list_policy_template_versions_with_pager_get_all()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v1/policy_templates/testString/versions')
+        mock_response1 = '{"next":{"start":"1"},"versions":[{"name":"name","description":"description","account_id":"account_id","version":"version","committed":false,"policy":{"type":"access","description":"description","resource":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}],"tags":[{"key":"key","value":"value","operator":"stringEquals"}]},"subject":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}]},"pattern":"pattern","rule":{"key":"key","operator":"stringEquals","value":"anyValue"},"control":{"grant":{"roles":[{"role_id":"role_id"}]}}},"state":"active","id":"id","href":"href","created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id"}],"total_count":2,"limit":1}'
+        mock_response2 = '{"versions":[{"name":"name","description":"description","account_id":"account_id","version":"version","committed":false,"policy":{"type":"access","description":"description","resource":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}],"tags":[{"key":"key","value":"value","operator":"stringEquals"}]},"subject":{"attributes":[{"key":"key","operator":"stringEquals","value":"anyValue"}]},"pattern":"pattern","rule":{"key":"key","operator":"stringEquals","value":"anyValue"},"control":{"grant":{"roles":[{"role_id":"role_id"}]}}},"state":"active","id":"id","href":"href","created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id"}],"total_count":2,"limit":1}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response1,
+            content_type='application/json',
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response2,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Exercise the pager class for this operation
+        pager = PolicyTemplateVersionsPager(
+            client=_service,
+            policy_template_id='testString',
+            state='active',
+            limit=10,
+        )
+        all_results = pager.get_all()
+        assert all_results is not None
+        assert len(all_results) == 2
 
 
 class TestReplacePolicyTemplate:
@@ -3936,7 +4293,7 @@ class TestListPolicyAssignments:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_assignments')
-        mock_response = '{"assignments": [{"target": {"type": "Account", "id": "id"}, "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": {"type": "Account", "id": "id"}, "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "subject": {"id": "id", "type": "iam_id"}, "template": {"id": "id", "version": "version"}, "status": "in_progress"}]}'
+        mock_response = '{"limit": 1, "first": {"href": "href"}, "next": {"href": "href", "start": "start"}, "previous": {"href": "href", "start": "start"}, "assignments": [{"target": {"type": "Account", "id": "id"}, "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": {"type": "Account", "id": "id"}, "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "subject": {"id": "id", "type": "iam_id"}, "template": {"id": "id", "version": "version"}, "status": "in_progress"}]}'
         responses.add(
             responses.GET,
             url,
@@ -3951,6 +4308,8 @@ class TestListPolicyAssignments:
         accept_language = 'default'
         template_id = 'testString'
         template_version = 'testString'
+        limit = 50
+        start = 'testString'
 
         # Invoke method
         response = _service.list_policy_assignments(
@@ -3959,6 +4318,8 @@ class TestListPolicyAssignments:
             accept_language=accept_language,
             template_id=template_id,
             template_version=template_version,
+            limit=limit,
+            start=start,
             headers={},
         )
 
@@ -3972,6 +4333,8 @@ class TestListPolicyAssignments:
         assert 'account_id={}'.format(account_id) in query_string
         assert 'template_id={}'.format(template_id) in query_string
         assert 'template_version={}'.format(template_version) in query_string
+        assert 'limit={}'.format(limit) in query_string
+        assert 'start={}'.format(start) in query_string
 
     def test_list_policy_assignments_all_params_with_retries(self):
         # Enable retries and run test_list_policy_assignments_all_params.
@@ -3989,7 +4352,7 @@ class TestListPolicyAssignments:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_assignments')
-        mock_response = '{"assignments": [{"target": {"type": "Account", "id": "id"}, "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": {"type": "Account", "id": "id"}, "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "subject": {"id": "id", "type": "iam_id"}, "template": {"id": "id", "version": "version"}, "status": "in_progress"}]}'
+        mock_response = '{"limit": 1, "first": {"href": "href"}, "next": {"href": "href", "start": "start"}, "previous": {"href": "href", "start": "start"}, "assignments": [{"target": {"type": "Account", "id": "id"}, "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": {"type": "Account", "id": "id"}, "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "subject": {"id": "id", "type": "iam_id"}, "template": {"id": "id", "version": "version"}, "status": "in_progress"}]}'
         responses.add(
             responses.GET,
             url,
@@ -4034,7 +4397,7 @@ class TestListPolicyAssignments:
         """
         # Set up mock
         url = preprocess_url('/v1/policy_assignments')
-        mock_response = '{"assignments": [{"target": {"type": "Account", "id": "id"}, "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": {"type": "Account", "id": "id"}, "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "subject": {"id": "id", "type": "iam_id"}, "template": {"id": "id", "version": "version"}, "status": "in_progress"}]}'
+        mock_response = '{"limit": 1, "first": {"href": "href"}, "next": {"href": "href", "start": "start"}, "previous": {"href": "href", "start": "start"}, "assignments": [{"target": {"type": "Account", "id": "id"}, "id": "id", "account_id": "account_id", "href": "href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "created_by_id", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "last_modified_by_id", "resources": [{"target": {"type": "Account", "id": "id"}, "policy": {"resource_created": {"id": "id"}, "status": "status", "error_message": {"trace": "trace", "errors": [{"code": "insufficent_permissions", "message": "message", "details": {"conflicts_with": {"etag": "etag", "role": "role", "policy": "policy"}}, "more_info": "more_info"}], "status_code": 11}}}], "subject": {"id": "id", "type": "iam_id"}, "template": {"id": "id", "version": "version"}, "status": "in_progress"}]}'
         responses.add(
             responses.GET,
             url,
@@ -4065,6 +4428,85 @@ class TestListPolicyAssignments:
         # Disable retries and run test_list_policy_assignments_value_error.
         _service.disable_retries()
         self.test_list_policy_assignments_value_error()
+
+    @responses.activate
+    def test_list_policy_assignments_with_pager_get_next(self):
+        """
+        test_list_policy_assignments_with_pager_get_next()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v1/policy_assignments')
+        mock_response1 = '{"next":{"start":"1"},"assignments":[{"target":{"type":"Account","id":"id"},"id":"id","account_id":"account_id","href":"href","created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id","resources":[{"target":{"type":"Account","id":"id"},"policy":{"resource_created":{"id":"id"},"status":"status","error_message":{"trace":"trace","errors":[{"code":"insufficent_permissions","message":"message","details":{"conflicts_with":{"etag":"etag","role":"role","policy":"policy"}},"more_info":"more_info"}],"status_code":11}}}],"subject":{"id":"id","type":"iam_id"},"template":{"id":"id","version":"version"},"status":"in_progress"}],"total_count":2,"limit":1}'
+        mock_response2 = '{"assignments":[{"target":{"type":"Account","id":"id"},"id":"id","account_id":"account_id","href":"href","created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id","resources":[{"target":{"type":"Account","id":"id"},"policy":{"resource_created":{"id":"id"},"status":"status","error_message":{"trace":"trace","errors":[{"code":"insufficent_permissions","message":"message","details":{"conflicts_with":{"etag":"etag","role":"role","policy":"policy"}},"more_info":"more_info"}],"status_code":11}}}],"subject":{"id":"id","type":"iam_id"},"template":{"id":"id","version":"version"},"status":"in_progress"}],"total_count":2,"limit":1}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response1,
+            content_type='application/json',
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response2,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Exercise the pager class for this operation
+        all_results = []
+        pager = PolicyAssignmentsPager(
+            client=_service,
+            version='1.0',
+            account_id='testString',
+            accept_language='default',
+            template_id='testString',
+            template_version='testString',
+            limit=10,
+        )
+        while pager.has_next():
+            next_page = pager.get_next()
+            assert next_page is not None
+            all_results.extend(next_page)
+        assert len(all_results) == 2
+
+    @responses.activate
+    def test_list_policy_assignments_with_pager_get_all(self):
+        """
+        test_list_policy_assignments_with_pager_get_all()
+        """
+        # Set up a two-page mock response
+        url = preprocess_url('/v1/policy_assignments')
+        mock_response1 = '{"next":{"start":"1"},"assignments":[{"target":{"type":"Account","id":"id"},"id":"id","account_id":"account_id","href":"href","created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id","resources":[{"target":{"type":"Account","id":"id"},"policy":{"resource_created":{"id":"id"},"status":"status","error_message":{"trace":"trace","errors":[{"code":"insufficent_permissions","message":"message","details":{"conflicts_with":{"etag":"etag","role":"role","policy":"policy"}},"more_info":"more_info"}],"status_code":11}}}],"subject":{"id":"id","type":"iam_id"},"template":{"id":"id","version":"version"},"status":"in_progress"}],"total_count":2,"limit":1}'
+        mock_response2 = '{"assignments":[{"target":{"type":"Account","id":"id"},"id":"id","account_id":"account_id","href":"href","created_at":"2019-01-01T12:00:00.000Z","created_by_id":"created_by_id","last_modified_at":"2019-01-01T12:00:00.000Z","last_modified_by_id":"last_modified_by_id","resources":[{"target":{"type":"Account","id":"id"},"policy":{"resource_created":{"id":"id"},"status":"status","error_message":{"trace":"trace","errors":[{"code":"insufficent_permissions","message":"message","details":{"conflicts_with":{"etag":"etag","role":"role","policy":"policy"}},"more_info":"more_info"}],"status_code":11}}}],"subject":{"id":"id","type":"iam_id"},"template":{"id":"id","version":"version"},"status":"in_progress"}],"total_count":2,"limit":1}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response1,
+            content_type='application/json',
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response2,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Exercise the pager class for this operation
+        pager = PolicyAssignmentsPager(
+            client=_service,
+            version='1.0',
+            account_id='testString',
+            accept_language='default',
+            template_id='testString',
+            template_version='testString',
+            limit=10,
+        )
+        all_results = pager.get_all()
+        assert all_results is not None
+        assert len(all_results) == 2
 
 
 class TestCreatePolicyTemplateAssignment:
@@ -4515,11 +4957,406 @@ class TestDeletePolicyAssignment:
 # End of Service: PolicyAssignments
 ##############################################################################
 
+##############################################################################
+# Start of Service: AccessManagementSettings
+##############################################################################
+# region
+
+
+class TestNewInstance:
+    """
+    Test Class for new_instance
+    """
+
+    def test_new_instance(self):
+        """
+        new_instance()
+        """
+        os.environ['TEST_SERVICE_AUTH_TYPE'] = 'noAuth'
+
+        service = IamPolicyManagementV1.new_instance(
+            service_name='TEST_SERVICE',
+        )
+
+        assert service is not None
+        assert isinstance(service, IamPolicyManagementV1)
+
+    def test_new_instance_without_authenticator(self):
+        """
+        new_instance_without_authenticator()
+        """
+        with pytest.raises(ValueError, match='authenticator must be provided'):
+            service = IamPolicyManagementV1.new_instance(
+                service_name='TEST_SERVICE_NOT_FOUND',
+            )
+
+
+class TestGetSettings:
+    """
+    Test Class for get_settings
+    """
+
+    @responses.activate
+    def test_get_settings_all_params(self):
+        """
+        get_settings()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/accounts/testString/settings/access_management')
+        mock_response = '{"external_account_identity_interaction": {"identity_types": {"user": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}, "service_id": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}, "service": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}}}}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        account_id = 'testString'
+        accept_language = 'default'
+
+        # Invoke method
+        response = _service.get_settings(
+            account_id,
+            accept_language=accept_language,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_settings_all_params_with_retries(self):
+        # Enable retries and run test_get_settings_all_params.
+        _service.enable_retries()
+        self.test_get_settings_all_params()
+
+        # Disable retries and run test_get_settings_all_params.
+        _service.disable_retries()
+        self.test_get_settings_all_params()
+
+    @responses.activate
+    def test_get_settings_required_params(self):
+        """
+        test_get_settings_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/accounts/testString/settings/access_management')
+        mock_response = '{"external_account_identity_interaction": {"identity_types": {"user": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}, "service_id": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}, "service": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}}}}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        account_id = 'testString'
+
+        # Invoke method
+        response = _service.get_settings(
+            account_id,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_settings_required_params_with_retries(self):
+        # Enable retries and run test_get_settings_required_params.
+        _service.enable_retries()
+        self.test_get_settings_required_params()
+
+        # Disable retries and run test_get_settings_required_params.
+        _service.disable_retries()
+        self.test_get_settings_required_params()
+
+    @responses.activate
+    def test_get_settings_value_error(self):
+        """
+        test_get_settings_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/accounts/testString/settings/access_management')
+        mock_response = '{"external_account_identity_interaction": {"identity_types": {"user": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}, "service_id": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}, "service": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}}}}'
+        responses.add(
+            responses.GET,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Set up parameter values
+        account_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "account_id": account_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_settings(**req_copy)
+
+    def test_get_settings_value_error_with_retries(self):
+        # Enable retries and run test_get_settings_value_error.
+        _service.enable_retries()
+        self.test_get_settings_value_error()
+
+        # Disable retries and run test_get_settings_value_error.
+        _service.disable_retries()
+        self.test_get_settings_value_error()
+
+
+class TestUpdateSettings:
+    """
+    Test Class for update_settings
+    """
+
+    @responses.activate
+    def test_update_settings_all_params(self):
+        """
+        update_settings()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/accounts/testString/settings/access_management')
+        mock_response = '{"external_account_identity_interaction": {"identity_types": {"user": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}, "service_id": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}, "service": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}}}}'
+        responses.add(
+            responses.PATCH,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Construct a dict representation of a IdentityTypesBase model
+        identity_types_base_model = {}
+        identity_types_base_model['state'] = 'enabled'
+        identity_types_base_model['external_allowed_accounts'] = ['testString']
+
+        # Construct a dict representation of a IdentityTypesPatch model
+        identity_types_patch_model = {}
+        identity_types_patch_model['user'] = identity_types_base_model
+        identity_types_patch_model['service_id'] = identity_types_base_model
+        identity_types_patch_model['service'] = identity_types_base_model
+
+        # Construct a dict representation of a ExternalAccountIdentityInteractionPatch model
+        external_account_identity_interaction_patch_model = {}
+        external_account_identity_interaction_patch_model['identity_types'] = identity_types_patch_model
+
+        # Set up parameter values
+        account_id = 'testString'
+        if_match = 'testString'
+        external_account_identity_interaction = external_account_identity_interaction_patch_model
+        accept_language = 'default'
+
+        # Invoke method
+        response = _service.update_settings(
+            account_id,
+            if_match,
+            external_account_identity_interaction=external_account_identity_interaction,
+            accept_language=accept_language,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['external_account_identity_interaction'] == external_account_identity_interaction_patch_model
+
+    def test_update_settings_all_params_with_retries(self):
+        # Enable retries and run test_update_settings_all_params.
+        _service.enable_retries()
+        self.test_update_settings_all_params()
+
+        # Disable retries and run test_update_settings_all_params.
+        _service.disable_retries()
+        self.test_update_settings_all_params()
+
+    @responses.activate
+    def test_update_settings_required_params(self):
+        """
+        test_update_settings_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/accounts/testString/settings/access_management')
+        mock_response = '{"external_account_identity_interaction": {"identity_types": {"user": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}, "service_id": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}, "service": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}}}}'
+        responses.add(
+            responses.PATCH,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Construct a dict representation of a IdentityTypesBase model
+        identity_types_base_model = {}
+        identity_types_base_model['state'] = 'enabled'
+        identity_types_base_model['external_allowed_accounts'] = ['testString']
+
+        # Construct a dict representation of a IdentityTypesPatch model
+        identity_types_patch_model = {}
+        identity_types_patch_model['user'] = identity_types_base_model
+        identity_types_patch_model['service_id'] = identity_types_base_model
+        identity_types_patch_model['service'] = identity_types_base_model
+
+        # Construct a dict representation of a ExternalAccountIdentityInteractionPatch model
+        external_account_identity_interaction_patch_model = {}
+        external_account_identity_interaction_patch_model['identity_types'] = identity_types_patch_model
+
+        # Set up parameter values
+        account_id = 'testString'
+        if_match = 'testString'
+        external_account_identity_interaction = external_account_identity_interaction_patch_model
+
+        # Invoke method
+        response = _service.update_settings(
+            account_id,
+            if_match,
+            external_account_identity_interaction=external_account_identity_interaction,
+            headers={},
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['external_account_identity_interaction'] == external_account_identity_interaction_patch_model
+
+    def test_update_settings_required_params_with_retries(self):
+        # Enable retries and run test_update_settings_required_params.
+        _service.enable_retries()
+        self.test_update_settings_required_params()
+
+        # Disable retries and run test_update_settings_required_params.
+        _service.disable_retries()
+        self.test_update_settings_required_params()
+
+    @responses.activate
+    def test_update_settings_value_error(self):
+        """
+        test_update_settings_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v1/accounts/testString/settings/access_management')
+        mock_response = '{"external_account_identity_interaction": {"identity_types": {"user": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}, "service_id": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}, "service": {"state": "enabled", "external_allowed_accounts": ["external_allowed_accounts"]}}}}'
+        responses.add(
+            responses.PATCH,
+            url,
+            body=mock_response,
+            content_type='application/json',
+            status=200,
+        )
+
+        # Construct a dict representation of a IdentityTypesBase model
+        identity_types_base_model = {}
+        identity_types_base_model['state'] = 'enabled'
+        identity_types_base_model['external_allowed_accounts'] = ['testString']
+
+        # Construct a dict representation of a IdentityTypesPatch model
+        identity_types_patch_model = {}
+        identity_types_patch_model['user'] = identity_types_base_model
+        identity_types_patch_model['service_id'] = identity_types_base_model
+        identity_types_patch_model['service'] = identity_types_base_model
+
+        # Construct a dict representation of a ExternalAccountIdentityInteractionPatch model
+        external_account_identity_interaction_patch_model = {}
+        external_account_identity_interaction_patch_model['identity_types'] = identity_types_patch_model
+
+        # Set up parameter values
+        account_id = 'testString'
+        if_match = 'testString'
+        external_account_identity_interaction = external_account_identity_interaction_patch_model
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "account_id": account_id,
+            "if_match": if_match,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.update_settings(**req_copy)
+
+    def test_update_settings_value_error_with_retries(self):
+        # Enable retries and run test_update_settings_value_error.
+        _service.enable_retries()
+        self.test_update_settings_value_error()
+
+        # Disable retries and run test_update_settings_value_error.
+        _service.disable_retries()
+        self.test_update_settings_value_error()
+
+
+# endregion
+##############################################################################
+# End of Service: AccessManagementSettings
+##############################################################################
+
 
 ##############################################################################
 # Start of Model Tests
 ##############################################################################
 # region
+
+
+class TestModel_AccountSettingsAccessManagement:
+    """
+    Test Class for AccountSettingsAccessManagement
+    """
+
+    def test_account_settings_access_management_serialization(self):
+        """
+        Test serialization/deserialization for AccountSettingsAccessManagement
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        identity_types_base_model = {}  # IdentityTypesBase
+        identity_types_base_model['state'] = 'enabled'
+        identity_types_base_model['external_allowed_accounts'] = ['testString']
+
+        identity_types_model = {}  # IdentityTypes
+        identity_types_model['user'] = identity_types_base_model
+        identity_types_model['service_id'] = identity_types_base_model
+        identity_types_model['service'] = identity_types_base_model
+
+        external_account_identity_interaction_model = {}  # ExternalAccountIdentityInteraction
+        external_account_identity_interaction_model['identity_types'] = identity_types_model
+
+        # Construct a json representation of a AccountSettingsAccessManagement model
+        account_settings_access_management_model_json = {}
+        account_settings_access_management_model_json['external_account_identity_interaction'] = (
+            external_account_identity_interaction_model
+        )
+
+        # Construct a model instance of AccountSettingsAccessManagement by calling from_dict on the json representation
+        account_settings_access_management_model = AccountSettingsAccessManagement.from_dict(
+            account_settings_access_management_model_json
+        )
+        assert account_settings_access_management_model != False
+
+        # Construct a model instance of AccountSettingsAccessManagement by calling from_dict on the json representation
+        account_settings_access_management_model_dict = AccountSettingsAccessManagement.from_dict(
+            account_settings_access_management_model_json
+        ).__dict__
+        account_settings_access_management_model2 = AccountSettingsAccessManagement(
+            **account_settings_access_management_model_dict
+        )
+
+        # Verify the model instances are equivalent
+        assert account_settings_access_management_model == account_settings_access_management_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        account_settings_access_management_model_json2 = account_settings_access_management_model.to_dict()
+        assert account_settings_access_management_model_json2 == account_settings_access_management_model_json
 
 
 class TestModel_AssignmentResourceCreated:
@@ -4891,53 +5728,132 @@ class TestModel_ErrorResponse:
         assert error_response_model_json2 == error_response_model_json
 
 
-class TestModel_GetPolicyAssignmentResponsePolicyAssignmentV1Subject:
+class TestModel_ExternalAccountIdentityInteraction:
     """
-    Test Class for GetPolicyAssignmentResponsePolicyAssignmentV1Subject
+    Test Class for ExternalAccountIdentityInteraction
     """
 
-    def test_get_policy_assignment_response_policy_assignment_v1_subject_serialization(self):
+    def test_external_account_identity_interaction_serialization(self):
         """
-        Test serialization/deserialization for GetPolicyAssignmentResponsePolicyAssignmentV1Subject
+        Test serialization/deserialization for ExternalAccountIdentityInteraction
         """
 
-        # Construct a json representation of a GetPolicyAssignmentResponsePolicyAssignmentV1Subject model
-        get_policy_assignment_response_policy_assignment_v1_subject_model_json = {}
+        # Construct dict forms of any model objects needed in order to build this model.
 
-        # Construct a model instance of GetPolicyAssignmentResponsePolicyAssignmentV1Subject by calling from_dict on the json representation
-        get_policy_assignment_response_policy_assignment_v1_subject_model = (
-            GetPolicyAssignmentResponsePolicyAssignmentV1Subject.from_dict(
-                get_policy_assignment_response_policy_assignment_v1_subject_model_json
-            )
-        )
-        assert get_policy_assignment_response_policy_assignment_v1_subject_model != False
+        identity_types_base_model = {}  # IdentityTypesBase
+        identity_types_base_model['state'] = 'enabled'
+        identity_types_base_model['external_allowed_accounts'] = ['testString']
 
-        # Construct a model instance of GetPolicyAssignmentResponsePolicyAssignmentV1Subject by calling from_dict on the json representation
-        get_policy_assignment_response_policy_assignment_v1_subject_model_dict = (
-            GetPolicyAssignmentResponsePolicyAssignmentV1Subject.from_dict(
-                get_policy_assignment_response_policy_assignment_v1_subject_model_json
-            ).__dict__
+        identity_types_model = {}  # IdentityTypes
+        identity_types_model['user'] = identity_types_base_model
+        identity_types_model['service_id'] = identity_types_base_model
+        identity_types_model['service'] = identity_types_base_model
+
+        # Construct a json representation of a ExternalAccountIdentityInteraction model
+        external_account_identity_interaction_model_json = {}
+        external_account_identity_interaction_model_json['identity_types'] = identity_types_model
+
+        # Construct a model instance of ExternalAccountIdentityInteraction by calling from_dict on the json representation
+        external_account_identity_interaction_model = ExternalAccountIdentityInteraction.from_dict(
+            external_account_identity_interaction_model_json
         )
-        get_policy_assignment_response_policy_assignment_v1_subject_model2 = (
-            GetPolicyAssignmentResponsePolicyAssignmentV1Subject(
-                **get_policy_assignment_response_policy_assignment_v1_subject_model_dict
-            )
+        assert external_account_identity_interaction_model != False
+
+        # Construct a model instance of ExternalAccountIdentityInteraction by calling from_dict on the json representation
+        external_account_identity_interaction_model_dict = ExternalAccountIdentityInteraction.from_dict(
+            external_account_identity_interaction_model_json
+        ).__dict__
+        external_account_identity_interaction_model2 = ExternalAccountIdentityInteraction(
+            **external_account_identity_interaction_model_dict
         )
 
         # Verify the model instances are equivalent
-        assert (
-            get_policy_assignment_response_policy_assignment_v1_subject_model
-            == get_policy_assignment_response_policy_assignment_v1_subject_model2
-        )
+        assert external_account_identity_interaction_model == external_account_identity_interaction_model2
 
         # Convert model instance back to dict and verify no loss of data
-        get_policy_assignment_response_policy_assignment_v1_subject_model_json2 = (
-            get_policy_assignment_response_policy_assignment_v1_subject_model.to_dict()
+        external_account_identity_interaction_model_json2 = external_account_identity_interaction_model.to_dict()
+        assert external_account_identity_interaction_model_json2 == external_account_identity_interaction_model_json
+
+
+class TestModel_ExternalAccountIdentityInteractionPatch:
+    """
+    Test Class for ExternalAccountIdentityInteractionPatch
+    """
+
+    def test_external_account_identity_interaction_patch_serialization(self):
+        """
+        Test serialization/deserialization for ExternalAccountIdentityInteractionPatch
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        identity_types_base_model = {}  # IdentityTypesBase
+        identity_types_base_model['state'] = 'enabled'
+        identity_types_base_model['external_allowed_accounts'] = ['testString']
+
+        identity_types_patch_model = {}  # IdentityTypesPatch
+        identity_types_patch_model['user'] = identity_types_base_model
+        identity_types_patch_model['service_id'] = identity_types_base_model
+        identity_types_patch_model['service'] = identity_types_base_model
+
+        # Construct a json representation of a ExternalAccountIdentityInteractionPatch model
+        external_account_identity_interaction_patch_model_json = {}
+        external_account_identity_interaction_patch_model_json['identity_types'] = identity_types_patch_model
+
+        # Construct a model instance of ExternalAccountIdentityInteractionPatch by calling from_dict on the json representation
+        external_account_identity_interaction_patch_model = ExternalAccountIdentityInteractionPatch.from_dict(
+            external_account_identity_interaction_patch_model_json
+        )
+        assert external_account_identity_interaction_patch_model != False
+
+        # Construct a model instance of ExternalAccountIdentityInteractionPatch by calling from_dict on the json representation
+        external_account_identity_interaction_patch_model_dict = ExternalAccountIdentityInteractionPatch.from_dict(
+            external_account_identity_interaction_patch_model_json
+        ).__dict__
+        external_account_identity_interaction_patch_model2 = ExternalAccountIdentityInteractionPatch(
+            **external_account_identity_interaction_patch_model_dict
+        )
+
+        # Verify the model instances are equivalent
+        assert external_account_identity_interaction_patch_model == external_account_identity_interaction_patch_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        external_account_identity_interaction_patch_model_json2 = (
+            external_account_identity_interaction_patch_model.to_dict()
         )
         assert (
-            get_policy_assignment_response_policy_assignment_v1_subject_model_json2
-            == get_policy_assignment_response_policy_assignment_v1_subject_model_json
+            external_account_identity_interaction_patch_model_json2
+            == external_account_identity_interaction_patch_model_json
         )
+
+
+class TestModel_First:
+    """
+    Test Class for First
+    """
+
+    def test_first_serialization(self):
+        """
+        Test serialization/deserialization for First
+        """
+
+        # Construct a json representation of a First model
+        first_model_json = {}
+
+        # Construct a model instance of First by calling from_dict on the json representation
+        first_model = First.from_dict(first_model_json)
+        assert first_model != False
+
+        # Construct a model instance of First by calling from_dict on the json representation
+        first_model_dict = First.from_dict(first_model_json).__dict__
+        first_model2 = First(**first_model_dict)
+
+        # Verify the model instances are equivalent
+        assert first_model == first_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        first_model_json2 = first_model.to_dict()
+        assert first_model_json2 == first_model_json
 
 
 class TestModel_Grant:
@@ -5018,6 +5934,113 @@ class TestModel_GrantWithEnrichedRoles:
         assert grant_with_enriched_roles_model_json2 == grant_with_enriched_roles_model_json
 
 
+class TestModel_IdentityTypes:
+    """
+    Test Class for IdentityTypes
+    """
+
+    def test_identity_types_serialization(self):
+        """
+        Test serialization/deserialization for IdentityTypes
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        identity_types_base_model = {}  # IdentityTypesBase
+        identity_types_base_model['state'] = 'enabled'
+        identity_types_base_model['external_allowed_accounts'] = ['testString']
+
+        # Construct a json representation of a IdentityTypes model
+        identity_types_model_json = {}
+        identity_types_model_json['user'] = identity_types_base_model
+        identity_types_model_json['service_id'] = identity_types_base_model
+        identity_types_model_json['service'] = identity_types_base_model
+
+        # Construct a model instance of IdentityTypes by calling from_dict on the json representation
+        identity_types_model = IdentityTypes.from_dict(identity_types_model_json)
+        assert identity_types_model != False
+
+        # Construct a model instance of IdentityTypes by calling from_dict on the json representation
+        identity_types_model_dict = IdentityTypes.from_dict(identity_types_model_json).__dict__
+        identity_types_model2 = IdentityTypes(**identity_types_model_dict)
+
+        # Verify the model instances are equivalent
+        assert identity_types_model == identity_types_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        identity_types_model_json2 = identity_types_model.to_dict()
+        assert identity_types_model_json2 == identity_types_model_json
+
+
+class TestModel_IdentityTypesBase:
+    """
+    Test Class for IdentityTypesBase
+    """
+
+    def test_identity_types_base_serialization(self):
+        """
+        Test serialization/deserialization for IdentityTypesBase
+        """
+
+        # Construct a json representation of a IdentityTypesBase model
+        identity_types_base_model_json = {}
+        identity_types_base_model_json['state'] = 'enabled'
+        identity_types_base_model_json['external_allowed_accounts'] = ['testString']
+
+        # Construct a model instance of IdentityTypesBase by calling from_dict on the json representation
+        identity_types_base_model = IdentityTypesBase.from_dict(identity_types_base_model_json)
+        assert identity_types_base_model != False
+
+        # Construct a model instance of IdentityTypesBase by calling from_dict on the json representation
+        identity_types_base_model_dict = IdentityTypesBase.from_dict(identity_types_base_model_json).__dict__
+        identity_types_base_model2 = IdentityTypesBase(**identity_types_base_model_dict)
+
+        # Verify the model instances are equivalent
+        assert identity_types_base_model == identity_types_base_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        identity_types_base_model_json2 = identity_types_base_model.to_dict()
+        assert identity_types_base_model_json2 == identity_types_base_model_json
+
+
+class TestModel_IdentityTypesPatch:
+    """
+    Test Class for IdentityTypesPatch
+    """
+
+    def test_identity_types_patch_serialization(self):
+        """
+        Test serialization/deserialization for IdentityTypesPatch
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        identity_types_base_model = {}  # IdentityTypesBase
+        identity_types_base_model['state'] = 'enabled'
+        identity_types_base_model['external_allowed_accounts'] = ['testString']
+
+        # Construct a json representation of a IdentityTypesPatch model
+        identity_types_patch_model_json = {}
+        identity_types_patch_model_json['user'] = identity_types_base_model
+        identity_types_patch_model_json['service_id'] = identity_types_base_model
+        identity_types_patch_model_json['service'] = identity_types_base_model
+
+        # Construct a model instance of IdentityTypesPatch by calling from_dict on the json representation
+        identity_types_patch_model = IdentityTypesPatch.from_dict(identity_types_patch_model_json)
+        assert identity_types_patch_model != False
+
+        # Construct a model instance of IdentityTypesPatch by calling from_dict on the json representation
+        identity_types_patch_model_dict = IdentityTypesPatch.from_dict(identity_types_patch_model_json).__dict__
+        identity_types_patch_model2 = IdentityTypesPatch(**identity_types_patch_model_dict)
+
+        # Verify the model instances are equivalent
+        assert identity_types_patch_model == identity_types_patch_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        identity_types_patch_model_json2 = identity_types_patch_model.to_dict()
+        assert identity_types_patch_model_json2 == identity_types_patch_model_json
+
+
 class TestModel_LimitData:
     """
     Test Class for LimitData
@@ -5045,6 +6068,36 @@ class TestModel_LimitData:
         # Convert model instance back to dict and verify no loss of data
         limit_data_model_json2 = limit_data_model.to_dict()
         assert limit_data_model_json2 == limit_data_model_json
+
+
+class TestModel_Next:
+    """
+    Test Class for Next
+    """
+
+    def test_next_serialization(self):
+        """
+        Test serialization/deserialization for Next
+        """
+
+        # Construct a json representation of a Next model
+        next_model_json = {}
+        next_model_json['start'] = 'testString'
+
+        # Construct a model instance of Next by calling from_dict on the json representation
+        next_model = Next.from_dict(next_model_json)
+        assert next_model != False
+
+        # Construct a model instance of Next by calling from_dict on the json representation
+        next_model_dict = Next.from_dict(next_model_json).__dict__
+        next_model2 = Next(**next_model_dict)
+
+        # Verify the model instances are equivalent
+        assert next_model == next_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        next_model_json2 = next_model.to_dict()
+        assert next_model_json2 == next_model_json
 
 
 class TestModel_Policy:
@@ -5508,6 +6561,14 @@ class TestModel_PolicyCollection:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
+        first_model = {}  # First
+
+        next_model = {}  # Next
+        next_model['start'] = 'testString'
+
+        previous_model = {}  # Previous
+        previous_model['start'] = 'testString'
+
         subject_attribute_model = {}  # SubjectAttribute
         subject_attribute_model['name'] = 'testString'
         subject_attribute_model['value'] = 'testString'
@@ -5550,6 +6611,10 @@ class TestModel_PolicyCollection:
 
         # Construct a json representation of a PolicyCollection model
         policy_collection_model_json = {}
+        policy_collection_model_json['limit'] = 1
+        policy_collection_model_json['first'] = first_model
+        policy_collection_model_json['next'] = next_model
+        policy_collection_model_json['previous'] = previous_model
         policy_collection_model_json['policies'] = [policy_template_meta_data_model]
 
         # Construct a model instance of PolicyCollection by calling from_dict on the json representation
@@ -5772,6 +6837,14 @@ class TestModel_PolicyTemplateAssignmentCollection:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
+        first_model = {}  # First
+
+        next_model = {}  # Next
+        next_model['start'] = 'testString'
+
+        previous_model = {}  # Previous
+        previous_model['start'] = 'testString'
+
         assignment_target_details_model = {}  # AssignmentTargetDetails
         assignment_target_details_model['type'] = 'Account'
         assignment_target_details_model['id'] = 'testString'
@@ -5822,6 +6895,10 @@ class TestModel_PolicyTemplateAssignmentCollection:
 
         # Construct a json representation of a PolicyTemplateAssignmentCollection model
         policy_template_assignment_collection_model_json = {}
+        policy_template_assignment_collection_model_json['limit'] = 1
+        policy_template_assignment_collection_model_json['first'] = first_model
+        policy_template_assignment_collection_model_json['next'] = next_model
+        policy_template_assignment_collection_model_json['previous'] = previous_model
         policy_template_assignment_collection_model_json['assignments'] = [policy_template_assignment_items_model]
 
         # Construct a model instance of PolicyTemplateAssignmentCollection by calling from_dict on the json representation
@@ -5857,6 +6934,14 @@ class TestModel_PolicyTemplateCollection:
         """
 
         # Construct dict forms of any model objects needed in order to build this model.
+
+        first_model = {}  # First
+
+        next_model = {}  # Next
+        next_model['start'] = 'testString'
+
+        previous_model = {}  # Previous
+        previous_model['start'] = 'testString'
 
         v2_policy_resource_attribute_model = {}  # V2PolicyResourceAttribute
         v2_policy_resource_attribute_model['key'] = 'testString'
@@ -5914,6 +6999,10 @@ class TestModel_PolicyTemplateCollection:
 
         # Construct a json representation of a PolicyTemplateCollection model
         policy_template_collection_model_json = {}
+        policy_template_collection_model_json['limit'] = 1
+        policy_template_collection_model_json['first'] = first_model
+        policy_template_collection_model_json['next'] = next_model
+        policy_template_collection_model_json['previous'] = previous_model
         policy_template_collection_model_json['policy_templates'] = [policy_template_model]
 
         # Construct a model instance of PolicyTemplateCollection by calling from_dict on the json representation
@@ -6109,6 +7198,14 @@ class TestModel_PolicyTemplateVersionsCollection:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
+        first_model = {}  # First
+
+        next_model = {}  # Next
+        next_model['start'] = 'testString'
+
+        previous_model = {}  # Previous
+        previous_model['start'] = 'testString'
+
         v2_policy_resource_attribute_model = {}  # V2PolicyResourceAttribute
         v2_policy_resource_attribute_model['key'] = 'testString'
         v2_policy_resource_attribute_model['operator'] = 'stringEquals'
@@ -6165,6 +7262,10 @@ class TestModel_PolicyTemplateVersionsCollection:
 
         # Construct a json representation of a PolicyTemplateVersionsCollection model
         policy_template_versions_collection_model_json = {}
+        policy_template_versions_collection_model_json['limit'] = 1
+        policy_template_versions_collection_model_json['first'] = first_model
+        policy_template_versions_collection_model_json['next'] = next_model
+        policy_template_versions_collection_model_json['previous'] = previous_model
         policy_template_versions_collection_model_json['versions'] = [policy_template_model]
 
         # Construct a model instance of PolicyTemplateVersionsCollection by calling from_dict on the json representation
@@ -6187,6 +7288,36 @@ class TestModel_PolicyTemplateVersionsCollection:
         # Convert model instance back to dict and verify no loss of data
         policy_template_versions_collection_model_json2 = policy_template_versions_collection_model.to_dict()
         assert policy_template_versions_collection_model_json2 == policy_template_versions_collection_model_json
+
+
+class TestModel_Previous:
+    """
+    Test Class for Previous
+    """
+
+    def test_previous_serialization(self):
+        """
+        Test serialization/deserialization for Previous
+        """
+
+        # Construct a json representation of a Previous model
+        previous_model_json = {}
+        previous_model_json['start'] = 'testString'
+
+        # Construct a model instance of Previous by calling from_dict on the json representation
+        previous_model = Previous.from_dict(previous_model_json)
+        assert previous_model != False
+
+        # Construct a model instance of Previous by calling from_dict on the json representation
+        previous_model_dict = Previous.from_dict(previous_model_json).__dict__
+        previous_model2 = Previous(**previous_model_dict)
+
+        # Verify the model instances are equivalent
+        assert previous_model == previous_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        previous_model_json2 = previous_model.to_dict()
+        assert previous_model_json2 == previous_model_json
 
 
 class TestModel_ResourceAttribute:
@@ -6689,6 +7820,14 @@ class TestModel_V2PolicyCollection:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
+        first_model = {}  # First
+
+        next_model = {}  # Next
+        next_model['start'] = 'testString'
+
+        previous_model = {}  # Previous
+        previous_model['start'] = 'testString'
+
         v2_policy_subject_attribute_model = {}  # V2PolicySubjectAttribute
         v2_policy_subject_attribute_model['key'] = 'testString'
         v2_policy_subject_attribute_model['operator'] = 'stringEquals'
@@ -6747,6 +7886,10 @@ class TestModel_V2PolicyCollection:
 
         # Construct a json representation of a V2PolicyCollection model
         v2_policy_collection_model_json = {}
+        v2_policy_collection_model_json['limit'] = 1
+        v2_policy_collection_model_json['first'] = first_model
+        v2_policy_collection_model_json['next'] = next_model
+        v2_policy_collection_model_json['previous'] = previous_model
         v2_policy_collection_model_json['policies'] = [v2_policy_template_meta_data_model]
 
         # Construct a model instance of V2PolicyCollection by calling from_dict on the json representation
@@ -7126,192 +8269,6 @@ class TestModel_ControlResponseControlWithEnrichedRoles:
         assert (
             control_response_control_with_enriched_roles_model_json2
             == control_response_control_with_enriched_roles_model_json
-        )
-
-
-class TestModel_GetPolicyAssignmentResponsePolicyAssignment:
-    """
-    Test Class for GetPolicyAssignmentResponsePolicyAssignment
-    """
-
-    def test_get_policy_assignment_response_policy_assignment_serialization(self):
-        """
-        Test serialization/deserialization for GetPolicyAssignmentResponsePolicyAssignment
-        """
-
-        # Construct dict forms of any model objects needed in order to build this model.
-
-        assignment_resource_created_model = {}  # AssignmentResourceCreated
-        assignment_resource_created_model['id'] = 'testString'
-
-        conflicts_with_model = {}  # ConflictsWith
-        conflicts_with_model['etag'] = 'testString'
-        conflicts_with_model['role'] = 'testString'
-        conflicts_with_model['policy'] = 'testString'
-
-        error_details_model = {}  # ErrorDetails
-        error_details_model['conflicts_with'] = conflicts_with_model
-
-        error_object_model = {}  # ErrorObject
-        error_object_model['code'] = 'insufficent_permissions'
-        error_object_model['message'] = 'testString'
-        error_object_model['details'] = error_details_model
-        error_object_model['more_info'] = 'testString'
-
-        error_response_model = {}  # ErrorResponse
-        error_response_model['trace'] = 'testString'
-        error_response_model['errors'] = [error_object_model]
-        error_response_model['status_code'] = 38
-
-        policy_assignment_resource_policy_model = {}  # PolicyAssignmentResourcePolicy
-        policy_assignment_resource_policy_model['resource_created'] = assignment_resource_created_model
-        policy_assignment_resource_policy_model['status'] = 'testString'
-        policy_assignment_resource_policy_model['error_message'] = error_response_model
-
-        policy_assignment_resources_model = {}  # PolicyAssignmentResources
-        policy_assignment_resources_model['target'] = 'testString'
-        policy_assignment_resources_model['policy'] = policy_assignment_resource_policy_model
-
-        # Construct a json representation of a GetPolicyAssignmentResponsePolicyAssignment model
-        get_policy_assignment_response_policy_assignment_model_json = {}
-        get_policy_assignment_response_policy_assignment_model_json['template_id'] = 'testString'
-        get_policy_assignment_response_policy_assignment_model_json['template_version'] = 'testString'
-        get_policy_assignment_response_policy_assignment_model_json['assignment_id'] = 'testString'
-        get_policy_assignment_response_policy_assignment_model_json['target_type'] = 'Account'
-        get_policy_assignment_response_policy_assignment_model_json['target'] = 'testString'
-        get_policy_assignment_response_policy_assignment_model_json['resources'] = [policy_assignment_resources_model]
-        get_policy_assignment_response_policy_assignment_model_json['status'] = 'in_progress'
-
-        # Construct a model instance of GetPolicyAssignmentResponsePolicyAssignment by calling from_dict on the json representation
-        get_policy_assignment_response_policy_assignment_model = GetPolicyAssignmentResponsePolicyAssignment.from_dict(
-            get_policy_assignment_response_policy_assignment_model_json
-        )
-        assert get_policy_assignment_response_policy_assignment_model != False
-
-        # Construct a model instance of GetPolicyAssignmentResponsePolicyAssignment by calling from_dict on the json representation
-        get_policy_assignment_response_policy_assignment_model_dict = (
-            GetPolicyAssignmentResponsePolicyAssignment.from_dict(
-                get_policy_assignment_response_policy_assignment_model_json
-            ).__dict__
-        )
-        get_policy_assignment_response_policy_assignment_model2 = GetPolicyAssignmentResponsePolicyAssignment(
-            **get_policy_assignment_response_policy_assignment_model_dict
-        )
-
-        # Verify the model instances are equivalent
-        assert (
-            get_policy_assignment_response_policy_assignment_model
-            == get_policy_assignment_response_policy_assignment_model2
-        )
-
-        # Convert model instance back to dict and verify no loss of data
-        get_policy_assignment_response_policy_assignment_model_json2 = (
-            get_policy_assignment_response_policy_assignment_model.to_dict()
-        )
-        assert (
-            get_policy_assignment_response_policy_assignment_model_json2
-            == get_policy_assignment_response_policy_assignment_model_json
-        )
-
-
-class TestModel_GetPolicyAssignmentResponsePolicyAssignmentV1:
-    """
-    Test Class for GetPolicyAssignmentResponsePolicyAssignmentV1
-    """
-
-    def test_get_policy_assignment_response_policy_assignment_v1_serialization(self):
-        """
-        Test serialization/deserialization for GetPolicyAssignmentResponsePolicyAssignmentV1
-        """
-
-        # Construct dict forms of any model objects needed in order to build this model.
-
-        assignment_target_details_model = {}  # AssignmentTargetDetails
-        assignment_target_details_model['type'] = 'Account'
-        assignment_target_details_model['id'] = 'testString'
-
-        assignment_resource_created_model = {}  # AssignmentResourceCreated
-        assignment_resource_created_model['id'] = 'testString'
-
-        conflicts_with_model = {}  # ConflictsWith
-        conflicts_with_model['etag'] = 'testString'
-        conflicts_with_model['role'] = 'testString'
-        conflicts_with_model['policy'] = 'testString'
-
-        error_details_model = {}  # ErrorDetails
-        error_details_model['conflicts_with'] = conflicts_with_model
-
-        error_object_model = {}  # ErrorObject
-        error_object_model['code'] = 'insufficent_permissions'
-        error_object_model['message'] = 'testString'
-        error_object_model['details'] = error_details_model
-        error_object_model['more_info'] = 'testString'
-
-        error_response_model = {}  # ErrorResponse
-        error_response_model['trace'] = 'testString'
-        error_response_model['errors'] = [error_object_model]
-        error_response_model['status_code'] = 38
-
-        policy_assignment_resource_policy_model = {}  # PolicyAssignmentResourcePolicy
-        policy_assignment_resource_policy_model['resource_created'] = assignment_resource_created_model
-        policy_assignment_resource_policy_model['status'] = 'testString'
-        policy_assignment_resource_policy_model['error_message'] = error_response_model
-
-        policy_assignment_v1_resources_model = {}  # PolicyAssignmentV1Resources
-        policy_assignment_v1_resources_model['target'] = assignment_target_details_model
-        policy_assignment_v1_resources_model['policy'] = policy_assignment_resource_policy_model
-
-        get_policy_assignment_response_policy_assignment_v1_subject_model = (
-            {}
-        )  # GetPolicyAssignmentResponsePolicyAssignmentV1Subject
-
-        assignment_template_details_model = {}  # AssignmentTemplateDetails
-        assignment_template_details_model['id'] = 'testString'
-        assignment_template_details_model['version'] = 'testString'
-
-        # Construct a json representation of a GetPolicyAssignmentResponsePolicyAssignmentV1 model
-        get_policy_assignment_response_policy_assignment_v1_model_json = {}
-        get_policy_assignment_response_policy_assignment_v1_model_json['target'] = assignment_target_details_model
-        get_policy_assignment_response_policy_assignment_v1_model_json['resources'] = [
-            policy_assignment_v1_resources_model
-        ]
-        get_policy_assignment_response_policy_assignment_v1_model_json['subject'] = (
-            get_policy_assignment_response_policy_assignment_v1_subject_model
-        )
-        get_policy_assignment_response_policy_assignment_v1_model_json['template'] = assignment_template_details_model
-        get_policy_assignment_response_policy_assignment_v1_model_json['status'] = 'in_progress'
-
-        # Construct a model instance of GetPolicyAssignmentResponsePolicyAssignmentV1 by calling from_dict on the json representation
-        get_policy_assignment_response_policy_assignment_v1_model = (
-            GetPolicyAssignmentResponsePolicyAssignmentV1.from_dict(
-                get_policy_assignment_response_policy_assignment_v1_model_json
-            )
-        )
-        assert get_policy_assignment_response_policy_assignment_v1_model != False
-
-        # Construct a model instance of GetPolicyAssignmentResponsePolicyAssignmentV1 by calling from_dict on the json representation
-        get_policy_assignment_response_policy_assignment_v1_model_dict = (
-            GetPolicyAssignmentResponsePolicyAssignmentV1.from_dict(
-                get_policy_assignment_response_policy_assignment_v1_model_json
-            ).__dict__
-        )
-        get_policy_assignment_response_policy_assignment_v1_model2 = GetPolicyAssignmentResponsePolicyAssignmentV1(
-            **get_policy_assignment_response_policy_assignment_v1_model_dict
-        )
-
-        # Verify the model instances are equivalent
-        assert (
-            get_policy_assignment_response_policy_assignment_v1_model
-            == get_policy_assignment_response_policy_assignment_v1_model2
-        )
-
-        # Convert model instance back to dict and verify no loss of data
-        get_policy_assignment_response_policy_assignment_v1_model_json2 = (
-            get_policy_assignment_response_policy_assignment_v1_model.to_dict()
-        )
-        assert (
-            get_policy_assignment_response_policy_assignment_v1_model_json2
-            == get_policy_assignment_response_policy_assignment_v1_model_json
         )
 
 


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
Adds new Access Management Account Settings API (GET and PATCH paths)

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Issue: https://github.ibm.com/IAM/AM-issues/issues/3316

Examples and Integration Test results:
```sh
(venv) kelum@kelums-mbp platform-services-python-sdk % python -m pytest examples/test_iam_policy_management_v1_examples.py
=============================================================================================================== test session starts ===============================================================================================================
platform darwin -- Python 3.9.6, pytest-7.4.4, pluggy-1.5.0
rootdir: /Users/kelum/MyDocuments/Projects/platform-services-python-sdk
plugins: cov-4.1.0
collected 33 items                                                                                                                                                                                                                                

examples/test_iam_policy_management_v1_examples.py .................................                                                                                                                                                        [100%]

================================================================================================================ warnings summary =================================================================================================================
venv/lib/python3.9/site-packages/urllib3/__init__.py:35
  /Users/kelum/MyDocuments/Projects/platform-services-python-sdk/venv/lib/python3.9/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================= 33 passed, 1 warning in 11.01s ==========================================================================================================
(venv) kelum@kelums-mbp platform-services-python-sdk % python -m pytest test/integration/test_iam_policy_management_v1.py 
=============================================================================================================== test session starts ===============================================================================================================
platform darwin -- Python 3.9.6, pytest-7.4.4, pluggy-1.5.0
rootdir: /Users/kelum/MyDocuments/Projects/platform-services-python-sdk
plugins: cov-4.1.0
collected 35 items                                                                                                                                                                                                                                

test/integration/test_iam_policy_management_v1.py ...................................                                                                                                                                                       [100%]

================================================================================================================ warnings summary =================================================================================================================
venv/lib/python3.9/site-packages/urllib3/__init__.py:35
  /Users/kelum/MyDocuments/Projects/platform-services-python-sdk/venv/lib/python3.9/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================= 35 passed, 1 warning in 15.86s ==========================================================================================================
(venv) kelum@kelums-mbp platform-services-python-sdk % 
```