### PR TITLE
feat(IAM Policy Management): re-gen service after recent API changes for role template references

### DIFF
--- a/examples/test_iam_policy_management_v1_examples.py
+++ b/examples/test_iam_policy_management_v1_examples.py
@@ -72,6 +72,7 @@ example_role_template_version = None
 example_role_template_etag = None
 example_role_template_assignment_id = None
 example_role_template_assignment_etag = None
+example_role_policy_template_id = None
 
 
 ##############################################################################
@@ -1443,10 +1444,17 @@ class TestIamPolicyManagementV1Examples:
             print('\ncreate_role_template() result:')
 
             # begin-create_role_template
-
+            template_role_model = {
+                'name': 'SDKCustomRoleName',
+                'display_name': 'SDK Test Custom Role',
+                'service_name': 'am-test-service',
+                'description': 'SDK Test Custom Role',
+                'actions': ['am-test-service.test.create'],
+            }
             response = iam_policy_management_service.create_role_template(
                 name='SDKRoleTemplateExample',
                 account_id=example_account_id,
+                role=template_role_model,
             )
             role_template = response.get_result()
 
@@ -1458,6 +1466,61 @@ class TestIamPolicyManagementV1Examples:
             print(json.dumps(role_template, indent=2))
 
             # end-create_role_template
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_create_role_policy_template_example(self):
+        """
+        create_role_policy_template request example
+        """
+        try:
+            print('\ncreate_role_policy_template() result:')
+            # begin-create_role_policy_template
+
+            policy_resource_model = {
+                'attributes': [
+                    {
+                        'key': 'serviceName',
+                        'operator': 'stringEquals',
+                        'value': 'am-test-service',
+                    }
+                ],
+            }
+
+            control_model = TemplateControl(
+                grant=TemplateGrant(
+                    roles=[
+                        {
+                            'role_id': 'crn:v1:bluemix:public:iam::::role:Viewer',
+                        }
+                    ],
+                    role_template_references=[
+                        {'id': example_role_template_id, 'version': example_role_template_version}
+                    ],
+                )
+            )
+
+            template_policy_model = {
+                'type': 'access',
+                'resource': policy_resource_model,
+                'control': control_model.to_dict(),
+            }
+
+            response = iam_policy_management_service.create_policy_template(
+                name='SDKExamplesTest',
+                account_id=example_account_id,
+                policy=template_policy_model,
+            )
+            policy_template = response.get_result()
+
+            global example_role_policy_template_id
+            example_role_policy_template_id = policy_template['id']
+
+            print(json.dumps(policy_template, indent=2))
+
+            # end-create_policy_template
 
         except ApiException as e:
             pytest.fail(str(e))
@@ -1498,7 +1561,6 @@ class TestIamPolicyManagementV1Examples:
             # begin-replace_role_template
 
             template_role_model = {
-                'name': 'SDKRoleTemplateExampleRe',
                 'display_name': 'am-test-service',
                 'service_name': 'am-test-service',
                 'actions': ['am-test-service.test.delete'],
@@ -1558,9 +1620,7 @@ class TestIamPolicyManagementV1Examples:
             # begin-create_role_template_version
 
             template_role_model = {
-                'name': 'SDKRoleTemplateExampleVer',
                 'display_name': 'am-test-service',
-                'service_name': 'am-test-service',
                 'actions': ['am-test-service.test.delete', 'am-test-service.test.create'],
             }
 
@@ -1775,6 +1835,24 @@ class TestIamPolicyManagementV1Examples:
 
             # end-delete_role_assignment
             print('\ndelete_role_assignment() response status code: ', response.get_status_code())
+
+        except ApiException as e:
+            pytest.fail(str(e))
+
+    @needscredentials
+    def test_delete_role_policy_template_example(self):
+        """
+        delete_role_policy_template request example
+        """
+        try:
+            # begin-delete_role_policy_template
+
+            response = iam_policy_management_service.delete_policy_template(
+                policy_template_id=example_role_policy_template_id,
+            )
+
+            # end-delete_policy_template
+            print('\ndelete_role_policy_template() response status code: ', response.get_status_code())
 
         except ApiException as e:
             pytest.fail(str(e))

--- a/ibm_platform_services/iam_policy_management_v1.py
+++ b/ibm_platform_services/iam_policy_management_v1.py
@@ -2073,10 +2073,10 @@ class IamPolicyManagementV1(BaseService):
         :param str policy_template_id: The policy template ID.
         :param str version: The policy template version.
         :param str if_match: The revision number for updating a policy template
-               version and must match the ETag value of the existing policy template
+               version and must match the Etag value of the existing policy template
                version. The Etag can be retrieved using the GET
                /v1/policy_templates/{policy_template_id}/versions/{version} API and
-               looking at the ETag response header.
+               looking at the Etag response header.
         :param TemplatePolicy policy: The core set of properties associated with
                the template's policy object.
         :param str name: (optional) Required field when creating a new template.
@@ -3872,7 +3872,7 @@ class IamPolicyManagementV1(BaseService):
         *,
         description: Optional[str] = None,
         committed: Optional[bool] = None,
-        role: Optional['TemplateRole'] = None,
+        role: Optional['RoleTemplatePrototypeRole'] = None,
         accept_language: Optional[str] = None,
         **kwargs,
     ) -> DetailedResponse:
@@ -3893,8 +3893,8 @@ class IamPolicyManagementV1(BaseService):
         :param bool committed: (optional) Committed status of the template. If
                committed is set to true, then the template version can no longer be
                updated.
-        :param TemplateRole role: (optional) The role properties that are created
-               in an action resource when the template is assigned.
+        :param RoleTemplatePrototypeRole role: (optional) The role properties that
+               are created in an action resource when the template is assigned.
         :param str accept_language: (optional) Language code for translations
                * `default` - English
                * `de` -  German (Standard)
@@ -4056,10 +4056,10 @@ class IamPolicyManagementV1(BaseService):
     def create_role_template_version(
         self,
         role_template_id: str,
-        role: 'TemplateRole',
         *,
         name: Optional[str] = None,
         description: Optional[str] = None,
+        role: Optional['TemplateRole'] = None,
         committed: Optional[bool] = None,
         **kwargs,
     ) -> DetailedResponse:
@@ -4070,14 +4070,14 @@ class IamPolicyManagementV1(BaseService):
         role template that is committed.
 
         :param str role_template_id: The role template ID.
-        :param TemplateRole role: The role properties that are created in an action
-               resource when the template is assigned.
         :param str name: (optional) Required field when creating a new template.
                Otherwise, this field is optional. If the field is included, it will change
                the name value for all existing versions of the template.
         :param str description: (optional) Description of the role template. This
                is shown to users in the enterprise account. Use this to describe the
                purpose or context of the role for enterprise users managing IAM templates.
+        :param TemplateRole role: (optional) The role properties that are created
+               in an action resource when the template is assigned.
         :param bool committed: (optional) Committed status of the template version.
                If committed is set to true, then the template version can no longer be
                updated.
@@ -4088,9 +4088,8 @@ class IamPolicyManagementV1(BaseService):
 
         if not role_template_id:
             raise ValueError('role_template_id must be provided')
-        if role is None:
-            raise ValueError('role must be provided')
-        role = convert_model(role)
+        if role is not None:
+            role = convert_model(role)
         headers = {}
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME,
@@ -4100,9 +4099,9 @@ class IamPolicyManagementV1(BaseService):
         headers.update(sdk_headers)
 
         data = {
-            'role': role,
             'name': name,
             'description': description,
+            'role': role,
             'committed': committed,
         }
         data = {k: v for (k, v) in data.items() if v is not None}
@@ -4193,10 +4192,10 @@ class IamPolicyManagementV1(BaseService):
         role_template_id: str,
         version: str,
         if_match: str,
-        role: 'TemplateRole',
         *,
         name: Optional[str] = None,
         description: Optional[str] = None,
+        role: Optional['TemplateRole'] = None,
         committed: Optional[bool] = None,
         **kwargs,
     ) -> DetailedResponse:
@@ -4213,14 +4212,14 @@ class IamPolicyManagementV1(BaseService):
                The Etag can be retrieved using the GET
                /v1/role_templates/{template_id}/versions/{version} API and looking at the
                Etag response header.
-        :param TemplateRole role: The role properties that are created in an action
-               resource when the template is assigned.
         :param str name: (optional) Required field when creating a new template.
                Otherwise, this field is optional. If the field is included, it will change
                the name value for all existing versions of the template.
         :param str description: (optional) Description of the role template. This
                is shown to users in the enterprise account. Use this to describe the
                purpose or context of the role for enterprise users managing IAM templates.
+        :param TemplateRole role: (optional) The role properties that are created
+               in an action resource when the template is assigned.
         :param bool committed: (optional) Committed status of the template version.
                If committed is set to true, then the template version can no longer be
                updated.
@@ -4235,9 +4234,8 @@ class IamPolicyManagementV1(BaseService):
             raise ValueError('version must be provided')
         if not if_match:
             raise ValueError('if_match must be provided')
-        if role is None:
-            raise ValueError('role must be provided')
-        role = convert_model(role)
+        if role is not None:
+            role = convert_model(role)
         headers = {
             'If-Match': if_match,
         }
@@ -4249,9 +4247,9 @@ class IamPolicyManagementV1(BaseService):
         headers.update(sdk_headers)
 
         data = {
-            'role': role,
             'name': name,
             'description': description,
+            'role': role,
             'committed': committed,
         }
         data = {k: v for (k, v) in data.items() if v is not None}
@@ -10552,7 +10550,7 @@ class RoleAssignmentResource:
 
 class RoleAssignmentResourceCreated:
     """
-    On success, it includes the action control assigned.
+    On success, it includes the role assigned.
 
     :param str id: (optional) role id.
     """
@@ -10613,7 +10611,7 @@ class RoleAssignmentResourceRole:
     Set of properties of the assigned resource or error message if assignment failed.
 
     :param RoleAssignmentResourceCreated resource_created: (optional) On success, it
-          includes the action control assigned.
+          includes the role assigned.
     :param AssignmentResourceError error_message: (optional) Body parameters for
           assignment error.
     """
@@ -10628,7 +10626,7 @@ class RoleAssignmentResourceRole:
         Initialize a RoleAssignmentResourceRole object.
 
         :param RoleAssignmentResourceCreated resource_created: (optional) On
-               success, it includes the action control assigned.
+               success, it includes the role assigned.
         :param AssignmentResourceError error_message: (optional) Body parameters
                for assignment error.
         """
@@ -10863,8 +10861,8 @@ class RoleTemplate:
     :param str account_id: Enterprise account ID where this template is created.
     :param bool committed: (optional) Committed status of the template. If committed
           is set to true, then the template version can no longer be updated.
-    :param TemplateRole role: (optional) The role properties that are created in an
-          action resource when the template is assigned.
+    :param RoleTemplatePrototypeRole role: (optional) The role properties that are
+          created in an action resource when the template is assigned.
     :param str id: (optional) The role template ID.
     :param str href: (optional) The href URL that links to the role templates API by
           role template ID.
@@ -10884,13 +10882,13 @@ class RoleTemplate:
     def __init__(
         self,
         name: str,
-        description: str,
         account_id: str,
         version: str,
         state: str,
         *,
+        description: Optional[str] = None,
         committed: Optional[bool] = None,
-        role: Optional['TemplateRole'] = None,
+        role: Optional['RoleTemplatePrototypeRole'] = None,
         id: Optional[str] = None,
         href: Optional[str] = None,
         created_at: Optional[datetime] = None,
@@ -10915,8 +10913,8 @@ class RoleTemplate:
         :param bool committed: (optional) Committed status of the template. If
                committed is set to true, then the template version can no longer be
                updated.
-        :param TemplateRole role: (optional) The role properties that are created
-               in an action resource when the template is assigned.
+        :param RoleTemplatePrototypeRole role: (optional) The role properties that
+               are created in an action resource when the template is assigned.
         """
         self.name = name
         self.description = description
@@ -10942,8 +10940,6 @@ class RoleTemplate:
             raise ValueError('Required property \'name\' not present in RoleTemplate JSON')
         if (description := _dict.get('description')) is not None:
             args['description'] = description
-        else:
-            raise ValueError('Required property \'description\' not present in RoleTemplate JSON')
         if (account_id := _dict.get('account_id')) is not None:
             args['account_id'] = account_id
         else:
@@ -10951,7 +10947,7 @@ class RoleTemplate:
         if (committed := _dict.get('committed')) is not None:
             args['committed'] = committed
         if (role := _dict.get('role')) is not None:
-            args['role'] = TemplateRole.from_dict(role)
+            args['role'] = RoleTemplatePrototypeRole.from_dict(role)
         if (id := _dict.get('id')) is not None:
             args['id'] = id
         if (href := _dict.get('href')) is not None:
@@ -11151,6 +11147,176 @@ class RoleTemplateCollection:
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other: 'RoleTemplateCollection') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class RoleTemplatePrototypeRole:
+    """
+    The role properties that are created in an action resource when the template is
+    assigned.
+
+    :param str name: The name of the role that is used in the CRN. This must be
+          alphanumeric and capitalized.
+    :param str display_name: The display the name of the role that is shown in the
+          console.
+    :param str service_name: (optional) The service name that the role refers.
+    :param str description: (optional) Description of the role.
+    :param List[str] actions: The actions of the role.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        display_name: str,
+        actions: List[str],
+        *,
+        service_name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize a RoleTemplatePrototypeRole object.
+
+        :param str name: The name of the role that is used in the CRN. This must be
+               alphanumeric and capitalized.
+        :param str display_name: The display the name of the role that is shown in
+               the console.
+        :param List[str] actions: The actions of the role.
+        :param str service_name: (optional) The service name that the role refers.
+        :param str description: (optional) Description of the role.
+        """
+        self.name = name
+        self.display_name = display_name
+        self.service_name = service_name
+        self.description = description
+        self.actions = actions
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'RoleTemplatePrototypeRole':
+        """Initialize a RoleTemplatePrototypeRole object from a json dictionary."""
+        args = {}
+        if (name := _dict.get('name')) is not None:
+            args['name'] = name
+        else:
+            raise ValueError('Required property \'name\' not present in RoleTemplatePrototypeRole JSON')
+        if (display_name := _dict.get('display_name')) is not None:
+            args['display_name'] = display_name
+        else:
+            raise ValueError('Required property \'display_name\' not present in RoleTemplatePrototypeRole JSON')
+        if (service_name := _dict.get('service_name')) is not None:
+            args['service_name'] = service_name
+        if (description := _dict.get('description')) is not None:
+            args['description'] = description
+        if (actions := _dict.get('actions')) is not None:
+            args['actions'] = actions
+        else:
+            raise ValueError('Required property \'actions\' not present in RoleTemplatePrototypeRole JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a RoleTemplatePrototypeRole object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'display_name') and self.display_name is not None:
+            _dict['display_name'] = self.display_name
+        if hasattr(self, 'service_name') and self.service_name is not None:
+            _dict['service_name'] = self.service_name
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'actions') and self.actions is not None:
+            _dict['actions'] = self.actions
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this RoleTemplatePrototypeRole object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'RoleTemplatePrototypeRole') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'RoleTemplatePrototypeRole') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class RoleTemplateReferencesItem:
+    """
+    A role template reference associated with a policy template.
+
+    :param str id: The role template ID.
+    :param str version: Role template version.
+    """
+
+    def __init__(
+        self,
+        id: str,
+        version: str,
+    ) -> None:
+        """
+        Initialize a RoleTemplateReferencesItem object.
+
+        :param str id: The role template ID.
+        :param str version: Role template version.
+        """
+        self.id = id
+        self.version = version
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'RoleTemplateReferencesItem':
+        """Initialize a RoleTemplateReferencesItem object from a json dictionary."""
+        args = {}
+        if (id := _dict.get('id')) is not None:
+            args['id'] = id
+        else:
+            raise ValueError('Required property \'id\' not present in RoleTemplateReferencesItem JSON')
+        if (version := _dict.get('version')) is not None:
+            args['version'] = version
+        else:
+            raise ValueError('Required property \'version\' not present in RoleTemplateReferencesItem JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a RoleTemplateReferencesItem object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'id') and self.id is not None:
+            _dict['id'] = self.id
+        if hasattr(self, 'version') and self.version is not None:
+            _dict['version'] = self.version
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this RoleTemplateReferencesItem object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'RoleTemplateReferencesItem') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'RoleTemplateReferencesItem') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -11590,6 +11756,68 @@ class TemplateActionControl:
         return not self == other
 
 
+class TemplateControl:
+    """
+    Specifies the type of access that is granted by the policy.
+
+    :param TemplateGrant grant: Permission is granted by the policy.
+    """
+
+    def __init__(
+        self,
+        grant: 'TemplateGrant',
+    ) -> None:
+        """
+        Initialize a TemplateControl object.
+
+        :param TemplateGrant grant: Permission is granted by the policy.
+        """
+        self.grant = grant
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TemplateControl':
+        """Initialize a TemplateControl object from a json dictionary."""
+        args = {}
+        if (grant := _dict.get('grant')) is not None:
+            args['grant'] = grant
+        else:
+            raise ValueError('Required property \'grant\' not present in TemplateControl JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TemplateControl object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'grant') and self.grant is not None:
+            if isinstance(self.grant, dict):
+                _dict['grant'] = self.grant
+            else:
+                _dict['grant'] = self.grant.to_dict()
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TemplateControl object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TemplateControl') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TemplateControl') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class TemplateCountData:
     """
     policy template count details.
@@ -11662,6 +11890,90 @@ class TemplateCountData:
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other: 'TemplateCountData') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class TemplateGrant:
+    """
+    Permission is granted by the policy.
+
+    :param List[Roles] roles: (optional) A set of role Cloud Resource Names (CRNs)
+          granted by the policy.
+    :param List[RoleTemplateReferencesItem] role_template_references: (optional) A
+          set of role template reference IDs granted by the policy.
+    """
+
+    def __init__(
+        self,
+        *,
+        roles: Optional[List['Roles']] = None,
+        role_template_references: Optional[List['RoleTemplateReferencesItem']] = None,
+    ) -> None:
+        """
+        Initialize a TemplateGrant object.
+
+        :param List[Roles] roles: (optional) A set of role Cloud Resource Names
+               (CRNs) granted by the policy.
+        :param List[RoleTemplateReferencesItem] role_template_references:
+               (optional) A set of role template reference IDs granted by the policy.
+        """
+        self.roles = roles
+        self.role_template_references = role_template_references
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TemplateGrant':
+        """Initialize a TemplateGrant object from a json dictionary."""
+        args = {}
+        if (roles := _dict.get('roles')) is not None:
+            args['roles'] = [Roles.from_dict(v) for v in roles]
+        if (role_template_references := _dict.get('role_template_references')) is not None:
+            args['role_template_references'] = [
+                RoleTemplateReferencesItem.from_dict(v) for v in role_template_references
+            ]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TemplateGrant object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'roles') and self.roles is not None:
+            roles_list = []
+            for v in self.roles:
+                if isinstance(v, dict):
+                    roles_list.append(v)
+                else:
+                    roles_list.append(v.to_dict())
+            _dict['roles'] = roles_list
+        if hasattr(self, 'role_template_references') and self.role_template_references is not None:
+            role_template_references_list = []
+            for v in self.role_template_references:
+                if isinstance(v, dict):
+                    role_template_references_list.append(v)
+                else:
+                    role_template_references_list.append(v.to_dict())
+            _dict['role_template_references'] = role_template_references_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TemplateGrant object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TemplateGrant') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TemplateGrant') -> bool:
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
@@ -11775,8 +12087,8 @@ class TemplatePolicy:
           'time-based-conditions:weekly:custom-hours'.
     :param V2PolicyRule rule: (optional) Additional access conditions associated
           with the policy.
-    :param Control control: (optional) Specifies the type of access that is granted
-          by the policy.
+    :param TemplateControl control: (optional) Specifies the type of access that is
+          granted by the policy.
     """
 
     def __init__(
@@ -11788,7 +12100,7 @@ class TemplatePolicy:
         subject: Optional['V2PolicySubject'] = None,
         pattern: Optional[str] = None,
         rule: Optional['V2PolicyRule'] = None,
-        control: Optional['Control'] = None,
+        control: Optional['TemplateControl'] = None,
     ) -> None:
         """
         Initialize a TemplatePolicy object.
@@ -11806,8 +12118,8 @@ class TemplatePolicy:
                'time-based-conditions:weekly:custom-hours'.
         :param V2PolicyRule rule: (optional) Additional access conditions
                associated with the policy.
-        :param Control control: (optional) Specifies the type of access that is
-               granted by the policy.
+        :param TemplateControl control: (optional) Specifies the type of access
+               that is granted by the policy.
         """
         self.type = type
         self.description = description
@@ -11836,7 +12148,7 @@ class TemplatePolicy:
         if (rule := _dict.get('rule')) is not None:
             args['rule'] = rule
         if (control := _dict.get('control')) is not None:
-            args['control'] = Control.from_dict(control)
+            args['control'] = TemplateControl.from_dict(control)
         return cls(**args)
 
     @classmethod
@@ -11907,36 +12219,30 @@ class TemplateRole:
     The role properties that are created in an action resource when the template is
     assigned.
 
-    :param str name: The name of the role that is used in the CRN. This must be
-          alphanumeric and capitalized.
     :param str display_name: The display the name of the role that is shown in the
           console.
-    :param str service_name: The service name that the role refers.
+    :param str service_name: (optional) The service name that the role refers.
     :param str description: (optional) Description of the role.
     :param List[str] actions: The actions of the role.
     """
 
     def __init__(
         self,
-        name: str,
         display_name: str,
-        service_name: str,
         actions: List[str],
         *,
+        service_name: Optional[str] = None,
         description: Optional[str] = None,
     ) -> None:
         """
         Initialize a TemplateRole object.
 
-        :param str name: The name of the role that is used in the CRN. This must be
-               alphanumeric and capitalized.
         :param str display_name: The display the name of the role that is shown in
                the console.
-        :param str service_name: The service name that the role refers.
         :param List[str] actions: The actions of the role.
+        :param str service_name: (optional) The service name that the role refers.
         :param str description: (optional) Description of the role.
         """
-        self.name = name
         self.display_name = display_name
         self.service_name = service_name
         self.description = description
@@ -11946,18 +12252,12 @@ class TemplateRole:
     def from_dict(cls, _dict: Dict) -> 'TemplateRole':
         """Initialize a TemplateRole object from a json dictionary."""
         args = {}
-        if (name := _dict.get('name')) is not None:
-            args['name'] = name
-        else:
-            raise ValueError('Required property \'name\' not present in TemplateRole JSON')
         if (display_name := _dict.get('display_name')) is not None:
             args['display_name'] = display_name
         else:
             raise ValueError('Required property \'display_name\' not present in TemplateRole JSON')
         if (service_name := _dict.get('service_name')) is not None:
             args['service_name'] = service_name
-        else:
-            raise ValueError('Required property \'service_name\' not present in TemplateRole JSON')
         if (description := _dict.get('description')) is not None:
             args['description'] = description
         if (actions := _dict.get('actions')) is not None:
@@ -11974,8 +12274,6 @@ class TemplateRole:
     def to_dict(self) -> Dict:
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, 'name') and self.name is not None:
-            _dict['name'] = self.name
         if hasattr(self, 'display_name') and self.display_name is not None:
             _dict['display_name'] = self.display_name
         if hasattr(self, 'service_name') and self.service_name is not None:
@@ -13773,6 +14071,146 @@ class PolicyTemplateAssignmentItemsPolicyAssignmentV1(PolicyTemplateAssignmentIt
         SUCCEEDED = 'succeeded'
         SUCCEED_WITH_ERRORS = 'succeed_with_errors'
         FAILED = 'failed'
+
+
+class TemplateGrantRoleReferences(TemplateGrant):
+    """
+    TemplateGrantRoleReferences.
+
+    :param List[RoleTemplateReferencesItem] role_template_references: A set of role
+          template reference IDs granted by the policy.
+    """
+
+    def __init__(
+        self,
+        role_template_references: List['RoleTemplateReferencesItem'],
+    ) -> None:
+        """
+        Initialize a TemplateGrantRoleReferences object.
+
+        :param List[RoleTemplateReferencesItem] role_template_references: A set of
+               role template reference IDs granted by the policy.
+        """
+        # pylint: disable=super-init-not-called
+        self.role_template_references = role_template_references
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TemplateGrantRoleReferences':
+        """Initialize a TemplateGrantRoleReferences object from a json dictionary."""
+        args = {}
+        if (role_template_references := _dict.get('role_template_references')) is not None:
+            args['role_template_references'] = [
+                RoleTemplateReferencesItem.from_dict(v) for v in role_template_references
+            ]
+        else:
+            raise ValueError(
+                'Required property \'role_template_references\' not present in TemplateGrantRoleReferences JSON'
+            )
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TemplateGrantRoleReferences object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'role_template_references') and self.role_template_references is not None:
+            role_template_references_list = []
+            for v in self.role_template_references:
+                if isinstance(v, dict):
+                    role_template_references_list.append(v)
+                else:
+                    role_template_references_list.append(v.to_dict())
+            _dict['role_template_references'] = role_template_references_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TemplateGrantRoleReferences object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TemplateGrantRoleReferences') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TemplateGrantRoleReferences') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class TemplateGrantRoles(TemplateGrant):
+    """
+    TemplateGrantRoles.
+
+    :param List[Roles] roles: A set of role Cloud Resource Names (CRNs) granted by
+          the policy.
+    """
+
+    def __init__(
+        self,
+        roles: List['Roles'],
+    ) -> None:
+        """
+        Initialize a TemplateGrantRoles object.
+
+        :param List[Roles] roles: A set of role Cloud Resource Names (CRNs) granted
+               by the policy.
+        """
+        # pylint: disable=super-init-not-called
+        self.roles = roles
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'TemplateGrantRoles':
+        """Initialize a TemplateGrantRoles object from a json dictionary."""
+        args = {}
+        if (roles := _dict.get('roles')) is not None:
+            args['roles'] = [Roles.from_dict(v) for v in roles]
+        else:
+            raise ValueError('Required property \'roles\' not present in TemplateGrantRoles JSON')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TemplateGrantRoles object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'roles') and self.roles is not None:
+            roles_list = []
+            for v in self.roles:
+                if isinstance(v, dict):
+                    roles_list.append(v)
+                else:
+                    roles_list.append(v.to_dict())
+            _dict['roles'] = roles_list
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this TemplateGrantRoles object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'TemplateGrantRoles') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'TemplateGrantRoles') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
 
 
 class V2PolicyRuleRuleAttribute(V2PolicyRule):

--- a/test/integration/test_iam_policy_management_v1.py
+++ b/test/integration/test_iam_policy_management_v1.py
@@ -158,6 +158,8 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         cls.testRoleTemplateEtag = ""
         cls.testRoleTemplateAssignmentId = ""
         cls.testRoleTemplateAssignmentEtag = ""
+        cls.testRolePolicyTemplateId = ""
+        cls.testRolePolicyTemplateName = cls.testTemplatePrefix + str(random.randint(0, 99999))
 
         print('\nSetup complete.')
 
@@ -1356,7 +1358,47 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         self.__class__.testRoleTemplateId = result.id
         self.__class__.testRoleTemplateVersion = result.version
 
-    def test_53_get_role_template(self):
+    def test_53_create_role_policy_template(self):
+        print("self.testRoleTemplateId", self.testRoleTemplateId)
+        print("self.__class__.testRoleTemplateId", self.__class__.testRoleTemplateId)
+        self.__class__.testPolicyControl = TemplateControl(
+            grant=TemplateGrant(
+                roles=[Roles(role_id=self.__class__.testViewerRoleCrn)],
+                role_template_references=[
+                    RoleTemplateReferencesItem(id=self.testRoleTemplateId, version=self.testRoleTemplateVersion)
+                ],
+            )
+        )
+        self.__class__.testTemplatePolicy = TemplatePolicy(
+            type='access',
+            control=self.testPolicyControl,
+            resource=V2PolicyResource(
+                attributes=[
+                    V2PolicyResourceAttribute(key='serviceName', value='iam-groups', operator='stringEquals'),
+                ],
+            ),
+            description='SDK Test Policy',
+        )
+        response = self.service.create_policy_template(
+            name=self.testRolePolicyTemplateName,
+            account_id=self.testAccountId,
+            policy=self.testTemplatePolicy,
+            description='SDK Test Policy Template',
+        )
+        assert response is not None
+
+        assert response.get_status_code() == 201
+
+        result_dict = response.get_result()
+        assert result_dict is not None
+
+        result = PolicyTemplate.from_dict(result_dict)
+        assert result is not None
+
+        self.__class__.testRolePolicyTemplateId = result.id
+        assert result.state == "active"
+
+    def test_54_get_role_template(self):
         response = self.service.get_role_template(
             role_template_id=self.testRoleTemplateId,
             state='active',
@@ -1371,10 +1413,9 @@ class TestIamPolicyManagementV1(unittest.TestCase):
 
         self.__class__.testRoleTemplateEtag = response.get_headers().get(self.etagHeader)
 
-    def test_54_replace_role_template(self):
+    def test_55_replace_role_template(self):
         # Construct a dict representation of a TemplateRole model
         template_role_model = {
-            'name': self.testCustomRoleName,
             'display_name': 'SDK Test Custom Role',
             'service_name': 'iam-groups',
             'description': 'SDK Test Custom Role',
@@ -1398,7 +1439,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert result is not None
         print("Replace Role Template: ", result)
 
-    def test_55_list_role_templates(self):
+    def test_56_list_role_templates(self):
         response = self.service.list_role_templates(
             account_id=self.testAccountId,
             state='active',
@@ -1412,7 +1453,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert result is not None
         print("List Role Template: ", result)
 
-    def test_56_list_role_templates_with_pager(self):
+    def test_57_list_role_templates_with_pager(self):
         all_results = []
 
         # Test get_next().
@@ -1440,12 +1481,10 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert len(all_results) == len(all_items)
         print(f'\nlist_role_templates() returned a total of {len(all_results)} items(s) using RoleTemplatesPager.')
 
-    def test_57_create_role_template_version(self):
+    def test_58_create_role_template_version(self):
         # Construct a dict representation of a TemplateRole model
         template_role_model = {
-            'name': 'SDKTestRoleVer',
             'display_name': 'SDK Test Custom Role ver',
-            'service_name': 'iam-groups',
             'description': 'SDK Test Custom Role ver',
             'actions': ['iam-groups.groups.delete', 'iam-groups.groups.create'],
         }
@@ -1466,7 +1505,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         self.__class__.testRoleTemplateVersion = result.version
         print("Create Role Template Version: ", result)
 
-    def test_58_list_role_template_versions(self):
+    def test_59_list_role_template_versions(self):
         response = self.service.list_role_template_versions(
             role_template_id=self.testRoleTemplateId,
             state='active',
@@ -1480,7 +1519,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert result is not None
         print("List Role Template Versions: ", result)
 
-    def test_59_list_role_template_versions_with_pager(self):
+    def test_60_list_role_template_versions_with_pager(self):
         all_results = []
 
         # Test get_next().
@@ -1510,7 +1549,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
             f'\nlist_role_template_versions() returned a total of {len(all_results)} items(s) using RoleTemplateVersionsPager.'
         )
 
-    def test_60_get_role_template_version(self):
+    def test_61_get_role_template_version(self):
         response = self.service.get_role_template_version(
             role_template_id=self.testRoleTemplateId,
             version=self.testRoleTemplateVersion,
@@ -1524,7 +1563,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert result is not None
         print("List Role Template Versions: ", result)
 
-    def test_61_commit_role_template(self):
+    def test_62_commit_role_template(self):
         response = self.service.commit_role_template(
             role_template_id=self.testRoleTemplateId,
             version=self.testRoleTemplateVersion,
@@ -1532,7 +1571,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
 
         assert response.get_status_code() == 204
 
-    def test_62_create_role_template_assignment(self):
+    def test_63_create_role_template_assignment(self):
         # Construct a dict representation of a AssignmentTargetDetails model
         assignment_target_details_model = {
             'type': 'Account',
@@ -1560,7 +1599,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
 
         print("Create Role Template Assignment: ", result)
 
-    def test_63_get_role_assignment(self):
+    def test_64_get_role_assignment(self):
         assert self.testRoleTemplateAssignmentId
         print("Assignment ID: ", self.testRoleTemplateAssignmentId)
         response = self.service.get_role_assignment(
@@ -1571,7 +1610,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         result_dict = response.get_result()
         assert result_dict is not None
 
-    def test_64_list_role_assignments(self):
+    def test_65_list_role_assignments(self):
         response = self.service.list_role_assignments(
             account_id=self.testAccountId,
         )
@@ -1580,7 +1619,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         role_assignment_collection = response.get_result()
         assert role_assignment_collection is not None
 
-    def test_65_list_role_assignments_with_pager(self):
+    def test_66_list_role_assignments_with_pager(self):
         all_results = []
 
         # Test get_next().
@@ -1606,7 +1645,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         assert len(all_results) == len(all_items)
         print(f'\nlist_role_assignments() returned a total of {len(all_results)} items(s) using RoleAssignmentsPager.')
 
-    def test_66_update_role_assignment(self):
+    def test_67_update_role_assignment(self):
         response = self.service.update_role_assignment(
             assignment_id=self.testRoleTemplateAssignmentId,
             if_match=self.testRoleTemplateAssignmentEtag,
@@ -1617,14 +1656,20 @@ class TestIamPolicyManagementV1(unittest.TestCase):
         role_assignment = response.get_result()
         assert role_assignment is not None
 
-    def test_67_delete_role_assignment(self):
+    def test_68_delete_role_assignment(self):
         response = self.service.delete_role_assignment(
             assignment_id=self.testRoleTemplateAssignmentId,
         )
 
         assert response.get_status_code() == 204
 
-    def test_68_delete_role_template_version(self):
+    def test_69_delete_role_policy_template(self):
+        response = self.service.delete_policy_template(
+            policy_template_id=self.testRolePolicyTemplateId,
+        )
+        assert response.get_status_code() == 204
+
+    def test_70_delete_role_template_version(self):
         response = self.service.delete_role_template_version(
             role_template_id=self.testRoleTemplateId,
             version=self.testRoleTemplateVersion,
@@ -1632,7 +1677,7 @@ class TestIamPolicyManagementV1(unittest.TestCase):
 
         assert response.get_status_code() == 204
 
-    def test_69_delete_role_template(self):
+    def test_71_delete_role_template(self):
         response = self.service.delete_role_template(
             role_template_id=self.testRoleTemplateId,
         )

--- a/test/unit/test_iam_policy_management_v1.py
+++ b/test/unit/test_iam_policy_management_v1.py
@@ -2903,13 +2903,13 @@ class TestCreatePolicyTemplate:
         roles_model = {}
         roles_model['role_id'] = 'testString'
 
-        # Construct a dict representation of a Grant model
-        grant_model = {}
-        grant_model['roles'] = [roles_model]
+        # Construct a dict representation of a TemplateGrantRoles model
+        template_grant_model = {}
+        template_grant_model['roles'] = [roles_model]
 
-        # Construct a dict representation of a Control model
-        control_model = {}
-        control_model['grant'] = grant_model
+        # Construct a dict representation of a TemplateControl model
+        template_control_model = {}
+        template_control_model['grant'] = template_grant_model
 
         # Construct a dict representation of a TemplatePolicy model
         template_policy_model = {}
@@ -2919,7 +2919,7 @@ class TestCreatePolicyTemplate:
         template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
-        template_policy_model['control'] = control_model
+        template_policy_model['control'] = template_control_model
 
         # Set up parameter values
         name = 'testString'
@@ -3013,13 +3013,13 @@ class TestCreatePolicyTemplate:
         roles_model = {}
         roles_model['role_id'] = 'testString'
 
-        # Construct a dict representation of a Grant model
-        grant_model = {}
-        grant_model['roles'] = [roles_model]
+        # Construct a dict representation of a TemplateGrantRoles model
+        template_grant_model = {}
+        template_grant_model['roles'] = [roles_model]
 
-        # Construct a dict representation of a Control model
-        control_model = {}
-        control_model['grant'] = grant_model
+        # Construct a dict representation of a TemplateControl model
+        template_control_model = {}
+        template_control_model['grant'] = template_grant_model
 
         # Construct a dict representation of a TemplatePolicy model
         template_policy_model = {}
@@ -3029,7 +3029,7 @@ class TestCreatePolicyTemplate:
         template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
-        template_policy_model['control'] = control_model
+        template_policy_model['control'] = template_control_model
 
         # Set up parameter values
         name = 'testString'
@@ -3121,13 +3121,13 @@ class TestCreatePolicyTemplate:
         roles_model = {}
         roles_model['role_id'] = 'testString'
 
-        # Construct a dict representation of a Grant model
-        grant_model = {}
-        grant_model['roles'] = [roles_model]
+        # Construct a dict representation of a TemplateGrantRoles model
+        template_grant_model = {}
+        template_grant_model['roles'] = [roles_model]
 
-        # Construct a dict representation of a Control model
-        control_model = {}
-        control_model['grant'] = grant_model
+        # Construct a dict representation of a TemplateControl model
+        template_control_model = {}
+        template_control_model['grant'] = template_grant_model
 
         # Construct a dict representation of a TemplatePolicy model
         template_policy_model = {}
@@ -3137,7 +3137,7 @@ class TestCreatePolicyTemplate:
         template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
-        template_policy_model['control'] = control_model
+        template_policy_model['control'] = template_control_model
 
         # Set up parameter values
         name = 'testString'
@@ -3425,13 +3425,13 @@ class TestCreatePolicyTemplateVersion:
         roles_model = {}
         roles_model['role_id'] = 'testString'
 
-        # Construct a dict representation of a Grant model
-        grant_model = {}
-        grant_model['roles'] = [roles_model]
+        # Construct a dict representation of a TemplateGrantRoles model
+        template_grant_model = {}
+        template_grant_model['roles'] = [roles_model]
 
-        # Construct a dict representation of a Control model
-        control_model = {}
-        control_model['grant'] = grant_model
+        # Construct a dict representation of a TemplateControl model
+        template_control_model = {}
+        template_control_model['grant'] = template_grant_model
 
         # Construct a dict representation of a TemplatePolicy model
         template_policy_model = {}
@@ -3441,7 +3441,7 @@ class TestCreatePolicyTemplateVersion:
         template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
-        template_policy_model['control'] = control_model
+        template_policy_model['control'] = template_control_model
 
         # Set up parameter values
         policy_template_id = 'testString'
@@ -3532,13 +3532,13 @@ class TestCreatePolicyTemplateVersion:
         roles_model = {}
         roles_model['role_id'] = 'testString'
 
-        # Construct a dict representation of a Grant model
-        grant_model = {}
-        grant_model['roles'] = [roles_model]
+        # Construct a dict representation of a TemplateGrantRoles model
+        template_grant_model = {}
+        template_grant_model['roles'] = [roles_model]
 
-        # Construct a dict representation of a Control model
-        control_model = {}
-        control_model['grant'] = grant_model
+        # Construct a dict representation of a TemplateControl model
+        template_control_model = {}
+        template_control_model['grant'] = template_grant_model
 
         # Construct a dict representation of a TemplatePolicy model
         template_policy_model = {}
@@ -3548,7 +3548,7 @@ class TestCreatePolicyTemplateVersion:
         template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
-        template_policy_model['control'] = control_model
+        template_policy_model['control'] = template_control_model
 
         # Set up parameter values
         policy_template_id = 'testString'
@@ -3839,13 +3839,13 @@ class TestReplacePolicyTemplate:
         roles_model = {}
         roles_model['role_id'] = 'testString'
 
-        # Construct a dict representation of a Grant model
-        grant_model = {}
-        grant_model['roles'] = [roles_model]
+        # Construct a dict representation of a TemplateGrantRoles model
+        template_grant_model = {}
+        template_grant_model['roles'] = [roles_model]
 
-        # Construct a dict representation of a Control model
-        control_model = {}
-        control_model['grant'] = grant_model
+        # Construct a dict representation of a TemplateControl model
+        template_control_model = {}
+        template_control_model['grant'] = template_grant_model
 
         # Construct a dict representation of a TemplatePolicy model
         template_policy_model = {}
@@ -3855,7 +3855,7 @@ class TestReplacePolicyTemplate:
         template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
-        template_policy_model['control'] = control_model
+        template_policy_model['control'] = template_control_model
 
         # Set up parameter values
         policy_template_id = 'testString'
@@ -3950,13 +3950,13 @@ class TestReplacePolicyTemplate:
         roles_model = {}
         roles_model['role_id'] = 'testString'
 
-        # Construct a dict representation of a Grant model
-        grant_model = {}
-        grant_model['roles'] = [roles_model]
+        # Construct a dict representation of a TemplateGrantRoles model
+        template_grant_model = {}
+        template_grant_model['roles'] = [roles_model]
 
-        # Construct a dict representation of a Control model
-        control_model = {}
-        control_model['grant'] = grant_model
+        # Construct a dict representation of a TemplateControl model
+        template_control_model = {}
+        template_control_model['grant'] = template_grant_model
 
         # Construct a dict representation of a TemplatePolicy model
         template_policy_model = {}
@@ -3966,7 +3966,7 @@ class TestReplacePolicyTemplate:
         template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
-        template_policy_model['control'] = control_model
+        template_policy_model['control'] = template_control_model
 
         # Set up parameter values
         policy_template_id = 'testString'
@@ -7551,20 +7551,20 @@ class TestCreateRoleTemplate:
             status=201,
         )
 
-        # Construct a dict representation of a TemplateRole model
-        template_role_model = {}
-        template_role_model['name'] = 'testString'
-        template_role_model['display_name'] = 'testString'
-        template_role_model['service_name'] = 'testString'
-        template_role_model['description'] = 'testString'
-        template_role_model['actions'] = ['testString']
+        # Construct a dict representation of a RoleTemplatePrototypeRole model
+        role_template_prototype_role_model = {}
+        role_template_prototype_role_model['name'] = 'testString'
+        role_template_prototype_role_model['display_name'] = 'testString'
+        role_template_prototype_role_model['service_name'] = 'testString'
+        role_template_prototype_role_model['description'] = 'testString'
+        role_template_prototype_role_model['actions'] = ['testString']
 
         # Set up parameter values
         name = 'testString'
         account_id = 'testString'
         description = 'testString'
         committed = True
-        role = template_role_model
+        role = role_template_prototype_role_model
         accept_language = 'default'
 
         # Invoke method
@@ -7587,7 +7587,7 @@ class TestCreateRoleTemplate:
         assert req_body['account_id'] == 'testString'
         assert req_body['description'] == 'testString'
         assert req_body['committed'] == True
-        assert req_body['role'] == template_role_model
+        assert req_body['role'] == role_template_prototype_role_model
 
     def test_create_role_template_all_params_with_retries(self):
         # Enable retries and run test_create_role_template_all_params.
@@ -7614,20 +7614,20 @@ class TestCreateRoleTemplate:
             status=201,
         )
 
-        # Construct a dict representation of a TemplateRole model
-        template_role_model = {}
-        template_role_model['name'] = 'testString'
-        template_role_model['display_name'] = 'testString'
-        template_role_model['service_name'] = 'testString'
-        template_role_model['description'] = 'testString'
-        template_role_model['actions'] = ['testString']
+        # Construct a dict representation of a RoleTemplatePrototypeRole model
+        role_template_prototype_role_model = {}
+        role_template_prototype_role_model['name'] = 'testString'
+        role_template_prototype_role_model['display_name'] = 'testString'
+        role_template_prototype_role_model['service_name'] = 'testString'
+        role_template_prototype_role_model['description'] = 'testString'
+        role_template_prototype_role_model['actions'] = ['testString']
 
         # Set up parameter values
         name = 'testString'
         account_id = 'testString'
         description = 'testString'
         committed = True
-        role = template_role_model
+        role = role_template_prototype_role_model
 
         # Invoke method
         response = _service.create_role_template(
@@ -7648,7 +7648,7 @@ class TestCreateRoleTemplate:
         assert req_body['account_id'] == 'testString'
         assert req_body['description'] == 'testString'
         assert req_body['committed'] == True
-        assert req_body['role'] == template_role_model
+        assert req_body['role'] == role_template_prototype_role_model
 
     def test_create_role_template_required_params_with_retries(self):
         # Enable retries and run test_create_role_template_required_params.
@@ -7675,20 +7675,20 @@ class TestCreateRoleTemplate:
             status=201,
         )
 
-        # Construct a dict representation of a TemplateRole model
-        template_role_model = {}
-        template_role_model['name'] = 'testString'
-        template_role_model['display_name'] = 'testString'
-        template_role_model['service_name'] = 'testString'
-        template_role_model['description'] = 'testString'
-        template_role_model['actions'] = ['testString']
+        # Construct a dict representation of a RoleTemplatePrototypeRole model
+        role_template_prototype_role_model = {}
+        role_template_prototype_role_model['name'] = 'testString'
+        role_template_prototype_role_model['display_name'] = 'testString'
+        role_template_prototype_role_model['service_name'] = 'testString'
+        role_template_prototype_role_model['description'] = 'testString'
+        role_template_prototype_role_model['actions'] = ['testString']
 
         # Set up parameter values
         name = 'testString'
         account_id = 'testString'
         description = 'testString'
         committed = True
-        role = template_role_model
+        role = role_template_prototype_role_model
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
@@ -7933,7 +7933,6 @@ class TestCreateRoleTemplateVersion:
 
         # Construct a dict representation of a TemplateRole model
         template_role_model = {}
-        template_role_model['name'] = 'testString'
         template_role_model['display_name'] = 'testString'
         template_role_model['service_name'] = 'testString'
         template_role_model['description'] = 'testString'
@@ -7941,17 +7940,17 @@ class TestCreateRoleTemplateVersion:
 
         # Set up parameter values
         role_template_id = 'testString'
-        role = template_role_model
         name = 'testString'
         description = 'testString'
+        role = template_role_model
         committed = True
 
         # Invoke method
         response = _service.create_role_template_version(
             role_template_id,
-            role,
             name=name,
             description=description,
+            role=role,
             committed=committed,
             headers={},
         )
@@ -7961,9 +7960,9 @@ class TestCreateRoleTemplateVersion:
         assert response.status_code == 201
         # Validate body params
         req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
-        assert req_body['role'] == template_role_model
         assert req_body['name'] == 'testString'
         assert req_body['description'] == 'testString'
+        assert req_body['role'] == template_role_model
         assert req_body['committed'] == True
 
     def test_create_role_template_version_all_params_with_retries(self):
@@ -7993,7 +7992,6 @@ class TestCreateRoleTemplateVersion:
 
         # Construct a dict representation of a TemplateRole model
         template_role_model = {}
-        template_role_model['name'] = 'testString'
         template_role_model['display_name'] = 'testString'
         template_role_model['service_name'] = 'testString'
         template_role_model['description'] = 'testString'
@@ -8001,15 +7999,14 @@ class TestCreateRoleTemplateVersion:
 
         # Set up parameter values
         role_template_id = 'testString'
-        role = template_role_model
         name = 'testString'
         description = 'testString'
+        role = template_role_model
         committed = True
 
         # Pass in all but one required param and check for a ValueError
         req_param_dict = {
             "role_template_id": role_template_id,
-            "role": role,
         }
         for param in req_param_dict.keys():
             req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
@@ -8253,7 +8250,6 @@ class TestReplaceRoleTemplate:
 
         # Construct a dict representation of a TemplateRole model
         template_role_model = {}
-        template_role_model['name'] = 'testString'
         template_role_model['display_name'] = 'testString'
         template_role_model['service_name'] = 'testString'
         template_role_model['description'] = 'testString'
@@ -8263,9 +8259,9 @@ class TestReplaceRoleTemplate:
         role_template_id = 'testString'
         version = 'testString'
         if_match = 'testString'
-        role = template_role_model
         name = 'testString'
         description = 'testString'
+        role = template_role_model
         committed = True
 
         # Invoke method
@@ -8273,9 +8269,9 @@ class TestReplaceRoleTemplate:
             role_template_id,
             version,
             if_match,
-            role,
             name=name,
             description=description,
+            role=role,
             committed=committed,
             headers={},
         )
@@ -8285,9 +8281,9 @@ class TestReplaceRoleTemplate:
         assert response.status_code == 200
         # Validate body params
         req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
-        assert req_body['role'] == template_role_model
         assert req_body['name'] == 'testString'
         assert req_body['description'] == 'testString'
+        assert req_body['role'] == template_role_model
         assert req_body['committed'] == True
 
     def test_replace_role_template_all_params_with_retries(self):
@@ -8317,7 +8313,6 @@ class TestReplaceRoleTemplate:
 
         # Construct a dict representation of a TemplateRole model
         template_role_model = {}
-        template_role_model['name'] = 'testString'
         template_role_model['display_name'] = 'testString'
         template_role_model['service_name'] = 'testString'
         template_role_model['description'] = 'testString'
@@ -8327,9 +8322,9 @@ class TestReplaceRoleTemplate:
         role_template_id = 'testString'
         version = 'testString'
         if_match = 'testString'
-        role = template_role_model
         name = 'testString'
         description = 'testString'
+        role = template_role_model
         committed = True
 
         # Pass in all but one required param and check for a ValueError
@@ -8337,7 +8332,6 @@ class TestReplaceRoleTemplate:
             "role_template_id": role_template_id,
             "version": version,
             "if_match": if_match,
-            "role": role,
         }
         for param in req_param_dict.keys():
             req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
@@ -11295,11 +11289,11 @@ class TestModel_PolicyTemplate:
         roles_model = {}  # Roles
         roles_model['role_id'] = 'testString'
 
-        grant_model = {}  # Grant
-        grant_model['roles'] = [roles_model]
+        template_grant_model = {}  # TemplateGrantRoles
+        template_grant_model['roles'] = [roles_model]
 
-        control_model = {}  # Control
-        control_model['grant'] = grant_model
+        template_control_model = {}  # TemplateControl
+        template_control_model['grant'] = template_grant_model
 
         template_policy_model = {}  # TemplatePolicy
         template_policy_model['type'] = 'access'
@@ -11308,7 +11302,7 @@ class TestModel_PolicyTemplate:
         template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
-        template_policy_model['control'] = control_model
+        template_policy_model['control'] = template_control_model
 
         # Construct a json representation of a PolicyTemplate model
         policy_template_model_json = {}
@@ -11486,11 +11480,11 @@ class TestModel_PolicyTemplateCollection:
         roles_model = {}  # Roles
         roles_model['role_id'] = 'testString'
 
-        grant_model = {}  # Grant
-        grant_model['roles'] = [roles_model]
+        template_grant_model = {}  # TemplateGrantRoles
+        template_grant_model['roles'] = [roles_model]
 
-        control_model = {}  # Control
-        control_model['grant'] = grant_model
+        template_control_model = {}  # TemplateControl
+        template_control_model['grant'] = template_grant_model
 
         template_policy_model = {}  # TemplatePolicy
         template_policy_model['type'] = 'access'
@@ -11499,7 +11493,7 @@ class TestModel_PolicyTemplateCollection:
         template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
-        template_policy_model['control'] = control_model
+        template_policy_model['control'] = template_control_model
 
         policy_template_model = {}  # PolicyTemplate
         policy_template_model['name'] = 'testString'
@@ -11578,11 +11572,11 @@ class TestModel_PolicyTemplateLimitData:
         roles_model = {}  # Roles
         roles_model['role_id'] = 'testString'
 
-        grant_model = {}  # Grant
-        grant_model['roles'] = [roles_model]
+        template_grant_model = {}  # TemplateGrantRoles
+        template_grant_model['roles'] = [roles_model]
 
-        control_model = {}  # Control
-        control_model['grant'] = grant_model
+        template_control_model = {}  # TemplateControl
+        template_control_model['grant'] = template_grant_model
 
         template_policy_model = {}  # TemplatePolicy
         template_policy_model['type'] = 'access'
@@ -11591,7 +11585,7 @@ class TestModel_PolicyTemplateLimitData:
         template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
-        template_policy_model['control'] = control_model
+        template_policy_model['control'] = template_control_model
 
         limit_data_model = {}  # LimitData
 
@@ -11749,11 +11743,11 @@ class TestModel_PolicyTemplateVersionsCollection:
         roles_model = {}  # Roles
         roles_model['role_id'] = 'testString'
 
-        grant_model = {}  # Grant
-        grant_model['roles'] = [roles_model]
+        template_grant_model = {}  # TemplateGrantRoles
+        template_grant_model['roles'] = [roles_model]
 
-        control_model = {}  # Control
-        control_model['grant'] = grant_model
+        template_control_model = {}  # TemplateControl
+        template_control_model['grant'] = template_grant_model
 
         template_policy_model = {}  # TemplatePolicy
         template_policy_model['type'] = 'access'
@@ -11762,7 +11756,7 @@ class TestModel_PolicyTemplateVersionsCollection:
         template_policy_model['subject'] = v2_policy_subject_model
         template_policy_model['pattern'] = 'testString'
         template_policy_model['rule'] = v2_policy_rule_model
-        template_policy_model['control'] = control_model
+        template_policy_model['control'] = template_control_model
 
         policy_template_model = {}  # PolicyTemplate
         policy_template_model['name'] = 'testString'
@@ -12316,12 +12310,12 @@ class TestModel_RoleTemplate:
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        template_role_model = {}  # TemplateRole
-        template_role_model['name'] = 'testString'
-        template_role_model['display_name'] = 'testString'
-        template_role_model['service_name'] = 'testString'
-        template_role_model['description'] = 'testString'
-        template_role_model['actions'] = ['testString']
+        role_template_prototype_role_model = {}  # RoleTemplatePrototypeRole
+        role_template_prototype_role_model['name'] = 'testString'
+        role_template_prototype_role_model['display_name'] = 'testString'
+        role_template_prototype_role_model['service_name'] = 'testString'
+        role_template_prototype_role_model['description'] = 'testString'
+        role_template_prototype_role_model['actions'] = ['testString']
 
         # Construct a json representation of a RoleTemplate model
         role_template_model_json = {}
@@ -12329,7 +12323,7 @@ class TestModel_RoleTemplate:
         role_template_model_json['description'] = 'testString'
         role_template_model_json['account_id'] = 'testString'
         role_template_model_json['committed'] = True
-        role_template_model_json['role'] = template_role_model
+        role_template_model_json['role'] = role_template_prototype_role_model
         role_template_model_json['version'] = 'testString'
         role_template_model_json['state'] = 'active'
 
@@ -12369,19 +12363,19 @@ class TestModel_RoleTemplateCollection:
         previous_model = {}  # Previous
         previous_model['start'] = 'testString'
 
-        template_role_model = {}  # TemplateRole
-        template_role_model['name'] = 'testString'
-        template_role_model['display_name'] = 'testString'
-        template_role_model['service_name'] = 'testString'
-        template_role_model['description'] = 'testString'
-        template_role_model['actions'] = ['testString']
+        role_template_prototype_role_model = {}  # RoleTemplatePrototypeRole
+        role_template_prototype_role_model['name'] = 'testString'
+        role_template_prototype_role_model['display_name'] = 'testString'
+        role_template_prototype_role_model['service_name'] = 'testString'
+        role_template_prototype_role_model['description'] = 'testString'
+        role_template_prototype_role_model['actions'] = ['testString']
 
         role_template_model = {}  # RoleTemplate
         role_template_model['name'] = 'testString'
         role_template_model['description'] = 'testString'
         role_template_model['account_id'] = 'testString'
         role_template_model['committed'] = True
-        role_template_model['role'] = template_role_model
+        role_template_model['role'] = role_template_prototype_role_model
         role_template_model['version'] = 'testString'
         role_template_model['state'] = 'active'
 
@@ -12411,6 +12405,79 @@ class TestModel_RoleTemplateCollection:
         assert role_template_collection_model_json2 == role_template_collection_model_json
 
 
+class TestModel_RoleTemplatePrototypeRole:
+    """
+    Test Class for RoleTemplatePrototypeRole
+    """
+
+    def test_role_template_prototype_role_serialization(self):
+        """
+        Test serialization/deserialization for RoleTemplatePrototypeRole
+        """
+
+        # Construct a json representation of a RoleTemplatePrototypeRole model
+        role_template_prototype_role_model_json = {}
+        role_template_prototype_role_model_json['name'] = 'testString'
+        role_template_prototype_role_model_json['display_name'] = 'testString'
+        role_template_prototype_role_model_json['service_name'] = 'testString'
+        role_template_prototype_role_model_json['description'] = 'testString'
+        role_template_prototype_role_model_json['actions'] = ['testString']
+
+        # Construct a model instance of RoleTemplatePrototypeRole by calling from_dict on the json representation
+        role_template_prototype_role_model = RoleTemplatePrototypeRole.from_dict(
+            role_template_prototype_role_model_json
+        )
+        assert role_template_prototype_role_model != False
+
+        # Construct a model instance of RoleTemplatePrototypeRole by calling from_dict on the json representation
+        role_template_prototype_role_model_dict = RoleTemplatePrototypeRole.from_dict(
+            role_template_prototype_role_model_json
+        ).__dict__
+        role_template_prototype_role_model2 = RoleTemplatePrototypeRole(**role_template_prototype_role_model_dict)
+
+        # Verify the model instances are equivalent
+        assert role_template_prototype_role_model == role_template_prototype_role_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        role_template_prototype_role_model_json2 = role_template_prototype_role_model.to_dict()
+        assert role_template_prototype_role_model_json2 == role_template_prototype_role_model_json
+
+
+class TestModel_RoleTemplateReferencesItem:
+    """
+    Test Class for RoleTemplateReferencesItem
+    """
+
+    def test_role_template_references_item_serialization(self):
+        """
+        Test serialization/deserialization for RoleTemplateReferencesItem
+        """
+
+        # Construct a json representation of a RoleTemplateReferencesItem model
+        role_template_references_item_model_json = {}
+        role_template_references_item_model_json['id'] = 'testString'
+        role_template_references_item_model_json['version'] = 'testString'
+
+        # Construct a model instance of RoleTemplateReferencesItem by calling from_dict on the json representation
+        role_template_references_item_model = RoleTemplateReferencesItem.from_dict(
+            role_template_references_item_model_json
+        )
+        assert role_template_references_item_model != False
+
+        # Construct a model instance of RoleTemplateReferencesItem by calling from_dict on the json representation
+        role_template_references_item_model_dict = RoleTemplateReferencesItem.from_dict(
+            role_template_references_item_model_json
+        ).__dict__
+        role_template_references_item_model2 = RoleTemplateReferencesItem(**role_template_references_item_model_dict)
+
+        # Verify the model instances are equivalent
+        assert role_template_references_item_model == role_template_references_item_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        role_template_references_item_model_json2 = role_template_references_item_model.to_dict()
+        assert role_template_references_item_model_json2 == role_template_references_item_model_json
+
+
 class TestModel_RoleTemplateVersionsCollection:
     """
     Test Class for RoleTemplateVersionsCollection
@@ -12431,19 +12498,19 @@ class TestModel_RoleTemplateVersionsCollection:
         previous_model = {}  # Previous
         previous_model['start'] = 'testString'
 
-        template_role_model = {}  # TemplateRole
-        template_role_model['name'] = 'testString'
-        template_role_model['display_name'] = 'testString'
-        template_role_model['service_name'] = 'testString'
-        template_role_model['description'] = 'testString'
-        template_role_model['actions'] = ['testString']
+        role_template_prototype_role_model = {}  # RoleTemplatePrototypeRole
+        role_template_prototype_role_model['name'] = 'testString'
+        role_template_prototype_role_model['display_name'] = 'testString'
+        role_template_prototype_role_model['service_name'] = 'testString'
+        role_template_prototype_role_model['description'] = 'testString'
+        role_template_prototype_role_model['actions'] = ['testString']
 
         role_template_model = {}  # RoleTemplate
         role_template_model['name'] = 'testString'
         role_template_model['description'] = 'testString'
         role_template_model['account_id'] = 'testString'
         role_template_model['committed'] = True
-        role_template_model['role'] = template_role_model
+        role_template_model['role'] = role_template_prototype_role_model
         role_template_model['version'] = 'testString'
         role_template_model['state'] = 'active'
 
@@ -12604,6 +12671,44 @@ class TestModel_TemplateActionControl:
         assert template_action_control_model_json2 == template_action_control_model_json
 
 
+class TestModel_TemplateControl:
+    """
+    Test Class for TemplateControl
+    """
+
+    def test_template_control_serialization(self):
+        """
+        Test serialization/deserialization for TemplateControl
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        roles_model = {}  # Roles
+        roles_model['role_id'] = 'testString'
+
+        template_grant_model = {}  # TemplateGrantRoles
+        template_grant_model['roles'] = [roles_model]
+
+        # Construct a json representation of a TemplateControl model
+        template_control_model_json = {}
+        template_control_model_json['grant'] = template_grant_model
+
+        # Construct a model instance of TemplateControl by calling from_dict on the json representation
+        template_control_model = TemplateControl.from_dict(template_control_model_json)
+        assert template_control_model != False
+
+        # Construct a model instance of TemplateControl by calling from_dict on the json representation
+        template_control_model_dict = TemplateControl.from_dict(template_control_model_json).__dict__
+        template_control_model2 = TemplateControl(**template_control_model_dict)
+
+        # Verify the model instances are equivalent
+        assert template_control_model == template_control_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        template_control_model_json2 = template_control_model.to_dict()
+        assert template_control_model_json2 == template_control_model_json
+
+
 class TestModel_TemplateCountData:
     """
     Test Class for TemplateCountData
@@ -12715,11 +12820,11 @@ class TestModel_TemplatePolicy:
         roles_model = {}  # Roles
         roles_model['role_id'] = 'testString'
 
-        grant_model = {}  # Grant
-        grant_model['roles'] = [roles_model]
+        template_grant_model = {}  # TemplateGrantRoles
+        template_grant_model['roles'] = [roles_model]
 
-        control_model = {}  # Control
-        control_model['grant'] = grant_model
+        template_control_model = {}  # TemplateControl
+        template_control_model['grant'] = template_grant_model
 
         # Construct a json representation of a TemplatePolicy model
         template_policy_model_json = {}
@@ -12729,7 +12834,7 @@ class TestModel_TemplatePolicy:
         template_policy_model_json['subject'] = v2_policy_subject_model
         template_policy_model_json['pattern'] = 'testString'
         template_policy_model_json['rule'] = v2_policy_rule_model
-        template_policy_model_json['control'] = control_model
+        template_policy_model_json['control'] = template_control_model
 
         # Construct a model instance of TemplatePolicy by calling from_dict on the json representation
         template_policy_model = TemplatePolicy.from_dict(template_policy_model_json)
@@ -12759,7 +12864,6 @@ class TestModel_TemplateRole:
 
         # Construct a json representation of a TemplateRole model
         template_role_model_json = {}
-        template_role_model_json['name'] = 'testString'
         template_role_model_json['display_name'] = 'testString'
         template_role_model_json['service_name'] = 'testString'
         template_role_model_json['description'] = 'testString'
@@ -13590,6 +13694,81 @@ class TestModel_PolicyTemplateAssignmentItemsPolicyAssignmentV1:
             policy_template_assignment_items_policy_assignment_v1_model_json2
             == policy_template_assignment_items_policy_assignment_v1_model_json
         )
+
+
+class TestModel_TemplateGrantRoleReferences:
+    """
+    Test Class for TemplateGrantRoleReferences
+    """
+
+    def test_template_grant_role_references_serialization(self):
+        """
+        Test serialization/deserialization for TemplateGrantRoleReferences
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        role_template_references_item_model = {}  # RoleTemplateReferencesItem
+        role_template_references_item_model['id'] = 'testString'
+        role_template_references_item_model['version'] = 'testString'
+
+        # Construct a json representation of a TemplateGrantRoleReferences model
+        template_grant_role_references_model_json = {}
+        template_grant_role_references_model_json['role_template_references'] = [role_template_references_item_model]
+
+        # Construct a model instance of TemplateGrantRoleReferences by calling from_dict on the json representation
+        template_grant_role_references_model = TemplateGrantRoleReferences.from_dict(
+            template_grant_role_references_model_json
+        )
+        assert template_grant_role_references_model != False
+
+        # Construct a model instance of TemplateGrantRoleReferences by calling from_dict on the json representation
+        template_grant_role_references_model_dict = TemplateGrantRoleReferences.from_dict(
+            template_grant_role_references_model_json
+        ).__dict__
+        template_grant_role_references_model2 = TemplateGrantRoleReferences(**template_grant_role_references_model_dict)
+
+        # Verify the model instances are equivalent
+        assert template_grant_role_references_model == template_grant_role_references_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        template_grant_role_references_model_json2 = template_grant_role_references_model.to_dict()
+        assert template_grant_role_references_model_json2 == template_grant_role_references_model_json
+
+
+class TestModel_TemplateGrantRoles:
+    """
+    Test Class for TemplateGrantRoles
+    """
+
+    def test_template_grant_roles_serialization(self):
+        """
+        Test serialization/deserialization for TemplateGrantRoles
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        roles_model = {}  # Roles
+        roles_model['role_id'] = 'testString'
+
+        # Construct a json representation of a TemplateGrantRoles model
+        template_grant_roles_model_json = {}
+        template_grant_roles_model_json['roles'] = [roles_model]
+
+        # Construct a model instance of TemplateGrantRoles by calling from_dict on the json representation
+        template_grant_roles_model = TemplateGrantRoles.from_dict(template_grant_roles_model_json)
+        assert template_grant_roles_model != False
+
+        # Construct a model instance of TemplateGrantRoles by calling from_dict on the json representation
+        template_grant_roles_model_dict = TemplateGrantRoles.from_dict(template_grant_roles_model_json).__dict__
+        template_grant_roles_model2 = TemplateGrantRoles(**template_grant_roles_model_dict)
+
+        # Verify the model instances are equivalent
+        assert template_grant_roles_model == template_grant_roles_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        template_grant_roles_model_json2 = template_grant_roles_model.to_dict()
+        assert template_grant_roles_model_json2 == template_grant_roles_model_json
 
 
 class TestModel_V2PolicyRuleRuleAttribute:


### PR DESCRIPTION
## PR summary
This PR includes changes for role_template_references changes for policy template creation.


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
Currently we do not support role_template_references in policy templates. With this new behaviour, we are adding that functionality

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

## Other information
https://github.ibm.com/IAM/AM-issues/issues/4045