### PR TITLE
fix(IAM Identity): add PowerVS compute resource type support

### DIFF
--- a/ibm_platform_services/iam_identity_v1.py
+++ b/ibm_platform_services/iam_identity_v1.py
@@ -56,9 +56,7 @@ class IamIdentityV1(BaseService):
                parameters and external configuration.
         """
         authenticator = get_authenticator_from_environment(service_name)
-        service = cls(
-            authenticator
-            )
+        service = cls(authenticator)
         service.configure_service(service_name)
         return service
 
@@ -3243,8 +3241,8 @@ class IamIdentityV1(BaseService):
         iam_id: str,
         service: str,
         preference_id: str,
-        value_string: str,
         *,
+        value_string: Optional[str] = None,
         value_list_of_strings: Optional[List[str]] = None,
         **kwargs,
     ) -> DetailedResponse:
@@ -3288,9 +3286,9 @@ class IamIdentityV1(BaseService):
         :param str iam_id: IAM id to update the preference for.
         :param str service: Service of the preference to be updated.
         :param str preference_id: Identifier of preference to be updated.
-        :param str value_string: contains a string value of the preference. only
-               one value property is set, either 'value_string' or 'value_list_of_strings'
-               is present.
+        :param str value_string: (optional) contains a string value of the
+               preference. only one value property is set, either 'value_string' or
+               'value_list_of_strings' is present.
         :param List[str] value_list_of_strings: (optional) contains a list of
                string values of the preference. only one value property is set, either
                'value_string' or 'value_list_of_strings' is present.
@@ -3307,8 +3305,6 @@ class IamIdentityV1(BaseService):
             raise ValueError('service must be provided')
         if not preference_id:
             raise ValueError('preference_id must be provided')
-        if value_string is None:
-            raise ValueError('value_string must be provided')
         headers = {}
         sdk_headers = get_sdk_headers(
             service_name=self.DEFAULT_SERVICE_NAME,
@@ -3333,7 +3329,9 @@ class IamIdentityV1(BaseService):
         path_param_keys = ['account_id', 'iam_id', 'service', 'preference_id']
         path_param_values = self.encode_path_vars(account_id, iam_id, service, preference_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v1/preferences/accounts/{account_id}/identities/{iam_id}/{service}/{preference_id}'.format(**path_param_dict)
+        url = '/v1/preferences/accounts/{account_id}/identities/{iam_id}/{service}/{preference_id}'.format(
+            **path_param_dict
+        )
         request = self.prepare_request(
             method='PUT',
             url=url,
@@ -3392,7 +3390,9 @@ class IamIdentityV1(BaseService):
         path_param_keys = ['account_id', 'iam_id', 'service', 'preference_id']
         path_param_values = self.encode_path_vars(account_id, iam_id, service, preference_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v1/preferences/accounts/{account_id}/identities/{iam_id}/{service}/{preference_id}'.format(**path_param_dict)
+        url = '/v1/preferences/accounts/{account_id}/identities/{iam_id}/{service}/{preference_id}'.format(
+            **path_param_dict
+        )
         request = self.prepare_request(
             method='DELETE',
             url=url,
@@ -3461,7 +3461,9 @@ class IamIdentityV1(BaseService):
         path_param_keys = ['account_id', 'iam_id', 'service', 'preference_id']
         path_param_values = self.encode_path_vars(account_id, iam_id, service, preference_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v1/preferences/accounts/{account_id}/identities/{iam_id}/{service}/{preference_id}'.format(**path_param_dict)
+        url = '/v1/preferences/accounts/{account_id}/identities/{iam_id}/{service}/{preference_id}'.format(
+            **path_param_dict
+        )
         request = self.prepare_request(
             method='GET',
             url=url,
@@ -5633,6 +5635,7 @@ class ListApiKeysEnums:
 
         ENTITY = 'entity'
         ACCOUNT = 'account'
+
     class Type(str, Enum):
         """
         Optional parameter to filter the type of the queried API keys. Can be 'user' or
@@ -5641,6 +5644,7 @@ class ListApiKeysEnums:
 
         USER = 'user'
         SERVICEID = 'serviceid'
+
     class Order(str, Enum):
         """
         Optional sort order, valid values are asc and desc. Default: asc.
@@ -5723,6 +5727,7 @@ class ListProfileTemplatesEnums:
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
         NAME = 'name'
+
     class Order(str, Enum):
         """
         Optional sort order.
@@ -5746,6 +5751,7 @@ class ListVersionsOfProfileTemplateEnums:
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
         NAME = 'name'
+
     class Order(str, Enum):
         """
         Optional sort order.
@@ -5767,6 +5773,7 @@ class ListTrustedProfileAssignmentsEnums:
 
         ACCOUNT = 'Account'
         ACCOUNTGROUP = 'AccountGroup'
+
     class Sort(str, Enum):
         """
         If specified, the items are sorted by the value of this property.
@@ -5775,6 +5782,7 @@ class ListTrustedProfileAssignmentsEnums:
         TEMPLATE_ID = 'template_id'
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
+
     class Order(str, Enum):
         """
         Sort order.
@@ -5798,6 +5806,7 @@ class ListAccountSettingsTemplatesEnums:
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
         NAME = 'name'
+
     class Order(str, Enum):
         """
         Optional sort order.
@@ -5821,6 +5830,7 @@ class ListVersionsOfAccountSettingsTemplateEnums:
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
         NAME = 'name'
+
     class Order(str, Enum):
         """
         Optional sort order.
@@ -5842,6 +5852,7 @@ class ListAccountSettingsAssignmentsEnums:
 
         ACCOUNT = 'Account'
         ACCOUNTGROUP = 'AccountGroup'
+
     class Sort(str, Enum):
         """
         If specified, the items are sorted by the value of this property.
@@ -5850,6 +5861,7 @@ class ListAccountSettingsAssignmentsEnums:
         TEMPLATE_ID = 'template_id'
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
+
     class Order(str, Enum):
         """
         Sort order.
@@ -6196,15 +6208,21 @@ class AccountSettingsAssignedTemplatesSection:
         if (template_id := _dict.get('template_id')) is not None:
             args['template_id'] = template_id
         else:
-            raise ValueError('Required property \'template_id\' not present in AccountSettingsAssignedTemplatesSection JSON')
+            raise ValueError(
+                'Required property \'template_id\' not present in AccountSettingsAssignedTemplatesSection JSON'
+            )
         if (template_version := _dict.get('template_version')) is not None:
             args['template_version'] = template_version
         else:
-            raise ValueError('Required property \'template_version\' not present in AccountSettingsAssignedTemplatesSection JSON')
+            raise ValueError(
+                'Required property \'template_version\' not present in AccountSettingsAssignedTemplatesSection JSON'
+            )
         if (template_name := _dict.get('template_name')) is not None:
             args['template_name'] = template_name
         else:
-            raise ValueError('Required property \'template_name\' not present in AccountSettingsAssignedTemplatesSection JSON')
+            raise ValueError(
+                'Required property \'template_name\' not present in AccountSettingsAssignedTemplatesSection JSON'
+            )
         if (restrict_create_service_id := _dict.get('restrict_create_service_id')) is not None:
             args['restrict_create_service_id'] = restrict_create_service_id
         if (restrict_create_platform_apikey := _dict.get('restrict_create_platform_apikey')) is not None:
@@ -6219,16 +6237,22 @@ class AccountSettingsAssignedTemplatesSection:
             args['session_invalidation_in_seconds'] = session_invalidation_in_seconds
         if (max_sessions_per_identity := _dict.get('max_sessions_per_identity')) is not None:
             args['max_sessions_per_identity'] = max_sessions_per_identity
-        if (system_access_token_expiration_in_seconds := _dict.get('system_access_token_expiration_in_seconds')) is not None:
+        if (
+            system_access_token_expiration_in_seconds := _dict.get('system_access_token_expiration_in_seconds')
+        ) is not None:
             args['system_access_token_expiration_in_seconds'] = system_access_token_expiration_in_seconds
-        if (system_refresh_token_expiration_in_seconds := _dict.get('system_refresh_token_expiration_in_seconds')) is not None:
+        if (
+            system_refresh_token_expiration_in_seconds := _dict.get('system_refresh_token_expiration_in_seconds')
+        ) is not None:
             args['system_refresh_token_expiration_in_seconds'] = system_refresh_token_expiration_in_seconds
         if (restrict_user_list_visibility := _dict.get('restrict_user_list_visibility')) is not None:
             args['restrict_user_list_visibility'] = restrict_user_list_visibility
         if (user_mfa := _dict.get('user_mfa')) is not None:
             args['user_mfa'] = [AccountSettingsUserMFAResponse.from_dict(v) for v in user_mfa]
         if (restrict_user_domains := _dict.get('restrict_user_domains')) is not None:
-            args['restrict_user_domains'] = AssignedTemplatesAccountSettingsRestrictUserDomains.from_dict(restrict_user_domains)
+            args['restrict_user_domains'] = AssignedTemplatesAccountSettingsRestrictUserDomains.from_dict(
+                restrict_user_domains
+            )
         return cls(**args)
 
     @classmethod
@@ -6259,9 +6283,15 @@ class AccountSettingsAssignedTemplatesSection:
             _dict['session_invalidation_in_seconds'] = self.session_invalidation_in_seconds
         if hasattr(self, 'max_sessions_per_identity') and self.max_sessions_per_identity is not None:
             _dict['max_sessions_per_identity'] = self.max_sessions_per_identity
-        if hasattr(self, 'system_access_token_expiration_in_seconds') and self.system_access_token_expiration_in_seconds is not None:
+        if (
+            hasattr(self, 'system_access_token_expiration_in_seconds')
+            and self.system_access_token_expiration_in_seconds is not None
+        ):
             _dict['system_access_token_expiration_in_seconds'] = self.system_access_token_expiration_in_seconds
-        if hasattr(self, 'system_refresh_token_expiration_in_seconds') and self.system_refresh_token_expiration_in_seconds is not None:
+        if (
+            hasattr(self, 'system_refresh_token_expiration_in_seconds')
+            and self.system_refresh_token_expiration_in_seconds is not None
+        ):
             _dict['system_refresh_token_expiration_in_seconds'] = self.system_refresh_token_expiration_in_seconds
         if hasattr(self, 'restrict_user_list_visibility') and self.restrict_user_list_visibility is not None:
             _dict['restrict_user_list_visibility'] = self.restrict_user_list_visibility
@@ -6311,7 +6341,6 @@ class AccountSettingsAssignedTemplatesSection:
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
 
-
     class RestrictCreatePlatformApikeyEnum(str, Enum):
         """
         Defines whether or not creating the resource is access controlled. Valid values:
@@ -6324,7 +6353,6 @@ class AccountSettingsAssignedTemplatesSection:
         RESTRICTED = 'RESTRICTED'
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
-
 
     class MfaEnum(str, Enum):
         """
@@ -6346,7 +6374,6 @@ class AccountSettingsAssignedTemplatesSection:
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
 
-
     class RestrictUserListVisibilityEnum(str, Enum):
         """
         Defines whether or not user visibility is access controlled. Valid values:
@@ -6361,7 +6388,6 @@ class AccountSettingsAssignedTemplatesSection:
         RESTRICTED = 'RESTRICTED'
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
-
 
 
 class AccountSettingsEffectiveSection:
@@ -6527,9 +6553,13 @@ class AccountSettingsEffectiveSection:
             args['session_invalidation_in_seconds'] = session_invalidation_in_seconds
         if (max_sessions_per_identity := _dict.get('max_sessions_per_identity')) is not None:
             args['max_sessions_per_identity'] = max_sessions_per_identity
-        if (system_access_token_expiration_in_seconds := _dict.get('system_access_token_expiration_in_seconds')) is not None:
+        if (
+            system_access_token_expiration_in_seconds := _dict.get('system_access_token_expiration_in_seconds')
+        ) is not None:
             args['system_access_token_expiration_in_seconds'] = system_access_token_expiration_in_seconds
-        if (system_refresh_token_expiration_in_seconds := _dict.get('system_refresh_token_expiration_in_seconds')) is not None:
+        if (
+            system_refresh_token_expiration_in_seconds := _dict.get('system_refresh_token_expiration_in_seconds')
+        ) is not None:
             args['system_refresh_token_expiration_in_seconds'] = system_refresh_token_expiration_in_seconds
         return cls(**args)
 
@@ -6565,9 +6595,15 @@ class AccountSettingsEffectiveSection:
             _dict['session_invalidation_in_seconds'] = self.session_invalidation_in_seconds
         if hasattr(self, 'max_sessions_per_identity') and self.max_sessions_per_identity is not None:
             _dict['max_sessions_per_identity'] = self.max_sessions_per_identity
-        if hasattr(self, 'system_access_token_expiration_in_seconds') and self.system_access_token_expiration_in_seconds is not None:
+        if (
+            hasattr(self, 'system_access_token_expiration_in_seconds')
+            and self.system_access_token_expiration_in_seconds is not None
+        ):
             _dict['system_access_token_expiration_in_seconds'] = self.system_access_token_expiration_in_seconds
-        if hasattr(self, 'system_refresh_token_expiration_in_seconds') and self.system_refresh_token_expiration_in_seconds is not None:
+        if (
+            hasattr(self, 'system_refresh_token_expiration_in_seconds')
+            and self.system_refresh_token_expiration_in_seconds is not None
+        ):
             _dict['system_refresh_token_expiration_in_seconds'] = self.system_refresh_token_expiration_in_seconds
         return _dict
 
@@ -6602,7 +6638,6 @@ class AccountSettingsEffectiveSection:
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
 
-
     class RestrictCreatePlatformApikeyEnum(str, Enum):
         """
         Defines whether or not creating the resource is access controlled. Valid values:
@@ -6616,7 +6651,6 @@ class AccountSettingsEffectiveSection:
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
 
-
     class RestrictUserListVisibilityEnum(str, Enum):
         """
         Defines whether or not user visibility is access controlled. Valid values:
@@ -6629,7 +6663,6 @@ class AccountSettingsEffectiveSection:
 
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         RESTRICTED = 'RESTRICTED'
-
 
     class MfaEnum(str, Enum):
         """
@@ -6650,7 +6683,6 @@ class AccountSettingsEffectiveSection:
         LEVEL1 = 'LEVEL1'
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
-
 
 
 class AccountSettingsResponse:
@@ -6841,11 +6873,15 @@ class AccountSettingsResponse:
         if (restrict_create_service_id := _dict.get('restrict_create_service_id')) is not None:
             args['restrict_create_service_id'] = restrict_create_service_id
         else:
-            raise ValueError('Required property \'restrict_create_service_id\' not present in AccountSettingsResponse JSON')
+            raise ValueError(
+                'Required property \'restrict_create_service_id\' not present in AccountSettingsResponse JSON'
+            )
         if (restrict_create_platform_apikey := _dict.get('restrict_create_platform_apikey')) is not None:
             args['restrict_create_platform_apikey'] = restrict_create_platform_apikey
         else:
-            raise ValueError('Required property \'restrict_create_platform_apikey\' not present in AccountSettingsResponse JSON')
+            raise ValueError(
+                'Required property \'restrict_create_platform_apikey\' not present in AccountSettingsResponse JSON'
+            )
         if (allowed_ip_addresses := _dict.get('allowed_ip_addresses')) is not None:
             args['allowed_ip_addresses'] = allowed_ip_addresses
         else:
@@ -6857,33 +6893,51 @@ class AccountSettingsResponse:
         if (session_expiration_in_seconds := _dict.get('session_expiration_in_seconds')) is not None:
             args['session_expiration_in_seconds'] = session_expiration_in_seconds
         else:
-            raise ValueError('Required property \'session_expiration_in_seconds\' not present in AccountSettingsResponse JSON')
+            raise ValueError(
+                'Required property \'session_expiration_in_seconds\' not present in AccountSettingsResponse JSON'
+            )
         if (session_invalidation_in_seconds := _dict.get('session_invalidation_in_seconds')) is not None:
             args['session_invalidation_in_seconds'] = session_invalidation_in_seconds
         else:
-            raise ValueError('Required property \'session_invalidation_in_seconds\' not present in AccountSettingsResponse JSON')
+            raise ValueError(
+                'Required property \'session_invalidation_in_seconds\' not present in AccountSettingsResponse JSON'
+            )
         if (max_sessions_per_identity := _dict.get('max_sessions_per_identity')) is not None:
             args['max_sessions_per_identity'] = max_sessions_per_identity
         else:
-            raise ValueError('Required property \'max_sessions_per_identity\' not present in AccountSettingsResponse JSON')
-        if (system_access_token_expiration_in_seconds := _dict.get('system_access_token_expiration_in_seconds')) is not None:
+            raise ValueError(
+                'Required property \'max_sessions_per_identity\' not present in AccountSettingsResponse JSON'
+            )
+        if (
+            system_access_token_expiration_in_seconds := _dict.get('system_access_token_expiration_in_seconds')
+        ) is not None:
             args['system_access_token_expiration_in_seconds'] = system_access_token_expiration_in_seconds
         else:
-            raise ValueError('Required property \'system_access_token_expiration_in_seconds\' not present in AccountSettingsResponse JSON')
-        if (system_refresh_token_expiration_in_seconds := _dict.get('system_refresh_token_expiration_in_seconds')) is not None:
+            raise ValueError(
+                'Required property \'system_access_token_expiration_in_seconds\' not present in AccountSettingsResponse JSON'
+            )
+        if (
+            system_refresh_token_expiration_in_seconds := _dict.get('system_refresh_token_expiration_in_seconds')
+        ) is not None:
             args['system_refresh_token_expiration_in_seconds'] = system_refresh_token_expiration_in_seconds
         else:
-            raise ValueError('Required property \'system_refresh_token_expiration_in_seconds\' not present in AccountSettingsResponse JSON')
+            raise ValueError(
+                'Required property \'system_refresh_token_expiration_in_seconds\' not present in AccountSettingsResponse JSON'
+            )
         if (restrict_user_list_visibility := _dict.get('restrict_user_list_visibility')) is not None:
             args['restrict_user_list_visibility'] = restrict_user_list_visibility
         else:
-            raise ValueError('Required property \'restrict_user_list_visibility\' not present in AccountSettingsResponse JSON')
+            raise ValueError(
+                'Required property \'restrict_user_list_visibility\' not present in AccountSettingsResponse JSON'
+            )
         if (user_mfa := _dict.get('user_mfa')) is not None:
             args['user_mfa'] = [AccountSettingsUserMFAResponse.from_dict(v) for v in user_mfa]
         else:
             raise ValueError('Required property \'user_mfa\' not present in AccountSettingsResponse JSON')
         if (restrict_user_domains := _dict.get('restrict_user_domains')) is not None:
-            args['restrict_user_domains'] = [AccountSettingsUserDomainRestriction.from_dict(v) for v in restrict_user_domains]
+            args['restrict_user_domains'] = [
+                AccountSettingsUserDomainRestriction.from_dict(v) for v in restrict_user_domains
+            ]
         else:
             raise ValueError('Required property \'restrict_user_domains\' not present in AccountSettingsResponse JSON')
         return cls(**args)
@@ -6927,9 +6981,15 @@ class AccountSettingsResponse:
             _dict['session_invalidation_in_seconds'] = self.session_invalidation_in_seconds
         if hasattr(self, 'max_sessions_per_identity') and self.max_sessions_per_identity is not None:
             _dict['max_sessions_per_identity'] = self.max_sessions_per_identity
-        if hasattr(self, 'system_access_token_expiration_in_seconds') and self.system_access_token_expiration_in_seconds is not None:
+        if (
+            hasattr(self, 'system_access_token_expiration_in_seconds')
+            and self.system_access_token_expiration_in_seconds is not None
+        ):
             _dict['system_access_token_expiration_in_seconds'] = self.system_access_token_expiration_in_seconds
-        if hasattr(self, 'system_refresh_token_expiration_in_seconds') and self.system_refresh_token_expiration_in_seconds is not None:
+        if (
+            hasattr(self, 'system_refresh_token_expiration_in_seconds')
+            and self.system_refresh_token_expiration_in_seconds is not None
+        ):
             _dict['system_refresh_token_expiration_in_seconds'] = self.system_refresh_token_expiration_in_seconds
         if hasattr(self, 'restrict_user_list_visibility') and self.restrict_user_list_visibility is not None:
             _dict['restrict_user_list_visibility'] = self.restrict_user_list_visibility
@@ -6982,7 +7042,6 @@ class AccountSettingsResponse:
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
 
-
     class RestrictCreatePlatformApikeyEnum(str, Enum):
         """
         Defines whether or not creating the resource is access controlled. Valid values:
@@ -6995,7 +7054,6 @@ class AccountSettingsResponse:
         RESTRICTED = 'RESTRICTED'
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
-
 
     class MfaEnum(str, Enum):
         """
@@ -7017,7 +7075,6 @@ class AccountSettingsResponse:
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
 
-
     class RestrictUserListVisibilityEnum(str, Enum):
         """
         Defines whether or not user visibility is access controlled. Valid values:
@@ -7030,7 +7087,6 @@ class AccountSettingsResponse:
 
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         RESTRICTED = 'RESTRICTED'
-
 
 
 class AccountSettingsTemplateList:
@@ -7107,9 +7163,13 @@ class AccountSettingsTemplateList:
         if (next := _dict.get('next')) is not None:
             args['next'] = next
         if (account_settings_templates := _dict.get('account_settings_templates')) is not None:
-            args['account_settings_templates'] = [AccountSettingsTemplateResponse.from_dict(v) for v in account_settings_templates]
+            args['account_settings_templates'] = [
+                AccountSettingsTemplateResponse.from_dict(v) for v in account_settings_templates
+            ]
         else:
-            raise ValueError('Required property \'account_settings_templates\' not present in AccountSettingsTemplateList JSON')
+            raise ValueError(
+                'Required property \'account_settings_templates\' not present in AccountSettingsTemplateList JSON'
+            )
         return cls(**args)
 
     @classmethod
@@ -7275,7 +7335,9 @@ class AccountSettingsTemplateResponse:
         if (account_settings := _dict.get('account_settings')) is not None:
             args['account_settings'] = TemplateAccountSettings.from_dict(account_settings)
         else:
-            raise ValueError('Required property \'account_settings\' not present in AccountSettingsTemplateResponse JSON')
+            raise ValueError(
+                'Required property \'account_settings\' not present in AccountSettingsTemplateResponse JSON'
+            )
         if (history := _dict.get('history')) is not None:
             args['history'] = [EnityHistoryRecord.from_dict(v) for v in history]
         if (entity_tag := _dict.get('entity_tag')) is not None:
@@ -7583,7 +7645,6 @@ class AccountSettingsUserMFAResponse:
         LEVEL1 = 'LEVEL1'
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
-
 
 
 class ActionControls:
@@ -8998,7 +9059,9 @@ class EffectiveAccountSettingsResponse:
         else:
             raise ValueError('Required property \'account\' not present in EffectiveAccountSettingsResponse JSON')
         if (assigned_templates := _dict.get('assigned_templates')) is not None:
-            args['assigned_templates'] = [AccountSettingsAssignedTemplatesSection.from_dict(v) for v in assigned_templates]
+            args['assigned_templates'] = [
+                AccountSettingsAssignedTemplatesSection.from_dict(v) for v in assigned_templates
+            ]
         return cls(**args)
 
     @classmethod
@@ -9603,7 +9666,6 @@ class IdBasedMfaEnrollment:
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
 
-
     class TraitUserSpecificEnum(str, Enum):
         """
         MFA trait definitions as follows:
@@ -9623,7 +9685,6 @@ class IdBasedMfaEnrollment:
         LEVEL1 = 'LEVEL1'
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
-
 
     class TraitEffectiveEnum(str, Enum):
         """
@@ -9645,7 +9706,6 @@ class IdBasedMfaEnrollment:
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
 
-
     class ComplyStateEnum(str, Enum):
         """
         Defines comply state for the account. Valid values:
@@ -9659,7 +9719,6 @@ class IdBasedMfaEnrollment:
         NO = 'NO'
         ACCOUNT = 'ACCOUNT'
         CROSS_ACCOUNT = 'CROSS_ACCOUNT'
-
 
 
 class IdentityCount:
@@ -9846,13 +9905,19 @@ class IdentityLimitsUsageResponse:
         if (account_settings_templates := _dict.get('account_settings_templates')) is not None:
             args['account_settings_templates'] = LimitCount.from_dict(account_settings_templates)
         if (template_versions_per_template := _dict.get('template_versions_per_template')) is not None:
-            args['template_versions_per_template'] = IdentityLimitsUsageResponseTemplateVersionsPerTemplate.from_dict(template_versions_per_template)
+            args['template_versions_per_template'] = IdentityLimitsUsageResponseTemplateVersionsPerTemplate.from_dict(
+                template_versions_per_template
+            )
         if (idps := _dict.get('idps')) is not None:
             args['idps'] = LimitCount.from_dict(idps)
         if (claim_rules_per_group := _dict.get('claim_rules_per_group')) is not None:
-            args['claim_rules_per_group'] = IdentityLimitsUsageResponseClaimRulesPerGroup.from_dict(claim_rules_per_group)
+            args['claim_rules_per_group'] = IdentityLimitsUsageResponseClaimRulesPerGroup.from_dict(
+                claim_rules_per_group
+            )
         if (claim_rules_per_profile := _dict.get('claim_rules_per_profile')) is not None:
-            args['claim_rules_per_profile'] = IdentityLimitsUsageResponseClaimRulesPerProfile.from_dict(claim_rules_per_profile)
+            args['claim_rules_per_profile'] = IdentityLimitsUsageResponseClaimRulesPerProfile.from_dict(
+                claim_rules_per_profile
+            )
         if (cr_links := _dict.get('cr_links')) is not None:
             args['cr_links'] = LimitCount.from_dict(cr_links)
         if (cr_links_per_profile := _dict.get('cr_links_per_profile')) is not None:
@@ -9994,7 +10059,9 @@ class IdentityLimitsUsageResponseApikeysPerIdentity:
         if (limit := _dict.get('limit')) is not None:
             args['limit'] = limit
         else:
-            raise ValueError('Required property \'limit\' not present in IdentityLimitsUsageResponseApikeysPerIdentity JSON')
+            raise ValueError(
+                'Required property \'limit\' not present in IdentityLimitsUsageResponseApikeysPerIdentity JSON'
+            )
         if (identities := _dict.get('identities')) is not None:
             args['identities'] = [IdentityCount.from_dict(v) for v in identities]
         return cls(**args)
@@ -10070,7 +10137,9 @@ class IdentityLimitsUsageResponseClaimRulesPerGroup:
         if (limit := _dict.get('limit')) is not None:
             args['limit'] = limit
         else:
-            raise ValueError('Required property \'limit\' not present in IdentityLimitsUsageResponseClaimRulesPerGroup JSON')
+            raise ValueError(
+                'Required property \'limit\' not present in IdentityLimitsUsageResponseClaimRulesPerGroup JSON'
+            )
         if (access_groups := _dict.get('access_groups')) is not None:
             args['access_groups'] = [AccessGroupCount.from_dict(v) for v in access_groups]
         return cls(**args)
@@ -10146,7 +10215,9 @@ class IdentityLimitsUsageResponseClaimRulesPerProfile:
         if (limit := _dict.get('limit')) is not None:
             args['limit'] = limit
         else:
-            raise ValueError('Required property \'limit\' not present in IdentityLimitsUsageResponseClaimRulesPerProfile JSON')
+            raise ValueError(
+                'Required property \'limit\' not present in IdentityLimitsUsageResponseClaimRulesPerProfile JSON'
+            )
         if (profiles := _dict.get('profiles')) is not None:
             args['profiles'] = [ProfileCount.from_dict(v) for v in profiles]
         return cls(**args)
@@ -10222,7 +10293,9 @@ class IdentityLimitsUsageResponseCrLinksPerProfile:
         if (limit := _dict.get('limit')) is not None:
             args['limit'] = limit
         else:
-            raise ValueError('Required property \'limit\' not present in IdentityLimitsUsageResponseCrLinksPerProfile JSON')
+            raise ValueError(
+                'Required property \'limit\' not present in IdentityLimitsUsageResponseCrLinksPerProfile JSON'
+            )
         if (profiles := _dict.get('profiles')) is not None:
             args['profiles'] = [ProfileCount.from_dict(v) for v in profiles]
         return cls(**args)
@@ -10298,7 +10371,9 @@ class IdentityLimitsUsageResponseCrRulesPerProfile:
         if (limit := _dict.get('limit')) is not None:
             args['limit'] = limit
         else:
-            raise ValueError('Required property \'limit\' not present in IdentityLimitsUsageResponseCrRulesPerProfile JSON')
+            raise ValueError(
+                'Required property \'limit\' not present in IdentityLimitsUsageResponseCrRulesPerProfile JSON'
+            )
         if (profiles := _dict.get('profiles')) is not None:
             args['profiles'] = [ProfileCount.from_dict(v) for v in profiles]
         return cls(**args)
@@ -10374,7 +10449,9 @@ class IdentityLimitsUsageResponseServiceidsPerGroup:
         if (limit := _dict.get('limit')) is not None:
             args['limit'] = limit
         else:
-            raise ValueError('Required property \'limit\' not present in IdentityLimitsUsageResponseServiceidsPerGroup JSON')
+            raise ValueError(
+                'Required property \'limit\' not present in IdentityLimitsUsageResponseServiceidsPerGroup JSON'
+            )
         if (serviceid_groups := _dict.get('serviceid_groups')) is not None:
             args['serviceid_groups'] = [ServiceIdGroupCount.from_dict(v) for v in serviceid_groups]
         return cls(**args)
@@ -10450,7 +10527,9 @@ class IdentityLimitsUsageResponseTemplateVersionsPerTemplate:
         if (limit := _dict.get('limit')) is not None:
             args['limit'] = limit
         else:
-            raise ValueError('Required property \'limit\' not present in IdentityLimitsUsageResponseTemplateVersionsPerTemplate JSON')
+            raise ValueError(
+                'Required property \'limit\' not present in IdentityLimitsUsageResponseTemplateVersionsPerTemplate JSON'
+            )
         if (templates := _dict.get('templates')) is not None:
             args['templates'] = [TemplateCount.from_dict(v) for v in templates]
         return cls(**args)
@@ -10506,7 +10585,7 @@ class IdentityPreferenceResponse:
     :param str value_string: (optional) String value of the preference, only one
           value property is set, either 'value_string' or 'value_list_of_strings' is
           present.
-    :param List[str] value_list_of_strings: (optional) List of value of the
+    :param List[str] value_list_of_strings: (optional) List of values of the
           preference, only one value property is set, either 'value_string' or
           'value_list_of_strings' is present.
     """
@@ -10533,7 +10612,7 @@ class IdentityPreferenceResponse:
         :param str value_string: (optional) String value of the preference, only
                one value property is set, either 'value_string' or 'value_list_of_strings'
                is present.
-        :param List[str] value_list_of_strings: (optional) List of value of the
+        :param List[str] value_list_of_strings: (optional) List of values of the
                preference, only one value property is set, either 'value_string' or
                'value_list_of_strings' is present.
         """
@@ -11454,7 +11533,6 @@ class ProfileIdentityRequest:
         CRN = 'crn'
 
 
-
 class ProfileIdentityResponse:
     """
     ProfileIdentityResponse.
@@ -11576,7 +11654,6 @@ class ProfileIdentityResponse:
         USER = 'user'
         SERVICEID = 'serviceid'
         CRN = 'crn'
-
 
 
 class ProfileLink:
@@ -13172,9 +13249,13 @@ class TemplateAccountSettings:
             args['session_invalidation_in_seconds'] = session_invalidation_in_seconds
         if (max_sessions_per_identity := _dict.get('max_sessions_per_identity')) is not None:
             args['max_sessions_per_identity'] = max_sessions_per_identity
-        if (system_access_token_expiration_in_seconds := _dict.get('system_access_token_expiration_in_seconds')) is not None:
+        if (
+            system_access_token_expiration_in_seconds := _dict.get('system_access_token_expiration_in_seconds')
+        ) is not None:
             args['system_access_token_expiration_in_seconds'] = system_access_token_expiration_in_seconds
-        if (system_refresh_token_expiration_in_seconds := _dict.get('system_refresh_token_expiration_in_seconds')) is not None:
+        if (
+            system_refresh_token_expiration_in_seconds := _dict.get('system_refresh_token_expiration_in_seconds')
+        ) is not None:
             args['system_refresh_token_expiration_in_seconds'] = system_refresh_token_expiration_in_seconds
         if (restrict_user_list_visibility := _dict.get('restrict_user_list_visibility')) is not None:
             args['restrict_user_list_visibility'] = restrict_user_list_visibility
@@ -13212,9 +13293,15 @@ class TemplateAccountSettings:
             _dict['session_invalidation_in_seconds'] = self.session_invalidation_in_seconds
         if hasattr(self, 'max_sessions_per_identity') and self.max_sessions_per_identity is not None:
             _dict['max_sessions_per_identity'] = self.max_sessions_per_identity
-        if hasattr(self, 'system_access_token_expiration_in_seconds') and self.system_access_token_expiration_in_seconds is not None:
+        if (
+            hasattr(self, 'system_access_token_expiration_in_seconds')
+            and self.system_access_token_expiration_in_seconds is not None
+        ):
             _dict['system_access_token_expiration_in_seconds'] = self.system_access_token_expiration_in_seconds
-        if hasattr(self, 'system_refresh_token_expiration_in_seconds') and self.system_refresh_token_expiration_in_seconds is not None:
+        if (
+            hasattr(self, 'system_refresh_token_expiration_in_seconds')
+            and self.system_refresh_token_expiration_in_seconds is not None
+        ):
             _dict['system_refresh_token_expiration_in_seconds'] = self.system_refresh_token_expiration_in_seconds
         if hasattr(self, 'restrict_user_list_visibility') and self.restrict_user_list_visibility is not None:
             _dict['restrict_user_list_visibility'] = self.restrict_user_list_visibility
@@ -13256,7 +13343,6 @@ class TemplateAccountSettings:
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
 
-
     class RestrictCreatePlatformApikeyEnum(str, Enum):
         """
         Defines whether or not creating the resource is access controlled. Valid values:
@@ -13269,7 +13355,6 @@ class TemplateAccountSettings:
         RESTRICTED = 'RESTRICTED'
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
-
 
     class MfaEnum(str, Enum):
         """
@@ -13291,7 +13376,6 @@ class TemplateAccountSettings:
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
 
-
     class RestrictUserListVisibilityEnum(str, Enum):
         """
         Defines whether or not user visibility is access controlled. Valid values:
@@ -13306,7 +13390,6 @@ class TemplateAccountSettings:
         RESTRICTED = 'RESTRICTED'
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
-
 
 
 class TemplateAccountSettingsRestrictUserDomains:
@@ -13940,7 +14023,9 @@ class TemplateAssignmentResponseResource:
         if (account_settings := _dict.get('account_settings')) is not None:
             args['account_settings'] = TemplateAssignmentResponseResourceDetail.from_dict(account_settings)
         if (policy_template_references := _dict.get('policy_template_references')) is not None:
-            args['policy_template_references'] = [TemplateAssignmentResponseResourceDetail.from_dict(v) for v in policy_template_references]
+            args['policy_template_references'] = [
+                TemplateAssignmentResponseResourceDetail.from_dict(v) for v in policy_template_references
+            ]
         return cls(**args)
 
     @classmethod
@@ -14050,7 +14135,9 @@ class TemplateAssignmentResponseResourceDetail:
         if (status := _dict.get('status')) is not None:
             args['status'] = status
         else:
-            raise ValueError('Required property \'status\' not present in TemplateAssignmentResponseResourceDetail JSON')
+            raise ValueError(
+                'Required property \'status\' not present in TemplateAssignmentResponseResourceDetail JSON'
+            )
         return cls(**args)
 
     @classmethod
@@ -14781,7 +14868,6 @@ class TrustedProfileTemplateClaimRule:
         PROFILE_SAML = 'Profile-SAML'
 
 
-
 class TrustedProfileTemplateList:
     """
     TrustedProfileTemplateList.
@@ -15039,7 +15125,9 @@ class TrustedProfileTemplateResponse:
         if (profile := _dict.get('profile')) is not None:
             args['profile'] = TemplateProfileComponentResponse.from_dict(profile)
         if (policy_template_references := _dict.get('policy_template_references')) is not None:
-            args['policy_template_references'] = [PolicyTemplateReference.from_dict(v) for v in policy_template_references]
+            args['policy_template_references'] = [
+                PolicyTemplateReference.from_dict(v) for v in policy_template_references
+            ]
         if (action_controls := _dict.get('action_controls')) is not None:
             args['action_controls'] = ActionControls.from_dict(action_controls)
         if (history := _dict.get('history')) is not None:
@@ -15458,7 +15546,6 @@ class UserMfa:
         LEVEL3 = 'LEVEL3'
 
 
-
 class UserMfaEnrollments:
     """
     UserMfaEnrollments.
@@ -15615,7 +15702,9 @@ class UserReportMfaEnrollmentStatus:
         if (effective_mfa_type := _dict.get('effective_mfa_type')) is not None:
             args['effective_mfa_type'] = effective_mfa_type
         else:
-            raise ValueError('Required property \'effective_mfa_type\' not present in UserReportMfaEnrollmentStatus JSON')
+            raise ValueError(
+                'Required property \'effective_mfa_type\' not present in UserReportMfaEnrollmentStatus JSON'
+            )
         if (id_based_mfa := _dict.get('id_based_mfa')) is not None:
             args['id_based_mfa'] = IdBasedMfaEnrollment.from_dict(id_based_mfa)
         else:
@@ -15623,7 +15712,9 @@ class UserReportMfaEnrollmentStatus:
         if (account_based_mfa := _dict.get('account_based_mfa')) is not None:
             args['account_based_mfa'] = AccountBasedMfaEnrollment.from_dict(account_based_mfa)
         else:
-            raise ValueError('Required property \'account_based_mfa\' not present in UserReportMfaEnrollmentStatus JSON')
+            raise ValueError(
+                'Required property \'account_based_mfa\' not present in UserReportMfaEnrollmentStatus JSON'
+            )
         return cls(**args)
 
     @classmethod

--- a/ibm_platform_services/iam_identity_v1.py
+++ b/ibm_platform_services/iam_identity_v1.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# IBM OpenAPI SDK Code Generator Version: 3.113.0-3f9df07a-20260317-160650
+# IBM OpenAPI SDK Code Generator Version: 3.113.1-d76630af-20260320-135953
 
 """
 The IAM Identity Service API allows for the management of Account Settings and Identities
@@ -56,7 +56,9 @@ class IamIdentityV1(BaseService):
                parameters and external configuration.
         """
         authenticator = get_authenticator_from_environment(service_name)
-        service = cls(authenticator)
+        service = cls(
+            authenticator
+            )
         service.configure_service(service_name)
         return service
 
@@ -1796,7 +1798,7 @@ class IamIdentityV1(BaseService):
                'Profile-SAML'.
         :param str cr_type: (optional) The compute resource type the rule applies
                to, required only if type is specified as 'Profile-CR'. Valid values are
-               VSI, IKS_SA, ROKS_SA.
+               VSI, PVS, IKS_SA, ROKS_SA.
         :param int expiration: (optional) Session expiration in seconds, only
                required if type is 'Profile-SAML'.
         :param dict headers: A `dict` containing the request headers
@@ -1985,7 +1987,7 @@ class IamIdentityV1(BaseService):
                'Profile-SAML'.
         :param str cr_type: (optional) The compute resource type the rule applies
                to, required only if type is specified as 'Profile-CR'. Valid values are
-               VSI, IKS_SA, ROKS_SA.
+               VSI, PVS, IKS_SA, ROKS_SA.
         :param int expiration: (optional) Session expiration in seconds, only
                required if type is 'Profile-SAML'.
         :param dict headers: A `dict` containing the request headers
@@ -2115,7 +2117,7 @@ class IamIdentityV1(BaseService):
         trusted profile.
 
         :param str profile_id: ID of the trusted profile.
-        :param str cr_type: The compute resource type. Valid values are VSI,
+        :param str cr_type: The compute resource type. Valid values are VSI, PVS,
                IKS_SA, ROKS_SA.
         :param CreateProfileLinkRequestLink link: Link details.
         :param str name: (optional) Optional name of the Link.
@@ -2233,7 +2235,7 @@ class IamIdentityV1(BaseService):
         Deletes compute resource link of a Trusted Profile matching the given parameters.
 
         :param str profile_id: The unique ID of the Trusted Profile.
-        :param str type: The compute resource type. Valid values are VSI, BMS,
+        :param str type: The compute resource type. Valid values are VSI, PVS, BMS,
                IKS_SA, ROKS_SA, CE.
         :param str crn: (optional) CRN of the compute resource (IKS/ROKS/VSI/BMS).
         :param str namespace: (optional) Namespace of the compute resource
@@ -3331,9 +3333,7 @@ class IamIdentityV1(BaseService):
         path_param_keys = ['account_id', 'iam_id', 'service', 'preference_id']
         path_param_values = self.encode_path_vars(account_id, iam_id, service, preference_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v1/preferences/accounts/{account_id}/identities/{iam_id}/{service}/{preference_id}'.format(
-            **path_param_dict
-        )
+        url = '/v1/preferences/accounts/{account_id}/identities/{iam_id}/{service}/{preference_id}'.format(**path_param_dict)
         request = self.prepare_request(
             method='PUT',
             url=url,
@@ -3392,9 +3392,7 @@ class IamIdentityV1(BaseService):
         path_param_keys = ['account_id', 'iam_id', 'service', 'preference_id']
         path_param_values = self.encode_path_vars(account_id, iam_id, service, preference_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v1/preferences/accounts/{account_id}/identities/{iam_id}/{service}/{preference_id}'.format(
-            **path_param_dict
-        )
+        url = '/v1/preferences/accounts/{account_id}/identities/{iam_id}/{service}/{preference_id}'.format(**path_param_dict)
         request = self.prepare_request(
             method='DELETE',
             url=url,
@@ -3463,9 +3461,7 @@ class IamIdentityV1(BaseService):
         path_param_keys = ['account_id', 'iam_id', 'service', 'preference_id']
         path_param_values = self.encode_path_vars(account_id, iam_id, service, preference_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v1/preferences/accounts/{account_id}/identities/{iam_id}/{service}/{preference_id}'.format(
-            **path_param_dict
-        )
+        url = '/v1/preferences/accounts/{account_id}/identities/{iam_id}/{service}/{preference_id}'.format(**path_param_dict)
         request = self.prepare_request(
             method='GET',
             url=url,
@@ -5637,7 +5633,6 @@ class ListApiKeysEnums:
 
         ENTITY = 'entity'
         ACCOUNT = 'account'
-
     class Type(str, Enum):
         """
         Optional parameter to filter the type of the queried API keys. Can be 'user' or
@@ -5646,7 +5641,6 @@ class ListApiKeysEnums:
 
         USER = 'user'
         SERVICEID = 'serviceid'
-
     class Order(str, Enum):
         """
         Optional sort order, valid values are asc and desc. Default: asc.
@@ -5729,7 +5723,6 @@ class ListProfileTemplatesEnums:
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
         NAME = 'name'
-
     class Order(str, Enum):
         """
         Optional sort order.
@@ -5753,7 +5746,6 @@ class ListVersionsOfProfileTemplateEnums:
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
         NAME = 'name'
-
     class Order(str, Enum):
         """
         Optional sort order.
@@ -5775,7 +5767,6 @@ class ListTrustedProfileAssignmentsEnums:
 
         ACCOUNT = 'Account'
         ACCOUNTGROUP = 'AccountGroup'
-
     class Sort(str, Enum):
         """
         If specified, the items are sorted by the value of this property.
@@ -5784,7 +5775,6 @@ class ListTrustedProfileAssignmentsEnums:
         TEMPLATE_ID = 'template_id'
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
-
     class Order(str, Enum):
         """
         Sort order.
@@ -5808,7 +5798,6 @@ class ListAccountSettingsTemplatesEnums:
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
         NAME = 'name'
-
     class Order(str, Enum):
         """
         Optional sort order.
@@ -5832,7 +5821,6 @@ class ListVersionsOfAccountSettingsTemplateEnums:
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
         NAME = 'name'
-
     class Order(str, Enum):
         """
         Optional sort order.
@@ -5854,7 +5842,6 @@ class ListAccountSettingsAssignmentsEnums:
 
         ACCOUNT = 'Account'
         ACCOUNTGROUP = 'AccountGroup'
-
     class Sort(str, Enum):
         """
         If specified, the items are sorted by the value of this property.
@@ -5863,7 +5850,6 @@ class ListAccountSettingsAssignmentsEnums:
         TEMPLATE_ID = 'template_id'
         CREATED_AT = 'created_at'
         LAST_MODIFIED_AT = 'last_modified_at'
-
     class Order(str, Enum):
         """
         Sort order.
@@ -6210,21 +6196,15 @@ class AccountSettingsAssignedTemplatesSection:
         if (template_id := _dict.get('template_id')) is not None:
             args['template_id'] = template_id
         else:
-            raise ValueError(
-                'Required property \'template_id\' not present in AccountSettingsAssignedTemplatesSection JSON'
-            )
+            raise ValueError('Required property \'template_id\' not present in AccountSettingsAssignedTemplatesSection JSON')
         if (template_version := _dict.get('template_version')) is not None:
             args['template_version'] = template_version
         else:
-            raise ValueError(
-                'Required property \'template_version\' not present in AccountSettingsAssignedTemplatesSection JSON'
-            )
+            raise ValueError('Required property \'template_version\' not present in AccountSettingsAssignedTemplatesSection JSON')
         if (template_name := _dict.get('template_name')) is not None:
             args['template_name'] = template_name
         else:
-            raise ValueError(
-                'Required property \'template_name\' not present in AccountSettingsAssignedTemplatesSection JSON'
-            )
+            raise ValueError('Required property \'template_name\' not present in AccountSettingsAssignedTemplatesSection JSON')
         if (restrict_create_service_id := _dict.get('restrict_create_service_id')) is not None:
             args['restrict_create_service_id'] = restrict_create_service_id
         if (restrict_create_platform_apikey := _dict.get('restrict_create_platform_apikey')) is not None:
@@ -6239,22 +6219,16 @@ class AccountSettingsAssignedTemplatesSection:
             args['session_invalidation_in_seconds'] = session_invalidation_in_seconds
         if (max_sessions_per_identity := _dict.get('max_sessions_per_identity')) is not None:
             args['max_sessions_per_identity'] = max_sessions_per_identity
-        if (
-            system_access_token_expiration_in_seconds := _dict.get('system_access_token_expiration_in_seconds')
-        ) is not None:
+        if (system_access_token_expiration_in_seconds := _dict.get('system_access_token_expiration_in_seconds')) is not None:
             args['system_access_token_expiration_in_seconds'] = system_access_token_expiration_in_seconds
-        if (
-            system_refresh_token_expiration_in_seconds := _dict.get('system_refresh_token_expiration_in_seconds')
-        ) is not None:
+        if (system_refresh_token_expiration_in_seconds := _dict.get('system_refresh_token_expiration_in_seconds')) is not None:
             args['system_refresh_token_expiration_in_seconds'] = system_refresh_token_expiration_in_seconds
         if (restrict_user_list_visibility := _dict.get('restrict_user_list_visibility')) is not None:
             args['restrict_user_list_visibility'] = restrict_user_list_visibility
         if (user_mfa := _dict.get('user_mfa')) is not None:
             args['user_mfa'] = [AccountSettingsUserMFAResponse.from_dict(v) for v in user_mfa]
         if (restrict_user_domains := _dict.get('restrict_user_domains')) is not None:
-            args['restrict_user_domains'] = AssignedTemplatesAccountSettingsRestrictUserDomains.from_dict(
-                restrict_user_domains
-            )
+            args['restrict_user_domains'] = AssignedTemplatesAccountSettingsRestrictUserDomains.from_dict(restrict_user_domains)
         return cls(**args)
 
     @classmethod
@@ -6285,15 +6259,9 @@ class AccountSettingsAssignedTemplatesSection:
             _dict['session_invalidation_in_seconds'] = self.session_invalidation_in_seconds
         if hasattr(self, 'max_sessions_per_identity') and self.max_sessions_per_identity is not None:
             _dict['max_sessions_per_identity'] = self.max_sessions_per_identity
-        if (
-            hasattr(self, 'system_access_token_expiration_in_seconds')
-            and self.system_access_token_expiration_in_seconds is not None
-        ):
+        if hasattr(self, 'system_access_token_expiration_in_seconds') and self.system_access_token_expiration_in_seconds is not None:
             _dict['system_access_token_expiration_in_seconds'] = self.system_access_token_expiration_in_seconds
-        if (
-            hasattr(self, 'system_refresh_token_expiration_in_seconds')
-            and self.system_refresh_token_expiration_in_seconds is not None
-        ):
+        if hasattr(self, 'system_refresh_token_expiration_in_seconds') and self.system_refresh_token_expiration_in_seconds is not None:
             _dict['system_refresh_token_expiration_in_seconds'] = self.system_refresh_token_expiration_in_seconds
         if hasattr(self, 'restrict_user_list_visibility') and self.restrict_user_list_visibility is not None:
             _dict['restrict_user_list_visibility'] = self.restrict_user_list_visibility
@@ -6343,6 +6311,7 @@ class AccountSettingsAssignedTemplatesSection:
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
 
+
     class RestrictCreatePlatformApikeyEnum(str, Enum):
         """
         Defines whether or not creating the resource is access controlled. Valid values:
@@ -6355,6 +6324,7 @@ class AccountSettingsAssignedTemplatesSection:
         RESTRICTED = 'RESTRICTED'
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
+
 
     class MfaEnum(str, Enum):
         """
@@ -6376,6 +6346,7 @@ class AccountSettingsAssignedTemplatesSection:
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
 
+
     class RestrictUserListVisibilityEnum(str, Enum):
         """
         Defines whether or not user visibility is access controlled. Valid values:
@@ -6390,6 +6361,7 @@ class AccountSettingsAssignedTemplatesSection:
         RESTRICTED = 'RESTRICTED'
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
+
 
 
 class AccountSettingsEffectiveSection:
@@ -6555,13 +6527,9 @@ class AccountSettingsEffectiveSection:
             args['session_invalidation_in_seconds'] = session_invalidation_in_seconds
         if (max_sessions_per_identity := _dict.get('max_sessions_per_identity')) is not None:
             args['max_sessions_per_identity'] = max_sessions_per_identity
-        if (
-            system_access_token_expiration_in_seconds := _dict.get('system_access_token_expiration_in_seconds')
-        ) is not None:
+        if (system_access_token_expiration_in_seconds := _dict.get('system_access_token_expiration_in_seconds')) is not None:
             args['system_access_token_expiration_in_seconds'] = system_access_token_expiration_in_seconds
-        if (
-            system_refresh_token_expiration_in_seconds := _dict.get('system_refresh_token_expiration_in_seconds')
-        ) is not None:
+        if (system_refresh_token_expiration_in_seconds := _dict.get('system_refresh_token_expiration_in_seconds')) is not None:
             args['system_refresh_token_expiration_in_seconds'] = system_refresh_token_expiration_in_seconds
         return cls(**args)
 
@@ -6597,15 +6565,9 @@ class AccountSettingsEffectiveSection:
             _dict['session_invalidation_in_seconds'] = self.session_invalidation_in_seconds
         if hasattr(self, 'max_sessions_per_identity') and self.max_sessions_per_identity is not None:
             _dict['max_sessions_per_identity'] = self.max_sessions_per_identity
-        if (
-            hasattr(self, 'system_access_token_expiration_in_seconds')
-            and self.system_access_token_expiration_in_seconds is not None
-        ):
+        if hasattr(self, 'system_access_token_expiration_in_seconds') and self.system_access_token_expiration_in_seconds is not None:
             _dict['system_access_token_expiration_in_seconds'] = self.system_access_token_expiration_in_seconds
-        if (
-            hasattr(self, 'system_refresh_token_expiration_in_seconds')
-            and self.system_refresh_token_expiration_in_seconds is not None
-        ):
+        if hasattr(self, 'system_refresh_token_expiration_in_seconds') and self.system_refresh_token_expiration_in_seconds is not None:
             _dict['system_refresh_token_expiration_in_seconds'] = self.system_refresh_token_expiration_in_seconds
         return _dict
 
@@ -6640,6 +6602,7 @@ class AccountSettingsEffectiveSection:
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
 
+
     class RestrictCreatePlatformApikeyEnum(str, Enum):
         """
         Defines whether or not creating the resource is access controlled. Valid values:
@@ -6653,6 +6616,7 @@ class AccountSettingsEffectiveSection:
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
 
+
     class RestrictUserListVisibilityEnum(str, Enum):
         """
         Defines whether or not user visibility is access controlled. Valid values:
@@ -6665,6 +6629,7 @@ class AccountSettingsEffectiveSection:
 
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         RESTRICTED = 'RESTRICTED'
+
 
     class MfaEnum(str, Enum):
         """
@@ -6685,6 +6650,7 @@ class AccountSettingsEffectiveSection:
         LEVEL1 = 'LEVEL1'
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
+
 
 
 class AccountSettingsResponse:
@@ -6875,15 +6841,11 @@ class AccountSettingsResponse:
         if (restrict_create_service_id := _dict.get('restrict_create_service_id')) is not None:
             args['restrict_create_service_id'] = restrict_create_service_id
         else:
-            raise ValueError(
-                'Required property \'restrict_create_service_id\' not present in AccountSettingsResponse JSON'
-            )
+            raise ValueError('Required property \'restrict_create_service_id\' not present in AccountSettingsResponse JSON')
         if (restrict_create_platform_apikey := _dict.get('restrict_create_platform_apikey')) is not None:
             args['restrict_create_platform_apikey'] = restrict_create_platform_apikey
         else:
-            raise ValueError(
-                'Required property \'restrict_create_platform_apikey\' not present in AccountSettingsResponse JSON'
-            )
+            raise ValueError('Required property \'restrict_create_platform_apikey\' not present in AccountSettingsResponse JSON')
         if (allowed_ip_addresses := _dict.get('allowed_ip_addresses')) is not None:
             args['allowed_ip_addresses'] = allowed_ip_addresses
         else:
@@ -6895,51 +6857,33 @@ class AccountSettingsResponse:
         if (session_expiration_in_seconds := _dict.get('session_expiration_in_seconds')) is not None:
             args['session_expiration_in_seconds'] = session_expiration_in_seconds
         else:
-            raise ValueError(
-                'Required property \'session_expiration_in_seconds\' not present in AccountSettingsResponse JSON'
-            )
+            raise ValueError('Required property \'session_expiration_in_seconds\' not present in AccountSettingsResponse JSON')
         if (session_invalidation_in_seconds := _dict.get('session_invalidation_in_seconds')) is not None:
             args['session_invalidation_in_seconds'] = session_invalidation_in_seconds
         else:
-            raise ValueError(
-                'Required property \'session_invalidation_in_seconds\' not present in AccountSettingsResponse JSON'
-            )
+            raise ValueError('Required property \'session_invalidation_in_seconds\' not present in AccountSettingsResponse JSON')
         if (max_sessions_per_identity := _dict.get('max_sessions_per_identity')) is not None:
             args['max_sessions_per_identity'] = max_sessions_per_identity
         else:
-            raise ValueError(
-                'Required property \'max_sessions_per_identity\' not present in AccountSettingsResponse JSON'
-            )
-        if (
-            system_access_token_expiration_in_seconds := _dict.get('system_access_token_expiration_in_seconds')
-        ) is not None:
+            raise ValueError('Required property \'max_sessions_per_identity\' not present in AccountSettingsResponse JSON')
+        if (system_access_token_expiration_in_seconds := _dict.get('system_access_token_expiration_in_seconds')) is not None:
             args['system_access_token_expiration_in_seconds'] = system_access_token_expiration_in_seconds
         else:
-            raise ValueError(
-                'Required property \'system_access_token_expiration_in_seconds\' not present in AccountSettingsResponse JSON'
-            )
-        if (
-            system_refresh_token_expiration_in_seconds := _dict.get('system_refresh_token_expiration_in_seconds')
-        ) is not None:
+            raise ValueError('Required property \'system_access_token_expiration_in_seconds\' not present in AccountSettingsResponse JSON')
+        if (system_refresh_token_expiration_in_seconds := _dict.get('system_refresh_token_expiration_in_seconds')) is not None:
             args['system_refresh_token_expiration_in_seconds'] = system_refresh_token_expiration_in_seconds
         else:
-            raise ValueError(
-                'Required property \'system_refresh_token_expiration_in_seconds\' not present in AccountSettingsResponse JSON'
-            )
+            raise ValueError('Required property \'system_refresh_token_expiration_in_seconds\' not present in AccountSettingsResponse JSON')
         if (restrict_user_list_visibility := _dict.get('restrict_user_list_visibility')) is not None:
             args['restrict_user_list_visibility'] = restrict_user_list_visibility
         else:
-            raise ValueError(
-                'Required property \'restrict_user_list_visibility\' not present in AccountSettingsResponse JSON'
-            )
+            raise ValueError('Required property \'restrict_user_list_visibility\' not present in AccountSettingsResponse JSON')
         if (user_mfa := _dict.get('user_mfa')) is not None:
             args['user_mfa'] = [AccountSettingsUserMFAResponse.from_dict(v) for v in user_mfa]
         else:
             raise ValueError('Required property \'user_mfa\' not present in AccountSettingsResponse JSON')
         if (restrict_user_domains := _dict.get('restrict_user_domains')) is not None:
-            args['restrict_user_domains'] = [
-                AccountSettingsUserDomainRestriction.from_dict(v) for v in restrict_user_domains
-            ]
+            args['restrict_user_domains'] = [AccountSettingsUserDomainRestriction.from_dict(v) for v in restrict_user_domains]
         else:
             raise ValueError('Required property \'restrict_user_domains\' not present in AccountSettingsResponse JSON')
         return cls(**args)
@@ -6983,15 +6927,9 @@ class AccountSettingsResponse:
             _dict['session_invalidation_in_seconds'] = self.session_invalidation_in_seconds
         if hasattr(self, 'max_sessions_per_identity') and self.max_sessions_per_identity is not None:
             _dict['max_sessions_per_identity'] = self.max_sessions_per_identity
-        if (
-            hasattr(self, 'system_access_token_expiration_in_seconds')
-            and self.system_access_token_expiration_in_seconds is not None
-        ):
+        if hasattr(self, 'system_access_token_expiration_in_seconds') and self.system_access_token_expiration_in_seconds is not None:
             _dict['system_access_token_expiration_in_seconds'] = self.system_access_token_expiration_in_seconds
-        if (
-            hasattr(self, 'system_refresh_token_expiration_in_seconds')
-            and self.system_refresh_token_expiration_in_seconds is not None
-        ):
+        if hasattr(self, 'system_refresh_token_expiration_in_seconds') and self.system_refresh_token_expiration_in_seconds is not None:
             _dict['system_refresh_token_expiration_in_seconds'] = self.system_refresh_token_expiration_in_seconds
         if hasattr(self, 'restrict_user_list_visibility') and self.restrict_user_list_visibility is not None:
             _dict['restrict_user_list_visibility'] = self.restrict_user_list_visibility
@@ -7044,6 +6982,7 @@ class AccountSettingsResponse:
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
 
+
     class RestrictCreatePlatformApikeyEnum(str, Enum):
         """
         Defines whether or not creating the resource is access controlled. Valid values:
@@ -7056,6 +6995,7 @@ class AccountSettingsResponse:
         RESTRICTED = 'RESTRICTED'
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
+
 
     class MfaEnum(str, Enum):
         """
@@ -7077,6 +7017,7 @@ class AccountSettingsResponse:
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
 
+
     class RestrictUserListVisibilityEnum(str, Enum):
         """
         Defines whether or not user visibility is access controlled. Valid values:
@@ -7089,6 +7030,7 @@ class AccountSettingsResponse:
 
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         RESTRICTED = 'RESTRICTED'
+
 
 
 class AccountSettingsTemplateList:
@@ -7165,13 +7107,9 @@ class AccountSettingsTemplateList:
         if (next := _dict.get('next')) is not None:
             args['next'] = next
         if (account_settings_templates := _dict.get('account_settings_templates')) is not None:
-            args['account_settings_templates'] = [
-                AccountSettingsTemplateResponse.from_dict(v) for v in account_settings_templates
-            ]
+            args['account_settings_templates'] = [AccountSettingsTemplateResponse.from_dict(v) for v in account_settings_templates]
         else:
-            raise ValueError(
-                'Required property \'account_settings_templates\' not present in AccountSettingsTemplateList JSON'
-            )
+            raise ValueError('Required property \'account_settings_templates\' not present in AccountSettingsTemplateList JSON')
         return cls(**args)
 
     @classmethod
@@ -7337,9 +7275,7 @@ class AccountSettingsTemplateResponse:
         if (account_settings := _dict.get('account_settings')) is not None:
             args['account_settings'] = TemplateAccountSettings.from_dict(account_settings)
         else:
-            raise ValueError(
-                'Required property \'account_settings\' not present in AccountSettingsTemplateResponse JSON'
-            )
+            raise ValueError('Required property \'account_settings\' not present in AccountSettingsTemplateResponse JSON')
         if (history := _dict.get('history')) is not None:
             args['history'] = [EnityHistoryRecord.from_dict(v) for v in history]
         if (entity_tag := _dict.get('entity_tag')) is not None:
@@ -7647,6 +7583,7 @@ class AccountSettingsUserMFAResponse:
         LEVEL1 = 'LEVEL1'
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
+
 
 
 class ActionControls:
@@ -9061,9 +8998,7 @@ class EffectiveAccountSettingsResponse:
         else:
             raise ValueError('Required property \'account\' not present in EffectiveAccountSettingsResponse JSON')
         if (assigned_templates := _dict.get('assigned_templates')) is not None:
-            args['assigned_templates'] = [
-                AccountSettingsAssignedTemplatesSection.from_dict(v) for v in assigned_templates
-            ]
+            args['assigned_templates'] = [AccountSettingsAssignedTemplatesSection.from_dict(v) for v in assigned_templates]
         return cls(**args)
 
     @classmethod
@@ -9668,6 +9603,7 @@ class IdBasedMfaEnrollment:
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
 
+
     class TraitUserSpecificEnum(str, Enum):
         """
         MFA trait definitions as follows:
@@ -9687,6 +9623,7 @@ class IdBasedMfaEnrollment:
         LEVEL1 = 'LEVEL1'
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
+
 
     class TraitEffectiveEnum(str, Enum):
         """
@@ -9708,6 +9645,7 @@ class IdBasedMfaEnrollment:
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
 
+
     class ComplyStateEnum(str, Enum):
         """
         Defines comply state for the account. Valid values:
@@ -9721,6 +9659,7 @@ class IdBasedMfaEnrollment:
         NO = 'NO'
         ACCOUNT = 'ACCOUNT'
         CROSS_ACCOUNT = 'CROSS_ACCOUNT'
+
 
 
 class IdentityCount:
@@ -9907,19 +9846,13 @@ class IdentityLimitsUsageResponse:
         if (account_settings_templates := _dict.get('account_settings_templates')) is not None:
             args['account_settings_templates'] = LimitCount.from_dict(account_settings_templates)
         if (template_versions_per_template := _dict.get('template_versions_per_template')) is not None:
-            args['template_versions_per_template'] = IdentityLimitsUsageResponseTemplateVersionsPerTemplate.from_dict(
-                template_versions_per_template
-            )
+            args['template_versions_per_template'] = IdentityLimitsUsageResponseTemplateVersionsPerTemplate.from_dict(template_versions_per_template)
         if (idps := _dict.get('idps')) is not None:
             args['idps'] = LimitCount.from_dict(idps)
         if (claim_rules_per_group := _dict.get('claim_rules_per_group')) is not None:
-            args['claim_rules_per_group'] = IdentityLimitsUsageResponseClaimRulesPerGroup.from_dict(
-                claim_rules_per_group
-            )
+            args['claim_rules_per_group'] = IdentityLimitsUsageResponseClaimRulesPerGroup.from_dict(claim_rules_per_group)
         if (claim_rules_per_profile := _dict.get('claim_rules_per_profile')) is not None:
-            args['claim_rules_per_profile'] = IdentityLimitsUsageResponseClaimRulesPerProfile.from_dict(
-                claim_rules_per_profile
-            )
+            args['claim_rules_per_profile'] = IdentityLimitsUsageResponseClaimRulesPerProfile.from_dict(claim_rules_per_profile)
         if (cr_links := _dict.get('cr_links')) is not None:
             args['cr_links'] = LimitCount.from_dict(cr_links)
         if (cr_links_per_profile := _dict.get('cr_links_per_profile')) is not None:
@@ -10061,9 +9994,7 @@ class IdentityLimitsUsageResponseApikeysPerIdentity:
         if (limit := _dict.get('limit')) is not None:
             args['limit'] = limit
         else:
-            raise ValueError(
-                'Required property \'limit\' not present in IdentityLimitsUsageResponseApikeysPerIdentity JSON'
-            )
+            raise ValueError('Required property \'limit\' not present in IdentityLimitsUsageResponseApikeysPerIdentity JSON')
         if (identities := _dict.get('identities')) is not None:
             args['identities'] = [IdentityCount.from_dict(v) for v in identities]
         return cls(**args)
@@ -10139,9 +10070,7 @@ class IdentityLimitsUsageResponseClaimRulesPerGroup:
         if (limit := _dict.get('limit')) is not None:
             args['limit'] = limit
         else:
-            raise ValueError(
-                'Required property \'limit\' not present in IdentityLimitsUsageResponseClaimRulesPerGroup JSON'
-            )
+            raise ValueError('Required property \'limit\' not present in IdentityLimitsUsageResponseClaimRulesPerGroup JSON')
         if (access_groups := _dict.get('access_groups')) is not None:
             args['access_groups'] = [AccessGroupCount.from_dict(v) for v in access_groups]
         return cls(**args)
@@ -10217,9 +10146,7 @@ class IdentityLimitsUsageResponseClaimRulesPerProfile:
         if (limit := _dict.get('limit')) is not None:
             args['limit'] = limit
         else:
-            raise ValueError(
-                'Required property \'limit\' not present in IdentityLimitsUsageResponseClaimRulesPerProfile JSON'
-            )
+            raise ValueError('Required property \'limit\' not present in IdentityLimitsUsageResponseClaimRulesPerProfile JSON')
         if (profiles := _dict.get('profiles')) is not None:
             args['profiles'] = [ProfileCount.from_dict(v) for v in profiles]
         return cls(**args)
@@ -10295,9 +10222,7 @@ class IdentityLimitsUsageResponseCrLinksPerProfile:
         if (limit := _dict.get('limit')) is not None:
             args['limit'] = limit
         else:
-            raise ValueError(
-                'Required property \'limit\' not present in IdentityLimitsUsageResponseCrLinksPerProfile JSON'
-            )
+            raise ValueError('Required property \'limit\' not present in IdentityLimitsUsageResponseCrLinksPerProfile JSON')
         if (profiles := _dict.get('profiles')) is not None:
             args['profiles'] = [ProfileCount.from_dict(v) for v in profiles]
         return cls(**args)
@@ -10373,9 +10298,7 @@ class IdentityLimitsUsageResponseCrRulesPerProfile:
         if (limit := _dict.get('limit')) is not None:
             args['limit'] = limit
         else:
-            raise ValueError(
-                'Required property \'limit\' not present in IdentityLimitsUsageResponseCrRulesPerProfile JSON'
-            )
+            raise ValueError('Required property \'limit\' not present in IdentityLimitsUsageResponseCrRulesPerProfile JSON')
         if (profiles := _dict.get('profiles')) is not None:
             args['profiles'] = [ProfileCount.from_dict(v) for v in profiles]
         return cls(**args)
@@ -10451,9 +10374,7 @@ class IdentityLimitsUsageResponseServiceidsPerGroup:
         if (limit := _dict.get('limit')) is not None:
             args['limit'] = limit
         else:
-            raise ValueError(
-                'Required property \'limit\' not present in IdentityLimitsUsageResponseServiceidsPerGroup JSON'
-            )
+            raise ValueError('Required property \'limit\' not present in IdentityLimitsUsageResponseServiceidsPerGroup JSON')
         if (serviceid_groups := _dict.get('serviceid_groups')) is not None:
             args['serviceid_groups'] = [ServiceIdGroupCount.from_dict(v) for v in serviceid_groups]
         return cls(**args)
@@ -10529,9 +10450,7 @@ class IdentityLimitsUsageResponseTemplateVersionsPerTemplate:
         if (limit := _dict.get('limit')) is not None:
             args['limit'] = limit
         else:
-            raise ValueError(
-                'Required property \'limit\' not present in IdentityLimitsUsageResponseTemplateVersionsPerTemplate JSON'
-            )
+            raise ValueError('Required property \'limit\' not present in IdentityLimitsUsageResponseTemplateVersionsPerTemplate JSON')
         if (templates := _dict.get('templates')) is not None:
             args['templates'] = [TemplateCount.from_dict(v) for v in templates]
         return cls(**args)
@@ -10973,7 +10892,7 @@ class ProfileClaimRule:
           applies to.
     :param int expiration: Session expiration in seconds.
     :param str cr_type: (optional) The compute resource type. Not required if type
-          is Profile-SAML. Valid values are VSI, IKS_SA, ROKS_SA.
+          is Profile-SAML. Valid values are VSI, PVS, IKS_SA, ROKS_SA.
     :param List[ProfileClaimRuleConditions] conditions: Conditions of this claim
           rule.
     """
@@ -11010,7 +10929,7 @@ class ProfileClaimRule:
         :param str realm_name: (optional) The realm name of the Idp this claim rule
                applies to.
         :param str cr_type: (optional) The compute resource type. Not required if
-               type is Profile-SAML. Valid values are VSI, IKS_SA, ROKS_SA.
+               type is Profile-SAML. Valid values are VSI, PVS, IKS_SA, ROKS_SA.
         """
         self.id = id
         self.entity_tag = entity_tag
@@ -11535,6 +11454,7 @@ class ProfileIdentityRequest:
         CRN = 'crn'
 
 
+
 class ProfileIdentityResponse:
     """
     ProfileIdentityResponse.
@@ -11658,6 +11578,7 @@ class ProfileIdentityResponse:
         CRN = 'crn'
 
 
+
 class ProfileLink:
     """
     Link details.
@@ -11669,7 +11590,7 @@ class ProfileLink:
     :param datetime modified_at: If set contains a date time string of the last
           modification date in ISO format.
     :param str name: (optional) Optional name of the Link.
-    :param str cr_type: The compute resource type. Valid values are VSI, BMS,
+    :param str cr_type: The compute resource type. Valid values are VSI, PVS, BMS,
           IKS_SA, ROKS_SA, CE.
     :param bool is_cross_account: (optional) Flag to indicate that the link provides
           cross account access. If not provided then the account scope of the CRN must
@@ -11698,8 +11619,8 @@ class ProfileLink:
                creation date in ISO format.
         :param datetime modified_at: If set contains a date time string of the last
                modification date in ISO format.
-        :param str cr_type: The compute resource type. Valid values are VSI, BMS,
-               IKS_SA, ROKS_SA, CE.
+        :param str cr_type: The compute resource type. Valid values are VSI, PVS,
+               BMS, IKS_SA, ROKS_SA, CE.
         :param ProfileLinkLink link:
         :param str name: (optional) Optional name of the Link.
         :param bool is_cross_account: (optional) Flag to indicate that the link
@@ -13251,13 +13172,9 @@ class TemplateAccountSettings:
             args['session_invalidation_in_seconds'] = session_invalidation_in_seconds
         if (max_sessions_per_identity := _dict.get('max_sessions_per_identity')) is not None:
             args['max_sessions_per_identity'] = max_sessions_per_identity
-        if (
-            system_access_token_expiration_in_seconds := _dict.get('system_access_token_expiration_in_seconds')
-        ) is not None:
+        if (system_access_token_expiration_in_seconds := _dict.get('system_access_token_expiration_in_seconds')) is not None:
             args['system_access_token_expiration_in_seconds'] = system_access_token_expiration_in_seconds
-        if (
-            system_refresh_token_expiration_in_seconds := _dict.get('system_refresh_token_expiration_in_seconds')
-        ) is not None:
+        if (system_refresh_token_expiration_in_seconds := _dict.get('system_refresh_token_expiration_in_seconds')) is not None:
             args['system_refresh_token_expiration_in_seconds'] = system_refresh_token_expiration_in_seconds
         if (restrict_user_list_visibility := _dict.get('restrict_user_list_visibility')) is not None:
             args['restrict_user_list_visibility'] = restrict_user_list_visibility
@@ -13295,15 +13212,9 @@ class TemplateAccountSettings:
             _dict['session_invalidation_in_seconds'] = self.session_invalidation_in_seconds
         if hasattr(self, 'max_sessions_per_identity') and self.max_sessions_per_identity is not None:
             _dict['max_sessions_per_identity'] = self.max_sessions_per_identity
-        if (
-            hasattr(self, 'system_access_token_expiration_in_seconds')
-            and self.system_access_token_expiration_in_seconds is not None
-        ):
+        if hasattr(self, 'system_access_token_expiration_in_seconds') and self.system_access_token_expiration_in_seconds is not None:
             _dict['system_access_token_expiration_in_seconds'] = self.system_access_token_expiration_in_seconds
-        if (
-            hasattr(self, 'system_refresh_token_expiration_in_seconds')
-            and self.system_refresh_token_expiration_in_seconds is not None
-        ):
+        if hasattr(self, 'system_refresh_token_expiration_in_seconds') and self.system_refresh_token_expiration_in_seconds is not None:
             _dict['system_refresh_token_expiration_in_seconds'] = self.system_refresh_token_expiration_in_seconds
         if hasattr(self, 'restrict_user_list_visibility') and self.restrict_user_list_visibility is not None:
             _dict['restrict_user_list_visibility'] = self.restrict_user_list_visibility
@@ -13345,6 +13256,7 @@ class TemplateAccountSettings:
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
 
+
     class RestrictCreatePlatformApikeyEnum(str, Enum):
         """
         Defines whether or not creating the resource is access controlled. Valid values:
@@ -13357,6 +13269,7 @@ class TemplateAccountSettings:
         RESTRICTED = 'RESTRICTED'
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
+
 
     class MfaEnum(str, Enum):
         """
@@ -13378,6 +13291,7 @@ class TemplateAccountSettings:
         LEVEL2 = 'LEVEL2'
         LEVEL3 = 'LEVEL3'
 
+
     class RestrictUserListVisibilityEnum(str, Enum):
         """
         Defines whether or not user visibility is access controlled. Valid values:
@@ -13392,6 +13306,7 @@ class TemplateAccountSettings:
         RESTRICTED = 'RESTRICTED'
         NOT_RESTRICTED = 'NOT_RESTRICTED'
         NOT_SET = 'NOT_SET'
+
 
 
 class TemplateAccountSettingsRestrictUserDomains:
@@ -14025,9 +13940,7 @@ class TemplateAssignmentResponseResource:
         if (account_settings := _dict.get('account_settings')) is not None:
             args['account_settings'] = TemplateAssignmentResponseResourceDetail.from_dict(account_settings)
         if (policy_template_references := _dict.get('policy_template_references')) is not None:
-            args['policy_template_references'] = [
-                TemplateAssignmentResponseResourceDetail.from_dict(v) for v in policy_template_references
-            ]
+            args['policy_template_references'] = [TemplateAssignmentResponseResourceDetail.from_dict(v) for v in policy_template_references]
         return cls(**args)
 
     @classmethod
@@ -14137,9 +14050,7 @@ class TemplateAssignmentResponseResourceDetail:
         if (status := _dict.get('status')) is not None:
             args['status'] = status
         else:
-            raise ValueError(
-                'Required property \'status\' not present in TemplateAssignmentResponseResourceDetail JSON'
-            )
+            raise ValueError('Required property \'status\' not present in TemplateAssignmentResponseResourceDetail JSON')
         return cls(**args)
 
     @classmethod
@@ -14870,6 +14781,7 @@ class TrustedProfileTemplateClaimRule:
         PROFILE_SAML = 'Profile-SAML'
 
 
+
 class TrustedProfileTemplateList:
     """
     TrustedProfileTemplateList.
@@ -15127,9 +15039,7 @@ class TrustedProfileTemplateResponse:
         if (profile := _dict.get('profile')) is not None:
             args['profile'] = TemplateProfileComponentResponse.from_dict(profile)
         if (policy_template_references := _dict.get('policy_template_references')) is not None:
-            args['policy_template_references'] = [
-                PolicyTemplateReference.from_dict(v) for v in policy_template_references
-            ]
+            args['policy_template_references'] = [PolicyTemplateReference.from_dict(v) for v in policy_template_references]
         if (action_controls := _dict.get('action_controls')) is not None:
             args['action_controls'] = ActionControls.from_dict(action_controls)
         if (history := _dict.get('history')) is not None:
@@ -15548,6 +15458,7 @@ class UserMfa:
         LEVEL3 = 'LEVEL3'
 
 
+
 class UserMfaEnrollments:
     """
     UserMfaEnrollments.
@@ -15704,9 +15615,7 @@ class UserReportMfaEnrollmentStatus:
         if (effective_mfa_type := _dict.get('effective_mfa_type')) is not None:
             args['effective_mfa_type'] = effective_mfa_type
         else:
-            raise ValueError(
-                'Required property \'effective_mfa_type\' not present in UserReportMfaEnrollmentStatus JSON'
-            )
+            raise ValueError('Required property \'effective_mfa_type\' not present in UserReportMfaEnrollmentStatus JSON')
         if (id_based_mfa := _dict.get('id_based_mfa')) is not None:
             args['id_based_mfa'] = IdBasedMfaEnrollment.from_dict(id_based_mfa)
         else:
@@ -15714,9 +15623,7 @@ class UserReportMfaEnrollmentStatus:
         if (account_based_mfa := _dict.get('account_based_mfa')) is not None:
             args['account_based_mfa'] = AccountBasedMfaEnrollment.from_dict(account_based_mfa)
         else:
-            raise ValueError(
-                'Required property \'account_based_mfa\' not present in UserReportMfaEnrollmentStatus JSON'
-            )
+            raise ValueError('Required property \'account_based_mfa\' not present in UserReportMfaEnrollmentStatus JSON')
         return cls(**args)
 
     @classmethod

--- a/ibm_platform_services/iam_identity_v1.py
+++ b/ibm_platform_services/iam_identity_v1.py
@@ -1796,7 +1796,7 @@ class IamIdentityV1(BaseService):
                'Profile-SAML'.
         :param str cr_type: (optional) The compute resource type the rule applies
                to, required only if type is specified as 'Profile-CR'. Valid values are
-               VSI, PVS, IKS_SA, ROKS_SA.
+               VSI, PVS, BMS, IKS_SA, ROKS_SA, CE.
         :param int expiration: (optional) Session expiration in seconds, only
                required if type is 'Profile-SAML'.
         :param dict headers: A `dict` containing the request headers
@@ -1985,7 +1985,7 @@ class IamIdentityV1(BaseService):
                'Profile-SAML'.
         :param str cr_type: (optional) The compute resource type the rule applies
                to, required only if type is specified as 'Profile-CR'. Valid values are
-               VSI, PVS, IKS_SA, ROKS_SA.
+               VSI, PVS, BMS, IKS_SA, ROKS_SA, CE.
         :param int expiration: (optional) Session expiration in seconds, only
                required if type is 'Profile-SAML'.
         :param dict headers: A `dict` containing the request headers
@@ -2116,7 +2116,7 @@ class IamIdentityV1(BaseService):
 
         :param str profile_id: ID of the trusted profile.
         :param str cr_type: The compute resource type. Valid values are VSI, PVS,
-               IKS_SA, ROKS_SA.
+               BMS, IKS_SA, ROKS_SA, CE.
         :param CreateProfileLinkRequestLink link: Link details.
         :param str name: (optional) Optional name of the Link.
         :param bool is_cross_account: (optional) Flag to indicate that the link
@@ -2235,7 +2235,8 @@ class IamIdentityV1(BaseService):
         :param str profile_id: The unique ID of the Trusted Profile.
         :param str type: The compute resource type. Valid values are VSI, PVS, BMS,
                IKS_SA, ROKS_SA, CE.
-        :param str crn: (optional) CRN of the compute resource (IKS/ROKS/VSI/BMS).
+        :param str crn: (optional) CRN of the compute resource
+               (VSI/PVS/BMS/IKS/ROKS/CE).
         :param str namespace: (optional) Namespace of the compute resource
                (IKS/ROKS).
         :param str name: (optional) Name of the compute resource (IKS/ROKS).
@@ -10971,7 +10972,7 @@ class ProfileClaimRule:
           applies to.
     :param int expiration: Session expiration in seconds.
     :param str cr_type: (optional) The compute resource type. Not required if type
-          is Profile-SAML. Valid values are VSI, PVS, IKS_SA, ROKS_SA.
+          is Profile-SAML. Valid values are VSI, PVS, BMS, IKS_SA, ROKS_SA, CE.
     :param List[ProfileClaimRuleConditions] conditions: Conditions of this claim
           rule.
     """
@@ -11008,7 +11009,7 @@ class ProfileClaimRule:
         :param str realm_name: (optional) The realm name of the Idp this claim rule
                applies to.
         :param str cr_type: (optional) The compute resource type. Not required if
-               type is Profile-SAML. Valid values are VSI, PVS, IKS_SA, ROKS_SA.
+               type is Profile-SAML. Valid values are VSI, PVS, BMS, IKS_SA, ROKS_SA, CE.
         """
         self.id = id
         self.entity_tag = entity_tag

--- a/test/unit/test_iam_identity_v1.py
+++ b/test/unit/test_iam_identity_v1.py
@@ -30,10 +30,7 @@ import responses
 import urllib
 from ibm_platform_services.iam_identity_v1 import *
 
-
-_service = IamIdentityV1(
-    authenticator=NoAuthAuthenticator()
-)
+_service = IamIdentityV1(authenticator=NoAuthAuthenticator())
 
 _base_url = 'https://iam.cloud.ibm.com'
 _service.set_service_url(_base_url)
@@ -5619,7 +5616,7 @@ class TestUpdatePreferenceOnScopeAccount:
             iam_id,
             service,
             preference_id,
-            value_string,
+            value_string=value_string,
             value_list_of_strings=value_list_of_strings,
             headers={},
         )
@@ -5671,7 +5668,6 @@ class TestUpdatePreferenceOnScopeAccount:
             "iam_id": iam_id,
             "service": service,
             "preference_id": preference_id,
-            "value_string": value_string,
         }
         for param in req_param_dict.keys():
             req_copy = {key: val if key is not param else None for (key, val) in req_param_dict.items()}
@@ -7984,7 +7980,9 @@ class TestCreateAccountSettingsTemplate:
         # Construct a dict representation of a TemplateAccountSettingsRestrictUserDomains model
         template_account_settings_restrict_user_domains_model = {}
         template_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
+        template_account_settings_restrict_user_domains_model['restrictions'] = [
+            account_settings_user_domain_restriction_model
+        ]
 
         # Construct a dict representation of a TemplateAccountSettings model
         template_account_settings_model = {}
@@ -8408,7 +8406,9 @@ class TestCreateAccountSettingsTemplateVersion:
         # Construct a dict representation of a TemplateAccountSettingsRestrictUserDomains model
         template_account_settings_restrict_user_domains_model = {}
         template_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
+        template_account_settings_restrict_user_domains_model['restrictions'] = [
+            account_settings_user_domain_restriction_model
+        ]
 
         # Construct a dict representation of a TemplateAccountSettings model
         template_account_settings_model = {}
@@ -8491,7 +8491,9 @@ class TestCreateAccountSettingsTemplateVersion:
         # Construct a dict representation of a TemplateAccountSettingsRestrictUserDomains model
         template_account_settings_restrict_user_domains_model = {}
         template_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
+        template_account_settings_restrict_user_domains_model['restrictions'] = [
+            account_settings_user_domain_restriction_model
+        ]
 
         # Construct a dict representation of a TemplateAccountSettings model
         template_account_settings_model = {}
@@ -8700,7 +8702,9 @@ class TestUpdateAccountSettingsTemplateVersion:
         # Construct a dict representation of a TemplateAccountSettingsRestrictUserDomains model
         template_account_settings_restrict_user_domains_model = {}
         template_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
+        template_account_settings_restrict_user_domains_model['restrictions'] = [
+            account_settings_user_domain_restriction_model
+        ]
 
         # Construct a dict representation of a TemplateAccountSettings model
         template_account_settings_model = {}
@@ -8787,7 +8791,9 @@ class TestUpdateAccountSettingsTemplateVersion:
         # Construct a dict representation of a TemplateAccountSettingsRestrictUserDomains model
         template_account_settings_restrict_user_domains_model = {}
         template_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
+        template_account_settings_restrict_user_domains_model['restrictions'] = [
+            account_settings_user_domain_restriction_model
+        ]
 
         # Construct a dict representation of a TemplateAccountSettings model
         template_account_settings_model = {}
@@ -9759,13 +9765,22 @@ class TestBulkListAccountEntityConsumption:
         # Set up parameter values
         account_id = 'testString'
         serviceid_groups = True
-        serviceids_per_group = ['ServiceIdGroup-12345678-1234-1234-1234-123456789abc', 'ServiceIdGroup-12345678-1234-1234-1234-123456789def']
+        serviceids_per_group = [
+            'ServiceIdGroup-12345678-1234-1234-1234-123456789abc',
+            'ServiceIdGroup-12345678-1234-1234-1234-123456789def',
+        ]
         profiles = True
         apikeys_per_identity = ['iam-ServiceId-12345678-1234-1234-1234-123456789def', 'IBMid-1234567ABC']
         templates = True
-        template_versions_per_template = ['AccountSettingsTemplate-12345678-1234-1234-1234-123456789abc', 'ProfileTemplate-12345678-1234-1234-1234-123456789def']
+        template_versions_per_template = [
+            'AccountSettingsTemplate-12345678-1234-1234-1234-123456789abc',
+            'ProfileTemplate-12345678-1234-1234-1234-123456789def',
+        ]
         idps = True
-        claim_rules_per_group = ['AccessGroupId-12345678-1234-1234-1234-123456789abc', 'AccessGroupId-12345678-1234-1234-1234-123456789def']
+        claim_rules_per_group = [
+            'AccessGroupId-12345678-1234-1234-1234-123456789abc',
+            'AccessGroupId-12345678-1234-1234-1234-123456789def',
+        ]
         claim_rules_per_profile = ['Profile-12345678-1234-1234-123456789abc', 'Profile-12345678-1234-1234-123456789def']
         cr_links = True
         cr_links_per_profile = ['Profile-12345678-1234-1234-123456789abc', 'Profile-12345678-1234-1234-123456789def']
@@ -9797,18 +9812,39 @@ class TestBulkListAccountEntityConsumption:
         # Validate body params
         req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
         assert req_body['serviceid_groups'] == True
-        assert req_body['serviceids_per_group'] == ['ServiceIdGroup-12345678-1234-1234-1234-123456789abc', 'ServiceIdGroup-12345678-1234-1234-1234-123456789def']
+        assert req_body['serviceids_per_group'] == [
+            'ServiceIdGroup-12345678-1234-1234-1234-123456789abc',
+            'ServiceIdGroup-12345678-1234-1234-1234-123456789def',
+        ]
         assert req_body['profiles'] == True
-        assert req_body['apikeys_per_identity'] == ['iam-ServiceId-12345678-1234-1234-1234-123456789def', 'IBMid-1234567ABC']
+        assert req_body['apikeys_per_identity'] == [
+            'iam-ServiceId-12345678-1234-1234-1234-123456789def',
+            'IBMid-1234567ABC',
+        ]
         assert req_body['templates'] == True
-        assert req_body['template_versions_per_template'] == ['AccountSettingsTemplate-12345678-1234-1234-1234-123456789abc', 'ProfileTemplate-12345678-1234-1234-1234-123456789def']
+        assert req_body['template_versions_per_template'] == [
+            'AccountSettingsTemplate-12345678-1234-1234-1234-123456789abc',
+            'ProfileTemplate-12345678-1234-1234-1234-123456789def',
+        ]
         assert req_body['idps'] == True
-        assert req_body['claim_rules_per_group'] == ['AccessGroupId-12345678-1234-1234-1234-123456789abc', 'AccessGroupId-12345678-1234-1234-1234-123456789def']
-        assert req_body['claim_rules_per_profile'] == ['Profile-12345678-1234-1234-123456789abc', 'Profile-12345678-1234-1234-123456789def']
+        assert req_body['claim_rules_per_group'] == [
+            'AccessGroupId-12345678-1234-1234-1234-123456789abc',
+            'AccessGroupId-12345678-1234-1234-1234-123456789def',
+        ]
+        assert req_body['claim_rules_per_profile'] == [
+            'Profile-12345678-1234-1234-123456789abc',
+            'Profile-12345678-1234-1234-123456789def',
+        ]
         assert req_body['cr_links'] == True
-        assert req_body['cr_links_per_profile'] == ['Profile-12345678-1234-1234-123456789abc', 'Profile-12345678-1234-1234-123456789def']
+        assert req_body['cr_links_per_profile'] == [
+            'Profile-12345678-1234-1234-123456789abc',
+            'Profile-12345678-1234-1234-123456789def',
+        ]
         assert req_body['cr_rules'] == True
-        assert req_body['cr_rules_per_profile'] == ['Profile-12345678-1234-1234-123456789abc', 'Profile-12345678-1234-1234-123456789def']
+        assert req_body['cr_rules_per_profile'] == [
+            'Profile-12345678-1234-1234-123456789abc',
+            'Profile-12345678-1234-1234-123456789def',
+        ]
 
     def test_bulk_list_account_entity_consumption_all_params_with_retries(self):
         # Enable retries and run test_bulk_list_account_entity_consumption_all_params.
@@ -9962,11 +9998,15 @@ class TestModel_AccountBasedMfaEnrollment:
         account_based_mfa_enrollment_model_json['complies'] = True
 
         # Construct a model instance of AccountBasedMfaEnrollment by calling from_dict on the json representation
-        account_based_mfa_enrollment_model = AccountBasedMfaEnrollment.from_dict(account_based_mfa_enrollment_model_json)
+        account_based_mfa_enrollment_model = AccountBasedMfaEnrollment.from_dict(
+            account_based_mfa_enrollment_model_json
+        )
         assert account_based_mfa_enrollment_model != False
 
         # Construct a model instance of AccountBasedMfaEnrollment by calling from_dict on the json representation
-        account_based_mfa_enrollment_model_dict = AccountBasedMfaEnrollment.from_dict(account_based_mfa_enrollment_model_json).__dict__
+        account_based_mfa_enrollment_model_dict = AccountBasedMfaEnrollment.from_dict(
+            account_based_mfa_enrollment_model_json
+        ).__dict__
         account_based_mfa_enrollment_model2 = AccountBasedMfaEnrollment(**account_based_mfa_enrollment_model_dict)
 
         # Verify the model instances are equivalent
@@ -10002,9 +10042,13 @@ class TestModel_AccountSettingsAssignedTemplatesSection:
         account_settings_user_domain_restriction_model['invitation_email_allow_patterns'] = []
         account_settings_user_domain_restriction_model['restrict_invitation'] = True
 
-        assigned_templates_account_settings_restrict_user_domains_model = {}  # AssignedTemplatesAccountSettingsRestrictUserDomains
+        assigned_templates_account_settings_restrict_user_domains_model = (
+            {}
+        )  # AssignedTemplatesAccountSettingsRestrictUserDomains
         assigned_templates_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        assigned_templates_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
+        assigned_templates_account_settings_restrict_user_domains_model['restrictions'] = [
+            account_settings_user_domain_restriction_model
+        ]
 
         # Construct a json representation of a AccountSettingsAssignedTemplatesSection model
         account_settings_assigned_templates_section_model_json = {}
@@ -10022,22 +10066,35 @@ class TestModel_AccountSettingsAssignedTemplatesSection:
         account_settings_assigned_templates_section_model_json['system_refresh_token_expiration_in_seconds'] = '259200'
         account_settings_assigned_templates_section_model_json['restrict_user_list_visibility'] = 'RESTRICTED'
         account_settings_assigned_templates_section_model_json['user_mfa'] = [account_settings_user_mfa_response_model]
-        account_settings_assigned_templates_section_model_json['restrict_user_domains'] = assigned_templates_account_settings_restrict_user_domains_model
+        account_settings_assigned_templates_section_model_json['restrict_user_domains'] = (
+            assigned_templates_account_settings_restrict_user_domains_model
+        )
 
         # Construct a model instance of AccountSettingsAssignedTemplatesSection by calling from_dict on the json representation
-        account_settings_assigned_templates_section_model = AccountSettingsAssignedTemplatesSection.from_dict(account_settings_assigned_templates_section_model_json)
+        account_settings_assigned_templates_section_model = AccountSettingsAssignedTemplatesSection.from_dict(
+            account_settings_assigned_templates_section_model_json
+        )
         assert account_settings_assigned_templates_section_model != False
 
         # Construct a model instance of AccountSettingsAssignedTemplatesSection by calling from_dict on the json representation
-        account_settings_assigned_templates_section_model_dict = AccountSettingsAssignedTemplatesSection.from_dict(account_settings_assigned_templates_section_model_json).__dict__
-        account_settings_assigned_templates_section_model2 = AccountSettingsAssignedTemplatesSection(**account_settings_assigned_templates_section_model_dict)
+        account_settings_assigned_templates_section_model_dict = AccountSettingsAssignedTemplatesSection.from_dict(
+            account_settings_assigned_templates_section_model_json
+        ).__dict__
+        account_settings_assigned_templates_section_model2 = AccountSettingsAssignedTemplatesSection(
+            **account_settings_assigned_templates_section_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert account_settings_assigned_templates_section_model == account_settings_assigned_templates_section_model2
 
         # Convert model instance back to dict and verify no loss of data
-        account_settings_assigned_templates_section_model_json2 = account_settings_assigned_templates_section_model.to_dict()
-        assert account_settings_assigned_templates_section_model_json2 == account_settings_assigned_templates_section_model_json
+        account_settings_assigned_templates_section_model_json2 = (
+            account_settings_assigned_templates_section_model.to_dict()
+        )
+        assert (
+            account_settings_assigned_templates_section_model_json2
+            == account_settings_assigned_templates_section_model_json
+        )
 
 
 class TestModel_AccountSettingsEffectiveSection:
@@ -10075,12 +10132,18 @@ class TestModel_AccountSettingsEffectiveSection:
         account_settings_effective_section_model_json['system_refresh_token_expiration_in_seconds'] = '259200'
 
         # Construct a model instance of AccountSettingsEffectiveSection by calling from_dict on the json representation
-        account_settings_effective_section_model = AccountSettingsEffectiveSection.from_dict(account_settings_effective_section_model_json)
+        account_settings_effective_section_model = AccountSettingsEffectiveSection.from_dict(
+            account_settings_effective_section_model_json
+        )
         assert account_settings_effective_section_model != False
 
         # Construct a model instance of AccountSettingsEffectiveSection by calling from_dict on the json representation
-        account_settings_effective_section_model_dict = AccountSettingsEffectiveSection.from_dict(account_settings_effective_section_model_json).__dict__
-        account_settings_effective_section_model2 = AccountSettingsEffectiveSection(**account_settings_effective_section_model_dict)
+        account_settings_effective_section_model_dict = AccountSettingsEffectiveSection.from_dict(
+            account_settings_effective_section_model_json
+        ).__dict__
+        account_settings_effective_section_model2 = AccountSettingsEffectiveSection(
+            **account_settings_effective_section_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert account_settings_effective_section_model == account_settings_effective_section_model2
@@ -10160,7 +10223,9 @@ class TestModel_AccountSettingsResponse:
         assert account_settings_response_model != False
 
         # Construct a model instance of AccountSettingsResponse by calling from_dict on the json representation
-        account_settings_response_model_dict = AccountSettingsResponse.from_dict(account_settings_response_model_json).__dict__
+        account_settings_response_model_dict = AccountSettingsResponse.from_dict(
+            account_settings_response_model_json
+        ).__dict__
         account_settings_response_model2 = AccountSettingsResponse(**account_settings_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -10207,7 +10272,9 @@ class TestModel_AccountSettingsTemplateList:
 
         template_account_settings_restrict_user_domains_model = {}  # TemplateAccountSettingsRestrictUserDomains
         template_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
+        template_account_settings_restrict_user_domains_model['restrictions'] = [
+            account_settings_user_domain_restriction_model
+        ]
 
         template_account_settings_model = {}  # TemplateAccountSettings
         template_account_settings_model['restrict_create_service_id'] = 'NOT_SET'
@@ -10255,14 +10322,20 @@ class TestModel_AccountSettingsTemplateList:
         account_settings_template_list_model_json['first'] = 'testString'
         account_settings_template_list_model_json['previous'] = 'testString'
         account_settings_template_list_model_json['next'] = 'testString'
-        account_settings_template_list_model_json['account_settings_templates'] = [account_settings_template_response_model]
+        account_settings_template_list_model_json['account_settings_templates'] = [
+            account_settings_template_response_model
+        ]
 
         # Construct a model instance of AccountSettingsTemplateList by calling from_dict on the json representation
-        account_settings_template_list_model = AccountSettingsTemplateList.from_dict(account_settings_template_list_model_json)
+        account_settings_template_list_model = AccountSettingsTemplateList.from_dict(
+            account_settings_template_list_model_json
+        )
         assert account_settings_template_list_model != False
 
         # Construct a model instance of AccountSettingsTemplateList by calling from_dict on the json representation
-        account_settings_template_list_model_dict = AccountSettingsTemplateList.from_dict(account_settings_template_list_model_json).__dict__
+        account_settings_template_list_model_dict = AccountSettingsTemplateList.from_dict(
+            account_settings_template_list_model_json
+        ).__dict__
         account_settings_template_list_model2 = AccountSettingsTemplateList(**account_settings_template_list_model_dict)
 
         # Verify the model instances are equivalent
@@ -10296,7 +10369,9 @@ class TestModel_AccountSettingsTemplateResponse:
 
         template_account_settings_restrict_user_domains_model = {}  # TemplateAccountSettingsRestrictUserDomains
         template_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
+        template_account_settings_restrict_user_domains_model['restrictions'] = [
+            account_settings_user_domain_restriction_model
+        ]
 
         template_account_settings_model = {}  # TemplateAccountSettings
         template_account_settings_model['restrict_create_service_id'] = 'NOT_SET'
@@ -10338,12 +10413,18 @@ class TestModel_AccountSettingsTemplateResponse:
         account_settings_template_response_model_json['last_modified_by_id'] = 'testString'
 
         # Construct a model instance of AccountSettingsTemplateResponse by calling from_dict on the json representation
-        account_settings_template_response_model = AccountSettingsTemplateResponse.from_dict(account_settings_template_response_model_json)
+        account_settings_template_response_model = AccountSettingsTemplateResponse.from_dict(
+            account_settings_template_response_model_json
+        )
         assert account_settings_template_response_model != False
 
         # Construct a model instance of AccountSettingsTemplateResponse by calling from_dict on the json representation
-        account_settings_template_response_model_dict = AccountSettingsTemplateResponse.from_dict(account_settings_template_response_model_json).__dict__
-        account_settings_template_response_model2 = AccountSettingsTemplateResponse(**account_settings_template_response_model_dict)
+        account_settings_template_response_model_dict = AccountSettingsTemplateResponse.from_dict(
+            account_settings_template_response_model_json
+        ).__dict__
+        account_settings_template_response_model2 = AccountSettingsTemplateResponse(
+            **account_settings_template_response_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert account_settings_template_response_model == account_settings_template_response_model2
@@ -10370,19 +10451,27 @@ class TestModel_AccountSettingsUserDomainRestriction:
         account_settings_user_domain_restriction_model_json['restrict_invitation'] = True
 
         # Construct a model instance of AccountSettingsUserDomainRestriction by calling from_dict on the json representation
-        account_settings_user_domain_restriction_model = AccountSettingsUserDomainRestriction.from_dict(account_settings_user_domain_restriction_model_json)
+        account_settings_user_domain_restriction_model = AccountSettingsUserDomainRestriction.from_dict(
+            account_settings_user_domain_restriction_model_json
+        )
         assert account_settings_user_domain_restriction_model != False
 
         # Construct a model instance of AccountSettingsUserDomainRestriction by calling from_dict on the json representation
-        account_settings_user_domain_restriction_model_dict = AccountSettingsUserDomainRestriction.from_dict(account_settings_user_domain_restriction_model_json).__dict__
-        account_settings_user_domain_restriction_model2 = AccountSettingsUserDomainRestriction(**account_settings_user_domain_restriction_model_dict)
+        account_settings_user_domain_restriction_model_dict = AccountSettingsUserDomainRestriction.from_dict(
+            account_settings_user_domain_restriction_model_json
+        ).__dict__
+        account_settings_user_domain_restriction_model2 = AccountSettingsUserDomainRestriction(
+            **account_settings_user_domain_restriction_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert account_settings_user_domain_restriction_model == account_settings_user_domain_restriction_model2
 
         # Convert model instance back to dict and verify no loss of data
         account_settings_user_domain_restriction_model_json2 = account_settings_user_domain_restriction_model.to_dict()
-        assert account_settings_user_domain_restriction_model_json2 == account_settings_user_domain_restriction_model_json
+        assert (
+            account_settings_user_domain_restriction_model_json2 == account_settings_user_domain_restriction_model_json
+        )
 
 
 class TestModel_AccountSettingsUserMFAResponse:
@@ -10405,12 +10494,18 @@ class TestModel_AccountSettingsUserMFAResponse:
         account_settings_user_mfa_response_model_json['description'] = 'testString'
 
         # Construct a model instance of AccountSettingsUserMFAResponse by calling from_dict on the json representation
-        account_settings_user_mfa_response_model = AccountSettingsUserMFAResponse.from_dict(account_settings_user_mfa_response_model_json)
+        account_settings_user_mfa_response_model = AccountSettingsUserMFAResponse.from_dict(
+            account_settings_user_mfa_response_model_json
+        )
         assert account_settings_user_mfa_response_model != False
 
         # Construct a model instance of AccountSettingsUserMFAResponse by calling from_dict on the json representation
-        account_settings_user_mfa_response_model_dict = AccountSettingsUserMFAResponse.from_dict(account_settings_user_mfa_response_model_json).__dict__
-        account_settings_user_mfa_response_model2 = AccountSettingsUserMFAResponse(**account_settings_user_mfa_response_model_dict)
+        account_settings_user_mfa_response_model_dict = AccountSettingsUserMFAResponse.from_dict(
+            account_settings_user_mfa_response_model_json
+        ).__dict__
+        account_settings_user_mfa_response_model2 = AccountSettingsUserMFAResponse(
+            **account_settings_user_mfa_response_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert account_settings_user_mfa_response_model == account_settings_user_mfa_response_model2
@@ -10486,7 +10581,9 @@ class TestModel_ActionControlsIdentities:
         assert action_controls_identities_model != False
 
         # Construct a model instance of ActionControlsIdentities by calling from_dict on the json representation
-        action_controls_identities_model_dict = ActionControlsIdentities.from_dict(action_controls_identities_model_json).__dict__
+        action_controls_identities_model_dict = ActionControlsIdentities.from_dict(
+            action_controls_identities_model_json
+        ).__dict__
         action_controls_identities_model2 = ActionControlsIdentities(**action_controls_identities_model_dict)
 
         # Verify the model instances are equivalent
@@ -10517,7 +10614,9 @@ class TestModel_ActionControlsPolicies:
         assert action_controls_policies_model != False
 
         # Construct a model instance of ActionControlsPolicies by calling from_dict on the json representation
-        action_controls_policies_model_dict = ActionControlsPolicies.from_dict(action_controls_policies_model_json).__dict__
+        action_controls_policies_model_dict = ActionControlsPolicies.from_dict(
+            action_controls_policies_model_json
+        ).__dict__
         action_controls_policies_model2 = ActionControlsPolicies(**action_controls_policies_model_dict)
 
         # Verify the model instances are equivalent
@@ -10685,19 +10784,27 @@ class TestModel_ApiKeyInsideCreateServiceIdRequest:
         api_key_inside_create_service_id_request_model_json['expires_at'] = 'testString'
 
         # Construct a model instance of ApiKeyInsideCreateServiceIdRequest by calling from_dict on the json representation
-        api_key_inside_create_service_id_request_model = ApiKeyInsideCreateServiceIdRequest.from_dict(api_key_inside_create_service_id_request_model_json)
+        api_key_inside_create_service_id_request_model = ApiKeyInsideCreateServiceIdRequest.from_dict(
+            api_key_inside_create_service_id_request_model_json
+        )
         assert api_key_inside_create_service_id_request_model != False
 
         # Construct a model instance of ApiKeyInsideCreateServiceIdRequest by calling from_dict on the json representation
-        api_key_inside_create_service_id_request_model_dict = ApiKeyInsideCreateServiceIdRequest.from_dict(api_key_inside_create_service_id_request_model_json).__dict__
-        api_key_inside_create_service_id_request_model2 = ApiKeyInsideCreateServiceIdRequest(**api_key_inside_create_service_id_request_model_dict)
+        api_key_inside_create_service_id_request_model_dict = ApiKeyInsideCreateServiceIdRequest.from_dict(
+            api_key_inside_create_service_id_request_model_json
+        ).__dict__
+        api_key_inside_create_service_id_request_model2 = ApiKeyInsideCreateServiceIdRequest(
+            **api_key_inside_create_service_id_request_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert api_key_inside_create_service_id_request_model == api_key_inside_create_service_id_request_model2
 
         # Convert model instance back to dict and verify no loss of data
         api_key_inside_create_service_id_request_model_json2 = api_key_inside_create_service_id_request_model.to_dict()
-        assert api_key_inside_create_service_id_request_model_json2 == api_key_inside_create_service_id_request_model_json
+        assert (
+            api_key_inside_create_service_id_request_model_json2 == api_key_inside_create_service_id_request_model_json
+        )
 
 
 class TestModel_ApiKeyList:
@@ -10851,7 +10958,9 @@ class TestModel_ApikeyActivityServiceid:
         assert apikey_activity_serviceid_model != False
 
         # Construct a model instance of ApikeyActivityServiceid by calling from_dict on the json representation
-        apikey_activity_serviceid_model_dict = ApikeyActivityServiceid.from_dict(apikey_activity_serviceid_model_json).__dict__
+        apikey_activity_serviceid_model_dict = ApikeyActivityServiceid.from_dict(
+            apikey_activity_serviceid_model_json
+        ).__dict__
         apikey_activity_serviceid_model2 = ApikeyActivityServiceid(**apikey_activity_serviceid_model_dict)
 
         # Verify the model instances are equivalent
@@ -10915,22 +11024,44 @@ class TestModel_AssignedTemplatesAccountSettingsRestrictUserDomains:
         # Construct a json representation of a AssignedTemplatesAccountSettingsRestrictUserDomains model
         assigned_templates_account_settings_restrict_user_domains_model_json = {}
         assigned_templates_account_settings_restrict_user_domains_model_json['account_sufficient'] = True
-        assigned_templates_account_settings_restrict_user_domains_model_json['restrictions'] = [account_settings_user_domain_restriction_model]
+        assigned_templates_account_settings_restrict_user_domains_model_json['restrictions'] = [
+            account_settings_user_domain_restriction_model
+        ]
 
         # Construct a model instance of AssignedTemplatesAccountSettingsRestrictUserDomains by calling from_dict on the json representation
-        assigned_templates_account_settings_restrict_user_domains_model = AssignedTemplatesAccountSettingsRestrictUserDomains.from_dict(assigned_templates_account_settings_restrict_user_domains_model_json)
+        assigned_templates_account_settings_restrict_user_domains_model = (
+            AssignedTemplatesAccountSettingsRestrictUserDomains.from_dict(
+                assigned_templates_account_settings_restrict_user_domains_model_json
+            )
+        )
         assert assigned_templates_account_settings_restrict_user_domains_model != False
 
         # Construct a model instance of AssignedTemplatesAccountSettingsRestrictUserDomains by calling from_dict on the json representation
-        assigned_templates_account_settings_restrict_user_domains_model_dict = AssignedTemplatesAccountSettingsRestrictUserDomains.from_dict(assigned_templates_account_settings_restrict_user_domains_model_json).__dict__
-        assigned_templates_account_settings_restrict_user_domains_model2 = AssignedTemplatesAccountSettingsRestrictUserDomains(**assigned_templates_account_settings_restrict_user_domains_model_dict)
+        assigned_templates_account_settings_restrict_user_domains_model_dict = (
+            AssignedTemplatesAccountSettingsRestrictUserDomains.from_dict(
+                assigned_templates_account_settings_restrict_user_domains_model_json
+            ).__dict__
+        )
+        assigned_templates_account_settings_restrict_user_domains_model2 = (
+            AssignedTemplatesAccountSettingsRestrictUserDomains(
+                **assigned_templates_account_settings_restrict_user_domains_model_dict
+            )
+        )
 
         # Verify the model instances are equivalent
-        assert assigned_templates_account_settings_restrict_user_domains_model == assigned_templates_account_settings_restrict_user_domains_model2
+        assert (
+            assigned_templates_account_settings_restrict_user_domains_model
+            == assigned_templates_account_settings_restrict_user_domains_model2
+        )
 
         # Convert model instance back to dict and verify no loss of data
-        assigned_templates_account_settings_restrict_user_domains_model_json2 = assigned_templates_account_settings_restrict_user_domains_model.to_dict()
-        assert assigned_templates_account_settings_restrict_user_domains_model_json2 == assigned_templates_account_settings_restrict_user_domains_model_json
+        assigned_templates_account_settings_restrict_user_domains_model_json2 = (
+            assigned_templates_account_settings_restrict_user_domains_model.to_dict()
+        )
+        assert (
+            assigned_templates_account_settings_restrict_user_domains_model_json2
+            == assigned_templates_account_settings_restrict_user_domains_model_json
+        )
 
 
 class TestModel_CreateProfileLinkRequestLink:
@@ -10952,12 +11083,18 @@ class TestModel_CreateProfileLinkRequestLink:
         create_profile_link_request_link_model_json['component_name'] = 'testString'
 
         # Construct a model instance of CreateProfileLinkRequestLink by calling from_dict on the json representation
-        create_profile_link_request_link_model = CreateProfileLinkRequestLink.from_dict(create_profile_link_request_link_model_json)
+        create_profile_link_request_link_model = CreateProfileLinkRequestLink.from_dict(
+            create_profile_link_request_link_model_json
+        )
         assert create_profile_link_request_link_model != False
 
         # Construct a model instance of CreateProfileLinkRequestLink by calling from_dict on the json representation
-        create_profile_link_request_link_model_dict = CreateProfileLinkRequestLink.from_dict(create_profile_link_request_link_model_json).__dict__
-        create_profile_link_request_link_model2 = CreateProfileLinkRequestLink(**create_profile_link_request_link_model_dict)
+        create_profile_link_request_link_model_dict = CreateProfileLinkRequestLink.from_dict(
+            create_profile_link_request_link_model_json
+        ).__dict__
+        create_profile_link_request_link_model2 = CreateProfileLinkRequestLink(
+            **create_profile_link_request_link_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert create_profile_link_request_link_model == create_profile_link_request_link_model2
@@ -11044,9 +11181,13 @@ class TestModel_EffectiveAccountSettingsResponse:
         account_settings_response_model['user_mfa'] = [account_settings_user_mfa_response_model]
         account_settings_response_model['restrict_user_domains'] = [account_settings_user_domain_restriction_model]
 
-        assigned_templates_account_settings_restrict_user_domains_model = {}  # AssignedTemplatesAccountSettingsRestrictUserDomains
+        assigned_templates_account_settings_restrict_user_domains_model = (
+            {}
+        )  # AssignedTemplatesAccountSettingsRestrictUserDomains
         assigned_templates_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        assigned_templates_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
+        assigned_templates_account_settings_restrict_user_domains_model['restrictions'] = [
+            account_settings_user_domain_restriction_model
+        ]
 
         account_settings_assigned_templates_section_model = {}  # AccountSettingsAssignedTemplatesSection
         account_settings_assigned_templates_section_model['template_id'] = 'testString'
@@ -11063,7 +11204,9 @@ class TestModel_EffectiveAccountSettingsResponse:
         account_settings_assigned_templates_section_model['system_refresh_token_expiration_in_seconds'] = '259200'
         account_settings_assigned_templates_section_model['restrict_user_list_visibility'] = 'RESTRICTED'
         account_settings_assigned_templates_section_model['user_mfa'] = [account_settings_user_mfa_response_model]
-        account_settings_assigned_templates_section_model['restrict_user_domains'] = assigned_templates_account_settings_restrict_user_domains_model
+        account_settings_assigned_templates_section_model['restrict_user_domains'] = (
+            assigned_templates_account_settings_restrict_user_domains_model
+        )
 
         # Construct a json representation of a EffectiveAccountSettingsResponse model
         effective_account_settings_response_model_json = {}
@@ -11071,15 +11214,23 @@ class TestModel_EffectiveAccountSettingsResponse:
         effective_account_settings_response_model_json['account_id'] = 'testString'
         effective_account_settings_response_model_json['effective'] = account_settings_effective_section_model
         effective_account_settings_response_model_json['account'] = account_settings_response_model
-        effective_account_settings_response_model_json['assigned_templates'] = [account_settings_assigned_templates_section_model]
+        effective_account_settings_response_model_json['assigned_templates'] = [
+            account_settings_assigned_templates_section_model
+        ]
 
         # Construct a model instance of EffectiveAccountSettingsResponse by calling from_dict on the json representation
-        effective_account_settings_response_model = EffectiveAccountSettingsResponse.from_dict(effective_account_settings_response_model_json)
+        effective_account_settings_response_model = EffectiveAccountSettingsResponse.from_dict(
+            effective_account_settings_response_model_json
+        )
         assert effective_account_settings_response_model != False
 
         # Construct a model instance of EffectiveAccountSettingsResponse by calling from_dict on the json representation
-        effective_account_settings_response_model_dict = EffectiveAccountSettingsResponse.from_dict(effective_account_settings_response_model_json).__dict__
-        effective_account_settings_response_model2 = EffectiveAccountSettingsResponse(**effective_account_settings_response_model_dict)
+        effective_account_settings_response_model_dict = EffectiveAccountSettingsResponse.from_dict(
+            effective_account_settings_response_model_json
+        ).__dict__
+        effective_account_settings_response_model2 = EffectiveAccountSettingsResponse(
+            **effective_account_settings_response_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert effective_account_settings_response_model == effective_account_settings_response_model2
@@ -11344,7 +11495,9 @@ class TestModel_IdentityLimitsUsageResponse:
         template_count_model['template_id'] = 'testString'
         template_count_model['count'] = 38
 
-        identity_limits_usage_response_template_versions_per_template_model = {}  # IdentityLimitsUsageResponseTemplateVersionsPerTemplate
+        identity_limits_usage_response_template_versions_per_template_model = (
+            {}
+        )  # IdentityLimitsUsageResponseTemplateVersionsPerTemplate
         identity_limits_usage_response_template_versions_per_template_model['limit'] = 38
         identity_limits_usage_response_template_versions_per_template_model['templates'] = [template_count_model]
 
@@ -11360,7 +11513,9 @@ class TestModel_IdentityLimitsUsageResponse:
         profile_count_model['profile_id'] = 'testString'
         profile_count_model['count'] = 38
 
-        identity_limits_usage_response_claim_rules_per_profile_model = {}  # IdentityLimitsUsageResponseClaimRulesPerProfile
+        identity_limits_usage_response_claim_rules_per_profile_model = (
+            {}
+        )  # IdentityLimitsUsageResponseClaimRulesPerProfile
         identity_limits_usage_response_claim_rules_per_profile_model['limit'] = 38
         identity_limits_usage_response_claim_rules_per_profile_model['profiles'] = [profile_count_model]
 
@@ -11375,26 +11530,44 @@ class TestModel_IdentityLimitsUsageResponse:
         # Construct a json representation of a IdentityLimitsUsageResponse model
         identity_limits_usage_response_model_json = {}
         identity_limits_usage_response_model_json['serviceid_groups'] = limit_count_model
-        identity_limits_usage_response_model_json['serviceids_per_group'] = identity_limits_usage_response_serviceids_per_group_model
+        identity_limits_usage_response_model_json['serviceids_per_group'] = (
+            identity_limits_usage_response_serviceids_per_group_model
+        )
         identity_limits_usage_response_model_json['profiles'] = limit_count_model
-        identity_limits_usage_response_model_json['apikeys_per_identity'] = identity_limits_usage_response_apikeys_per_identity_model
+        identity_limits_usage_response_model_json['apikeys_per_identity'] = (
+            identity_limits_usage_response_apikeys_per_identity_model
+        )
         identity_limits_usage_response_model_json['profile_templates'] = limit_count_model
         identity_limits_usage_response_model_json['account_settings_templates'] = limit_count_model
-        identity_limits_usage_response_model_json['template_versions_per_template'] = identity_limits_usage_response_template_versions_per_template_model
+        identity_limits_usage_response_model_json['template_versions_per_template'] = (
+            identity_limits_usage_response_template_versions_per_template_model
+        )
         identity_limits_usage_response_model_json['idps'] = limit_count_model
-        identity_limits_usage_response_model_json['claim_rules_per_group'] = identity_limits_usage_response_claim_rules_per_group_model
-        identity_limits_usage_response_model_json['claim_rules_per_profile'] = identity_limits_usage_response_claim_rules_per_profile_model
+        identity_limits_usage_response_model_json['claim_rules_per_group'] = (
+            identity_limits_usage_response_claim_rules_per_group_model
+        )
+        identity_limits_usage_response_model_json['claim_rules_per_profile'] = (
+            identity_limits_usage_response_claim_rules_per_profile_model
+        )
         identity_limits_usage_response_model_json['cr_links'] = limit_count_model
-        identity_limits_usage_response_model_json['cr_links_per_profile'] = identity_limits_usage_response_cr_links_per_profile_model
+        identity_limits_usage_response_model_json['cr_links_per_profile'] = (
+            identity_limits_usage_response_cr_links_per_profile_model
+        )
         identity_limits_usage_response_model_json['cr_rules'] = limit_count_model
-        identity_limits_usage_response_model_json['cr_rules_per_profile'] = identity_limits_usage_response_cr_rules_per_profile_model
+        identity_limits_usage_response_model_json['cr_rules_per_profile'] = (
+            identity_limits_usage_response_cr_rules_per_profile_model
+        )
 
         # Construct a model instance of IdentityLimitsUsageResponse by calling from_dict on the json representation
-        identity_limits_usage_response_model = IdentityLimitsUsageResponse.from_dict(identity_limits_usage_response_model_json)
+        identity_limits_usage_response_model = IdentityLimitsUsageResponse.from_dict(
+            identity_limits_usage_response_model_json
+        )
         assert identity_limits_usage_response_model != False
 
         # Construct a model instance of IdentityLimitsUsageResponse by calling from_dict on the json representation
-        identity_limits_usage_response_model_dict = IdentityLimitsUsageResponse.from_dict(identity_limits_usage_response_model_json).__dict__
+        identity_limits_usage_response_model_dict = IdentityLimitsUsageResponse.from_dict(
+            identity_limits_usage_response_model_json
+        ).__dict__
         identity_limits_usage_response_model2 = IdentityLimitsUsageResponse(**identity_limits_usage_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -11427,19 +11600,37 @@ class TestModel_IdentityLimitsUsageResponseApikeysPerIdentity:
         identity_limits_usage_response_apikeys_per_identity_model_json['identities'] = [identity_count_model]
 
         # Construct a model instance of IdentityLimitsUsageResponseApikeysPerIdentity by calling from_dict on the json representation
-        identity_limits_usage_response_apikeys_per_identity_model = IdentityLimitsUsageResponseApikeysPerIdentity.from_dict(identity_limits_usage_response_apikeys_per_identity_model_json)
+        identity_limits_usage_response_apikeys_per_identity_model = (
+            IdentityLimitsUsageResponseApikeysPerIdentity.from_dict(
+                identity_limits_usage_response_apikeys_per_identity_model_json
+            )
+        )
         assert identity_limits_usage_response_apikeys_per_identity_model != False
 
         # Construct a model instance of IdentityLimitsUsageResponseApikeysPerIdentity by calling from_dict on the json representation
-        identity_limits_usage_response_apikeys_per_identity_model_dict = IdentityLimitsUsageResponseApikeysPerIdentity.from_dict(identity_limits_usage_response_apikeys_per_identity_model_json).__dict__
-        identity_limits_usage_response_apikeys_per_identity_model2 = IdentityLimitsUsageResponseApikeysPerIdentity(**identity_limits_usage_response_apikeys_per_identity_model_dict)
+        identity_limits_usage_response_apikeys_per_identity_model_dict = (
+            IdentityLimitsUsageResponseApikeysPerIdentity.from_dict(
+                identity_limits_usage_response_apikeys_per_identity_model_json
+            ).__dict__
+        )
+        identity_limits_usage_response_apikeys_per_identity_model2 = IdentityLimitsUsageResponseApikeysPerIdentity(
+            **identity_limits_usage_response_apikeys_per_identity_model_dict
+        )
 
         # Verify the model instances are equivalent
-        assert identity_limits_usage_response_apikeys_per_identity_model == identity_limits_usage_response_apikeys_per_identity_model2
+        assert (
+            identity_limits_usage_response_apikeys_per_identity_model
+            == identity_limits_usage_response_apikeys_per_identity_model2
+        )
 
         # Convert model instance back to dict and verify no loss of data
-        identity_limits_usage_response_apikeys_per_identity_model_json2 = identity_limits_usage_response_apikeys_per_identity_model.to_dict()
-        assert identity_limits_usage_response_apikeys_per_identity_model_json2 == identity_limits_usage_response_apikeys_per_identity_model_json
+        identity_limits_usage_response_apikeys_per_identity_model_json2 = (
+            identity_limits_usage_response_apikeys_per_identity_model.to_dict()
+        )
+        assert (
+            identity_limits_usage_response_apikeys_per_identity_model_json2
+            == identity_limits_usage_response_apikeys_per_identity_model_json
+        )
 
 
 class TestModel_IdentityLimitsUsageResponseClaimRulesPerGroup:
@@ -11464,19 +11655,37 @@ class TestModel_IdentityLimitsUsageResponseClaimRulesPerGroup:
         identity_limits_usage_response_claim_rules_per_group_model_json['access_groups'] = [access_group_count_model]
 
         # Construct a model instance of IdentityLimitsUsageResponseClaimRulesPerGroup by calling from_dict on the json representation
-        identity_limits_usage_response_claim_rules_per_group_model = IdentityLimitsUsageResponseClaimRulesPerGroup.from_dict(identity_limits_usage_response_claim_rules_per_group_model_json)
+        identity_limits_usage_response_claim_rules_per_group_model = (
+            IdentityLimitsUsageResponseClaimRulesPerGroup.from_dict(
+                identity_limits_usage_response_claim_rules_per_group_model_json
+            )
+        )
         assert identity_limits_usage_response_claim_rules_per_group_model != False
 
         # Construct a model instance of IdentityLimitsUsageResponseClaimRulesPerGroup by calling from_dict on the json representation
-        identity_limits_usage_response_claim_rules_per_group_model_dict = IdentityLimitsUsageResponseClaimRulesPerGroup.from_dict(identity_limits_usage_response_claim_rules_per_group_model_json).__dict__
-        identity_limits_usage_response_claim_rules_per_group_model2 = IdentityLimitsUsageResponseClaimRulesPerGroup(**identity_limits_usage_response_claim_rules_per_group_model_dict)
+        identity_limits_usage_response_claim_rules_per_group_model_dict = (
+            IdentityLimitsUsageResponseClaimRulesPerGroup.from_dict(
+                identity_limits_usage_response_claim_rules_per_group_model_json
+            ).__dict__
+        )
+        identity_limits_usage_response_claim_rules_per_group_model2 = IdentityLimitsUsageResponseClaimRulesPerGroup(
+            **identity_limits_usage_response_claim_rules_per_group_model_dict
+        )
 
         # Verify the model instances are equivalent
-        assert identity_limits_usage_response_claim_rules_per_group_model == identity_limits_usage_response_claim_rules_per_group_model2
+        assert (
+            identity_limits_usage_response_claim_rules_per_group_model
+            == identity_limits_usage_response_claim_rules_per_group_model2
+        )
 
         # Convert model instance back to dict and verify no loss of data
-        identity_limits_usage_response_claim_rules_per_group_model_json2 = identity_limits_usage_response_claim_rules_per_group_model.to_dict()
-        assert identity_limits_usage_response_claim_rules_per_group_model_json2 == identity_limits_usage_response_claim_rules_per_group_model_json
+        identity_limits_usage_response_claim_rules_per_group_model_json2 = (
+            identity_limits_usage_response_claim_rules_per_group_model.to_dict()
+        )
+        assert (
+            identity_limits_usage_response_claim_rules_per_group_model_json2
+            == identity_limits_usage_response_claim_rules_per_group_model_json
+        )
 
 
 class TestModel_IdentityLimitsUsageResponseClaimRulesPerProfile:
@@ -11501,19 +11710,37 @@ class TestModel_IdentityLimitsUsageResponseClaimRulesPerProfile:
         identity_limits_usage_response_claim_rules_per_profile_model_json['profiles'] = [profile_count_model]
 
         # Construct a model instance of IdentityLimitsUsageResponseClaimRulesPerProfile by calling from_dict on the json representation
-        identity_limits_usage_response_claim_rules_per_profile_model = IdentityLimitsUsageResponseClaimRulesPerProfile.from_dict(identity_limits_usage_response_claim_rules_per_profile_model_json)
+        identity_limits_usage_response_claim_rules_per_profile_model = (
+            IdentityLimitsUsageResponseClaimRulesPerProfile.from_dict(
+                identity_limits_usage_response_claim_rules_per_profile_model_json
+            )
+        )
         assert identity_limits_usage_response_claim_rules_per_profile_model != False
 
         # Construct a model instance of IdentityLimitsUsageResponseClaimRulesPerProfile by calling from_dict on the json representation
-        identity_limits_usage_response_claim_rules_per_profile_model_dict = IdentityLimitsUsageResponseClaimRulesPerProfile.from_dict(identity_limits_usage_response_claim_rules_per_profile_model_json).__dict__
-        identity_limits_usage_response_claim_rules_per_profile_model2 = IdentityLimitsUsageResponseClaimRulesPerProfile(**identity_limits_usage_response_claim_rules_per_profile_model_dict)
+        identity_limits_usage_response_claim_rules_per_profile_model_dict = (
+            IdentityLimitsUsageResponseClaimRulesPerProfile.from_dict(
+                identity_limits_usage_response_claim_rules_per_profile_model_json
+            ).__dict__
+        )
+        identity_limits_usage_response_claim_rules_per_profile_model2 = IdentityLimitsUsageResponseClaimRulesPerProfile(
+            **identity_limits_usage_response_claim_rules_per_profile_model_dict
+        )
 
         # Verify the model instances are equivalent
-        assert identity_limits_usage_response_claim_rules_per_profile_model == identity_limits_usage_response_claim_rules_per_profile_model2
+        assert (
+            identity_limits_usage_response_claim_rules_per_profile_model
+            == identity_limits_usage_response_claim_rules_per_profile_model2
+        )
 
         # Convert model instance back to dict and verify no loss of data
-        identity_limits_usage_response_claim_rules_per_profile_model_json2 = identity_limits_usage_response_claim_rules_per_profile_model.to_dict()
-        assert identity_limits_usage_response_claim_rules_per_profile_model_json2 == identity_limits_usage_response_claim_rules_per_profile_model_json
+        identity_limits_usage_response_claim_rules_per_profile_model_json2 = (
+            identity_limits_usage_response_claim_rules_per_profile_model.to_dict()
+        )
+        assert (
+            identity_limits_usage_response_claim_rules_per_profile_model_json2
+            == identity_limits_usage_response_claim_rules_per_profile_model_json
+        )
 
 
 class TestModel_IdentityLimitsUsageResponseCrLinksPerProfile:
@@ -11538,19 +11765,37 @@ class TestModel_IdentityLimitsUsageResponseCrLinksPerProfile:
         identity_limits_usage_response_cr_links_per_profile_model_json['profiles'] = [profile_count_model]
 
         # Construct a model instance of IdentityLimitsUsageResponseCrLinksPerProfile by calling from_dict on the json representation
-        identity_limits_usage_response_cr_links_per_profile_model = IdentityLimitsUsageResponseCrLinksPerProfile.from_dict(identity_limits_usage_response_cr_links_per_profile_model_json)
+        identity_limits_usage_response_cr_links_per_profile_model = (
+            IdentityLimitsUsageResponseCrLinksPerProfile.from_dict(
+                identity_limits_usage_response_cr_links_per_profile_model_json
+            )
+        )
         assert identity_limits_usage_response_cr_links_per_profile_model != False
 
         # Construct a model instance of IdentityLimitsUsageResponseCrLinksPerProfile by calling from_dict on the json representation
-        identity_limits_usage_response_cr_links_per_profile_model_dict = IdentityLimitsUsageResponseCrLinksPerProfile.from_dict(identity_limits_usage_response_cr_links_per_profile_model_json).__dict__
-        identity_limits_usage_response_cr_links_per_profile_model2 = IdentityLimitsUsageResponseCrLinksPerProfile(**identity_limits_usage_response_cr_links_per_profile_model_dict)
+        identity_limits_usage_response_cr_links_per_profile_model_dict = (
+            IdentityLimitsUsageResponseCrLinksPerProfile.from_dict(
+                identity_limits_usage_response_cr_links_per_profile_model_json
+            ).__dict__
+        )
+        identity_limits_usage_response_cr_links_per_profile_model2 = IdentityLimitsUsageResponseCrLinksPerProfile(
+            **identity_limits_usage_response_cr_links_per_profile_model_dict
+        )
 
         # Verify the model instances are equivalent
-        assert identity_limits_usage_response_cr_links_per_profile_model == identity_limits_usage_response_cr_links_per_profile_model2
+        assert (
+            identity_limits_usage_response_cr_links_per_profile_model
+            == identity_limits_usage_response_cr_links_per_profile_model2
+        )
 
         # Convert model instance back to dict and verify no loss of data
-        identity_limits_usage_response_cr_links_per_profile_model_json2 = identity_limits_usage_response_cr_links_per_profile_model.to_dict()
-        assert identity_limits_usage_response_cr_links_per_profile_model_json2 == identity_limits_usage_response_cr_links_per_profile_model_json
+        identity_limits_usage_response_cr_links_per_profile_model_json2 = (
+            identity_limits_usage_response_cr_links_per_profile_model.to_dict()
+        )
+        assert (
+            identity_limits_usage_response_cr_links_per_profile_model_json2
+            == identity_limits_usage_response_cr_links_per_profile_model_json
+        )
 
 
 class TestModel_IdentityLimitsUsageResponseCrRulesPerProfile:
@@ -11575,19 +11820,37 @@ class TestModel_IdentityLimitsUsageResponseCrRulesPerProfile:
         identity_limits_usage_response_cr_rules_per_profile_model_json['profiles'] = [profile_count_model]
 
         # Construct a model instance of IdentityLimitsUsageResponseCrRulesPerProfile by calling from_dict on the json representation
-        identity_limits_usage_response_cr_rules_per_profile_model = IdentityLimitsUsageResponseCrRulesPerProfile.from_dict(identity_limits_usage_response_cr_rules_per_profile_model_json)
+        identity_limits_usage_response_cr_rules_per_profile_model = (
+            IdentityLimitsUsageResponseCrRulesPerProfile.from_dict(
+                identity_limits_usage_response_cr_rules_per_profile_model_json
+            )
+        )
         assert identity_limits_usage_response_cr_rules_per_profile_model != False
 
         # Construct a model instance of IdentityLimitsUsageResponseCrRulesPerProfile by calling from_dict on the json representation
-        identity_limits_usage_response_cr_rules_per_profile_model_dict = IdentityLimitsUsageResponseCrRulesPerProfile.from_dict(identity_limits_usage_response_cr_rules_per_profile_model_json).__dict__
-        identity_limits_usage_response_cr_rules_per_profile_model2 = IdentityLimitsUsageResponseCrRulesPerProfile(**identity_limits_usage_response_cr_rules_per_profile_model_dict)
+        identity_limits_usage_response_cr_rules_per_profile_model_dict = (
+            IdentityLimitsUsageResponseCrRulesPerProfile.from_dict(
+                identity_limits_usage_response_cr_rules_per_profile_model_json
+            ).__dict__
+        )
+        identity_limits_usage_response_cr_rules_per_profile_model2 = IdentityLimitsUsageResponseCrRulesPerProfile(
+            **identity_limits_usage_response_cr_rules_per_profile_model_dict
+        )
 
         # Verify the model instances are equivalent
-        assert identity_limits_usage_response_cr_rules_per_profile_model == identity_limits_usage_response_cr_rules_per_profile_model2
+        assert (
+            identity_limits_usage_response_cr_rules_per_profile_model
+            == identity_limits_usage_response_cr_rules_per_profile_model2
+        )
 
         # Convert model instance back to dict and verify no loss of data
-        identity_limits_usage_response_cr_rules_per_profile_model_json2 = identity_limits_usage_response_cr_rules_per_profile_model.to_dict()
-        assert identity_limits_usage_response_cr_rules_per_profile_model_json2 == identity_limits_usage_response_cr_rules_per_profile_model_json
+        identity_limits_usage_response_cr_rules_per_profile_model_json2 = (
+            identity_limits_usage_response_cr_rules_per_profile_model.to_dict()
+        )
+        assert (
+            identity_limits_usage_response_cr_rules_per_profile_model_json2
+            == identity_limits_usage_response_cr_rules_per_profile_model_json
+        )
 
 
 class TestModel_IdentityLimitsUsageResponseServiceidsPerGroup:
@@ -11609,22 +11872,42 @@ class TestModel_IdentityLimitsUsageResponseServiceidsPerGroup:
         # Construct a json representation of a IdentityLimitsUsageResponseServiceidsPerGroup model
         identity_limits_usage_response_serviceids_per_group_model_json = {}
         identity_limits_usage_response_serviceids_per_group_model_json['limit'] = 38
-        identity_limits_usage_response_serviceids_per_group_model_json['serviceid_groups'] = [service_id_group_count_model]
+        identity_limits_usage_response_serviceids_per_group_model_json['serviceid_groups'] = [
+            service_id_group_count_model
+        ]
 
         # Construct a model instance of IdentityLimitsUsageResponseServiceidsPerGroup by calling from_dict on the json representation
-        identity_limits_usage_response_serviceids_per_group_model = IdentityLimitsUsageResponseServiceidsPerGroup.from_dict(identity_limits_usage_response_serviceids_per_group_model_json)
+        identity_limits_usage_response_serviceids_per_group_model = (
+            IdentityLimitsUsageResponseServiceidsPerGroup.from_dict(
+                identity_limits_usage_response_serviceids_per_group_model_json
+            )
+        )
         assert identity_limits_usage_response_serviceids_per_group_model != False
 
         # Construct a model instance of IdentityLimitsUsageResponseServiceidsPerGroup by calling from_dict on the json representation
-        identity_limits_usage_response_serviceids_per_group_model_dict = IdentityLimitsUsageResponseServiceidsPerGroup.from_dict(identity_limits_usage_response_serviceids_per_group_model_json).__dict__
-        identity_limits_usage_response_serviceids_per_group_model2 = IdentityLimitsUsageResponseServiceidsPerGroup(**identity_limits_usage_response_serviceids_per_group_model_dict)
+        identity_limits_usage_response_serviceids_per_group_model_dict = (
+            IdentityLimitsUsageResponseServiceidsPerGroup.from_dict(
+                identity_limits_usage_response_serviceids_per_group_model_json
+            ).__dict__
+        )
+        identity_limits_usage_response_serviceids_per_group_model2 = IdentityLimitsUsageResponseServiceidsPerGroup(
+            **identity_limits_usage_response_serviceids_per_group_model_dict
+        )
 
         # Verify the model instances are equivalent
-        assert identity_limits_usage_response_serviceids_per_group_model == identity_limits_usage_response_serviceids_per_group_model2
+        assert (
+            identity_limits_usage_response_serviceids_per_group_model
+            == identity_limits_usage_response_serviceids_per_group_model2
+        )
 
         # Convert model instance back to dict and verify no loss of data
-        identity_limits_usage_response_serviceids_per_group_model_json2 = identity_limits_usage_response_serviceids_per_group_model.to_dict()
-        assert identity_limits_usage_response_serviceids_per_group_model_json2 == identity_limits_usage_response_serviceids_per_group_model_json
+        identity_limits_usage_response_serviceids_per_group_model_json2 = (
+            identity_limits_usage_response_serviceids_per_group_model.to_dict()
+        )
+        assert (
+            identity_limits_usage_response_serviceids_per_group_model_json2
+            == identity_limits_usage_response_serviceids_per_group_model_json
+        )
 
 
 class TestModel_IdentityLimitsUsageResponseTemplateVersionsPerTemplate:
@@ -11649,19 +11932,39 @@ class TestModel_IdentityLimitsUsageResponseTemplateVersionsPerTemplate:
         identity_limits_usage_response_template_versions_per_template_model_json['templates'] = [template_count_model]
 
         # Construct a model instance of IdentityLimitsUsageResponseTemplateVersionsPerTemplate by calling from_dict on the json representation
-        identity_limits_usage_response_template_versions_per_template_model = IdentityLimitsUsageResponseTemplateVersionsPerTemplate.from_dict(identity_limits_usage_response_template_versions_per_template_model_json)
+        identity_limits_usage_response_template_versions_per_template_model = (
+            IdentityLimitsUsageResponseTemplateVersionsPerTemplate.from_dict(
+                identity_limits_usage_response_template_versions_per_template_model_json
+            )
+        )
         assert identity_limits_usage_response_template_versions_per_template_model != False
 
         # Construct a model instance of IdentityLimitsUsageResponseTemplateVersionsPerTemplate by calling from_dict on the json representation
-        identity_limits_usage_response_template_versions_per_template_model_dict = IdentityLimitsUsageResponseTemplateVersionsPerTemplate.from_dict(identity_limits_usage_response_template_versions_per_template_model_json).__dict__
-        identity_limits_usage_response_template_versions_per_template_model2 = IdentityLimitsUsageResponseTemplateVersionsPerTemplate(**identity_limits_usage_response_template_versions_per_template_model_dict)
+        identity_limits_usage_response_template_versions_per_template_model_dict = (
+            IdentityLimitsUsageResponseTemplateVersionsPerTemplate.from_dict(
+                identity_limits_usage_response_template_versions_per_template_model_json
+            ).__dict__
+        )
+        identity_limits_usage_response_template_versions_per_template_model2 = (
+            IdentityLimitsUsageResponseTemplateVersionsPerTemplate(
+                **identity_limits_usage_response_template_versions_per_template_model_dict
+            )
+        )
 
         # Verify the model instances are equivalent
-        assert identity_limits_usage_response_template_versions_per_template_model == identity_limits_usage_response_template_versions_per_template_model2
+        assert (
+            identity_limits_usage_response_template_versions_per_template_model
+            == identity_limits_usage_response_template_versions_per_template_model2
+        )
 
         # Convert model instance back to dict and verify no loss of data
-        identity_limits_usage_response_template_versions_per_template_model_json2 = identity_limits_usage_response_template_versions_per_template_model.to_dict()
-        assert identity_limits_usage_response_template_versions_per_template_model_json2 == identity_limits_usage_response_template_versions_per_template_model_json
+        identity_limits_usage_response_template_versions_per_template_model_json2 = (
+            identity_limits_usage_response_template_versions_per_template_model.to_dict()
+        )
+        assert (
+            identity_limits_usage_response_template_versions_per_template_model_json2
+            == identity_limits_usage_response_template_versions_per_template_model_json
+        )
 
 
 class TestModel_IdentityPreferenceResponse:
@@ -11684,11 +11987,15 @@ class TestModel_IdentityPreferenceResponse:
         identity_preference_response_model_json['value_list_of_strings'] = ['testString']
 
         # Construct a model instance of IdentityPreferenceResponse by calling from_dict on the json representation
-        identity_preference_response_model = IdentityPreferenceResponse.from_dict(identity_preference_response_model_json)
+        identity_preference_response_model = IdentityPreferenceResponse.from_dict(
+            identity_preference_response_model_json
+        )
         assert identity_preference_response_model != False
 
         # Construct a model instance of IdentityPreferenceResponse by calling from_dict on the json representation
-        identity_preference_response_model_dict = IdentityPreferenceResponse.from_dict(identity_preference_response_model_json).__dict__
+        identity_preference_response_model_dict = IdentityPreferenceResponse.from_dict(
+            identity_preference_response_model_json
+        ).__dict__
         identity_preference_response_model2 = IdentityPreferenceResponse(**identity_preference_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -11724,11 +12031,15 @@ class TestModel_IdentityPreferencesResponse:
         identity_preferences_response_model_json['preferences'] = [identity_preference_response_model]
 
         # Construct a model instance of IdentityPreferencesResponse by calling from_dict on the json representation
-        identity_preferences_response_model = IdentityPreferencesResponse.from_dict(identity_preferences_response_model_json)
+        identity_preferences_response_model = IdentityPreferencesResponse.from_dict(
+            identity_preferences_response_model_json
+        )
         assert identity_preferences_response_model != False
 
         # Construct a model instance of IdentityPreferencesResponse by calling from_dict on the json representation
-        identity_preferences_response_model_dict = IdentityPreferencesResponse.from_dict(identity_preferences_response_model_json).__dict__
+        identity_preferences_response_model_dict = IdentityPreferencesResponse.from_dict(
+            identity_preferences_response_model_json
+        ).__dict__
         identity_preferences_response_model2 = IdentityPreferencesResponse(**identity_preferences_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -11790,7 +12101,9 @@ class TestModel_MfaEnrollmentTypeStatus:
         assert mfa_enrollment_type_status_model != False
 
         # Construct a model instance of MfaEnrollmentTypeStatus by calling from_dict on the json representation
-        mfa_enrollment_type_status_model_dict = MfaEnrollmentTypeStatus.from_dict(mfa_enrollment_type_status_model_json).__dict__
+        mfa_enrollment_type_status_model_dict = MfaEnrollmentTypeStatus.from_dict(
+            mfa_enrollment_type_status_model_json
+        ).__dict__
         mfa_enrollment_type_status_model2 = MfaEnrollmentTypeStatus(**mfa_enrollment_type_status_model_dict)
 
         # Verify the model instances are equivalent
@@ -11821,7 +12134,9 @@ class TestModel_PolicyTemplateReference:
         assert policy_template_reference_model != False
 
         # Construct a model instance of PolicyTemplateReference by calling from_dict on the json representation
-        policy_template_reference_model_dict = PolicyTemplateReference.from_dict(policy_template_reference_model_json).__dict__
+        policy_template_reference_model_dict = PolicyTemplateReference.from_dict(
+            policy_template_reference_model_json
+        ).__dict__
         policy_template_reference_model2 = PolicyTemplateReference(**policy_template_reference_model_dict)
 
         # Verify the model instances are equivalent
@@ -11895,11 +12210,15 @@ class TestModel_ProfileClaimRuleConditions:
         profile_claim_rule_conditions_model_json['value'] = 'testString'
 
         # Construct a model instance of ProfileClaimRuleConditions by calling from_dict on the json representation
-        profile_claim_rule_conditions_model = ProfileClaimRuleConditions.from_dict(profile_claim_rule_conditions_model_json)
+        profile_claim_rule_conditions_model = ProfileClaimRuleConditions.from_dict(
+            profile_claim_rule_conditions_model_json
+        )
         assert profile_claim_rule_conditions_model != False
 
         # Construct a model instance of ProfileClaimRuleConditions by calling from_dict on the json representation
-        profile_claim_rule_conditions_model_dict = ProfileClaimRuleConditions.from_dict(profile_claim_rule_conditions_model_json).__dict__
+        profile_claim_rule_conditions_model_dict = ProfileClaimRuleConditions.from_dict(
+            profile_claim_rule_conditions_model_json
+        ).__dict__
         profile_claim_rule_conditions_model2 = ProfileClaimRuleConditions(**profile_claim_rule_conditions_model_dict)
 
         # Verify the model instances are equivalent
@@ -12033,7 +12352,9 @@ class TestModel_ProfileIdentitiesResponse:
         assert profile_identities_response_model != False
 
         # Construct a model instance of ProfileIdentitiesResponse by calling from_dict on the json representation
-        profile_identities_response_model_dict = ProfileIdentitiesResponse.from_dict(profile_identities_response_model_json).__dict__
+        profile_identities_response_model_dict = ProfileIdentitiesResponse.from_dict(
+            profile_identities_response_model_json
+        ).__dict__
         profile_identities_response_model2 = ProfileIdentitiesResponse(**profile_identities_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -12066,7 +12387,9 @@ class TestModel_ProfileIdentityRequest:
         assert profile_identity_request_model != False
 
         # Construct a model instance of ProfileIdentityRequest by calling from_dict on the json representation
-        profile_identity_request_model_dict = ProfileIdentityRequest.from_dict(profile_identity_request_model_json).__dict__
+        profile_identity_request_model_dict = ProfileIdentityRequest.from_dict(
+            profile_identity_request_model_json
+        ).__dict__
         profile_identity_request_model2 = ProfileIdentityRequest(**profile_identity_request_model_dict)
 
         # Verify the model instances are equivalent
@@ -12100,7 +12423,9 @@ class TestModel_ProfileIdentityResponse:
         assert profile_identity_response_model != False
 
         # Construct a model instance of ProfileIdentityResponse by calling from_dict on the json representation
-        profile_identity_response_model_dict = ProfileIdentityResponse.from_dict(profile_identity_response_model_json).__dict__
+        profile_identity_response_model_dict = ProfileIdentityResponse.from_dict(
+            profile_identity_response_model_json
+        ).__dict__
         profile_identity_response_model2 = ProfileIdentityResponse(**profile_identity_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -12358,11 +12683,15 @@ class TestModel_ReportMfaEnrollmentStatus:
         report_mfa_enrollment_status_model_json['users'] = [user_report_mfa_enrollment_status_model]
 
         # Construct a model instance of ReportMfaEnrollmentStatus by calling from_dict on the json representation
-        report_mfa_enrollment_status_model = ReportMfaEnrollmentStatus.from_dict(report_mfa_enrollment_status_model_json)
+        report_mfa_enrollment_status_model = ReportMfaEnrollmentStatus.from_dict(
+            report_mfa_enrollment_status_model_json
+        )
         assert report_mfa_enrollment_status_model != False
 
         # Construct a model instance of ReportMfaEnrollmentStatus by calling from_dict on the json representation
-        report_mfa_enrollment_status_model_dict = ReportMfaEnrollmentStatus.from_dict(report_mfa_enrollment_status_model_json).__dict__
+        report_mfa_enrollment_status_model_dict = ReportMfaEnrollmentStatus.from_dict(
+            report_mfa_enrollment_status_model_json
+        ).__dict__
         report_mfa_enrollment_status_model2 = ReportMfaEnrollmentStatus(**report_mfa_enrollment_status_model_dict)
 
         # Verify the model instances are equivalent
@@ -12773,7 +13102,9 @@ class TestModel_TemplateAccountSettings:
 
         template_account_settings_restrict_user_domains_model = {}  # TemplateAccountSettingsRestrictUserDomains
         template_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
+        template_account_settings_restrict_user_domains_model['restrictions'] = [
+            account_settings_user_domain_restriction_model
+        ]
 
         # Construct a json representation of a TemplateAccountSettings model
         template_account_settings_model_json = {}
@@ -12788,14 +13119,18 @@ class TestModel_TemplateAccountSettings:
         template_account_settings_model_json['system_access_token_expiration_in_seconds'] = '3600'
         template_account_settings_model_json['system_refresh_token_expiration_in_seconds'] = '259200'
         template_account_settings_model_json['restrict_user_list_visibility'] = 'RESTRICTED'
-        template_account_settings_model_json['restrict_user_domains'] = template_account_settings_restrict_user_domains_model
+        template_account_settings_model_json['restrict_user_domains'] = (
+            template_account_settings_restrict_user_domains_model
+        )
 
         # Construct a model instance of TemplateAccountSettings by calling from_dict on the json representation
         template_account_settings_model = TemplateAccountSettings.from_dict(template_account_settings_model_json)
         assert template_account_settings_model != False
 
         # Construct a model instance of TemplateAccountSettings by calling from_dict on the json representation
-        template_account_settings_model_dict = TemplateAccountSettings.from_dict(template_account_settings_model_json).__dict__
+        template_account_settings_model_dict = TemplateAccountSettings.from_dict(
+            template_account_settings_model_json
+        ).__dict__
         template_account_settings_model2 = TemplateAccountSettings(**template_account_settings_model_dict)
 
         # Verify the model instances are equivalent
@@ -12826,22 +13161,40 @@ class TestModel_TemplateAccountSettingsRestrictUserDomains:
         # Construct a json representation of a TemplateAccountSettingsRestrictUserDomains model
         template_account_settings_restrict_user_domains_model_json = {}
         template_account_settings_restrict_user_domains_model_json['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model_json['restrictions'] = [account_settings_user_domain_restriction_model]
+        template_account_settings_restrict_user_domains_model_json['restrictions'] = [
+            account_settings_user_domain_restriction_model
+        ]
 
         # Construct a model instance of TemplateAccountSettingsRestrictUserDomains by calling from_dict on the json representation
-        template_account_settings_restrict_user_domains_model = TemplateAccountSettingsRestrictUserDomains.from_dict(template_account_settings_restrict_user_domains_model_json)
+        template_account_settings_restrict_user_domains_model = TemplateAccountSettingsRestrictUserDomains.from_dict(
+            template_account_settings_restrict_user_domains_model_json
+        )
         assert template_account_settings_restrict_user_domains_model != False
 
         # Construct a model instance of TemplateAccountSettingsRestrictUserDomains by calling from_dict on the json representation
-        template_account_settings_restrict_user_domains_model_dict = TemplateAccountSettingsRestrictUserDomains.from_dict(template_account_settings_restrict_user_domains_model_json).__dict__
-        template_account_settings_restrict_user_domains_model2 = TemplateAccountSettingsRestrictUserDomains(**template_account_settings_restrict_user_domains_model_dict)
+        template_account_settings_restrict_user_domains_model_dict = (
+            TemplateAccountSettingsRestrictUserDomains.from_dict(
+                template_account_settings_restrict_user_domains_model_json
+            ).__dict__
+        )
+        template_account_settings_restrict_user_domains_model2 = TemplateAccountSettingsRestrictUserDomains(
+            **template_account_settings_restrict_user_domains_model_dict
+        )
 
         # Verify the model instances are equivalent
-        assert template_account_settings_restrict_user_domains_model == template_account_settings_restrict_user_domains_model2
+        assert (
+            template_account_settings_restrict_user_domains_model
+            == template_account_settings_restrict_user_domains_model2
+        )
 
         # Convert model instance back to dict and verify no loss of data
-        template_account_settings_restrict_user_domains_model_json2 = template_account_settings_restrict_user_domains_model.to_dict()
-        assert template_account_settings_restrict_user_domains_model_json2 == template_account_settings_restrict_user_domains_model_json
+        template_account_settings_restrict_user_domains_model_json2 = (
+            template_account_settings_restrict_user_domains_model.to_dict()
+        )
+        assert (
+            template_account_settings_restrict_user_domains_model_json2
+            == template_account_settings_restrict_user_domains_model_json
+        )
 
 
 class TestModel_TemplateAssignmentListResponse:
@@ -12888,8 +13241,12 @@ class TestModel_TemplateAssignmentListResponse:
         template_assignment_response_resource_model = {}  # TemplateAssignmentResponseResource
         template_assignment_response_resource_model['target'] = 'testString'
         template_assignment_response_resource_model['profile'] = template_assignment_response_resource_detail_model
-        template_assignment_response_resource_model['account_settings'] = template_assignment_response_resource_detail_model
-        template_assignment_response_resource_model['policy_template_references'] = [template_assignment_response_resource_detail_model]
+        template_assignment_response_resource_model['account_settings'] = (
+            template_assignment_response_resource_detail_model
+        )
+        template_assignment_response_resource_model['policy_template_references'] = [
+            template_assignment_response_resource_detail_model
+        ]
 
         enity_history_record_model = {}  # EnityHistoryRecord
         enity_history_record_model['timestamp'] = 'testString'
@@ -12928,12 +13285,18 @@ class TestModel_TemplateAssignmentListResponse:
         template_assignment_list_response_model_json['assignments'] = [template_assignment_response_model]
 
         # Construct a model instance of TemplateAssignmentListResponse by calling from_dict on the json representation
-        template_assignment_list_response_model = TemplateAssignmentListResponse.from_dict(template_assignment_list_response_model_json)
+        template_assignment_list_response_model = TemplateAssignmentListResponse.from_dict(
+            template_assignment_list_response_model_json
+        )
         assert template_assignment_list_response_model != False
 
         # Construct a model instance of TemplateAssignmentListResponse by calling from_dict on the json representation
-        template_assignment_list_response_model_dict = TemplateAssignmentListResponse.from_dict(template_assignment_list_response_model_json).__dict__
-        template_assignment_list_response_model2 = TemplateAssignmentListResponse(**template_assignment_list_response_model_dict)
+        template_assignment_list_response_model_dict = TemplateAssignmentListResponse.from_dict(
+            template_assignment_list_response_model_json
+        ).__dict__
+        template_assignment_list_response_model2 = TemplateAssignmentListResponse(
+            **template_assignment_list_response_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert template_assignment_list_response_model == template_assignment_list_response_model2
@@ -12958,11 +13321,15 @@ class TestModel_TemplateAssignmentResource:
         template_assignment_resource_model_json['id'] = 'testString'
 
         # Construct a model instance of TemplateAssignmentResource by calling from_dict on the json representation
-        template_assignment_resource_model = TemplateAssignmentResource.from_dict(template_assignment_resource_model_json)
+        template_assignment_resource_model = TemplateAssignmentResource.from_dict(
+            template_assignment_resource_model_json
+        )
         assert template_assignment_resource_model != False
 
         # Construct a model instance of TemplateAssignmentResource by calling from_dict on the json representation
-        template_assignment_resource_model_dict = TemplateAssignmentResource.from_dict(template_assignment_resource_model_json).__dict__
+        template_assignment_resource_model_dict = TemplateAssignmentResource.from_dict(
+            template_assignment_resource_model_json
+        ).__dict__
         template_assignment_resource_model2 = TemplateAssignmentResource(**template_assignment_resource_model_dict)
 
         # Verify the model instances are equivalent
@@ -12991,12 +13358,18 @@ class TestModel_TemplateAssignmentResourceError:
         template_assignment_resource_error_model_json['statusCode'] = 'testString'
 
         # Construct a model instance of TemplateAssignmentResourceError by calling from_dict on the json representation
-        template_assignment_resource_error_model = TemplateAssignmentResourceError.from_dict(template_assignment_resource_error_model_json)
+        template_assignment_resource_error_model = TemplateAssignmentResourceError.from_dict(
+            template_assignment_resource_error_model_json
+        )
         assert template_assignment_resource_error_model != False
 
         # Construct a model instance of TemplateAssignmentResourceError by calling from_dict on the json representation
-        template_assignment_resource_error_model_dict = TemplateAssignmentResourceError.from_dict(template_assignment_resource_error_model_json).__dict__
-        template_assignment_resource_error_model2 = TemplateAssignmentResourceError(**template_assignment_resource_error_model_dict)
+        template_assignment_resource_error_model_dict = TemplateAssignmentResourceError.from_dict(
+            template_assignment_resource_error_model_json
+        ).__dict__
+        template_assignment_resource_error_model2 = TemplateAssignmentResourceError(
+            **template_assignment_resource_error_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert template_assignment_resource_error_model == template_assignment_resource_error_model2
@@ -13050,8 +13423,12 @@ class TestModel_TemplateAssignmentResponse:
         template_assignment_response_resource_model = {}  # TemplateAssignmentResponseResource
         template_assignment_response_resource_model['target'] = 'testString'
         template_assignment_response_resource_model['profile'] = template_assignment_response_resource_detail_model
-        template_assignment_response_resource_model['account_settings'] = template_assignment_response_resource_detail_model
-        template_assignment_response_resource_model['policy_template_references'] = [template_assignment_response_resource_detail_model]
+        template_assignment_response_resource_model['account_settings'] = (
+            template_assignment_response_resource_detail_model
+        )
+        template_assignment_response_resource_model['policy_template_references'] = [
+            template_assignment_response_resource_detail_model
+        ]
 
         enity_history_record_model = {}  # EnityHistoryRecord
         enity_history_record_model['timestamp'] = 'testString'
@@ -13081,11 +13458,15 @@ class TestModel_TemplateAssignmentResponse:
         template_assignment_response_model_json['entity_tag'] = 'testString'
 
         # Construct a model instance of TemplateAssignmentResponse by calling from_dict on the json representation
-        template_assignment_response_model = TemplateAssignmentResponse.from_dict(template_assignment_response_model_json)
+        template_assignment_response_model = TemplateAssignmentResponse.from_dict(
+            template_assignment_response_model_json
+        )
         assert template_assignment_response_model != False
 
         # Construct a model instance of TemplateAssignmentResponse by calling from_dict on the json representation
-        template_assignment_response_model_dict = TemplateAssignmentResponse.from_dict(template_assignment_response_model_json).__dict__
+        template_assignment_response_model_dict = TemplateAssignmentResponse.from_dict(
+            template_assignment_response_model_json
+        ).__dict__
         template_assignment_response_model2 = TemplateAssignmentResponse(**template_assignment_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -13128,16 +13509,26 @@ class TestModel_TemplateAssignmentResponseResource:
         template_assignment_response_resource_model_json = {}
         template_assignment_response_resource_model_json['target'] = 'testString'
         template_assignment_response_resource_model_json['profile'] = template_assignment_response_resource_detail_model
-        template_assignment_response_resource_model_json['account_settings'] = template_assignment_response_resource_detail_model
-        template_assignment_response_resource_model_json['policy_template_references'] = [template_assignment_response_resource_detail_model]
+        template_assignment_response_resource_model_json['account_settings'] = (
+            template_assignment_response_resource_detail_model
+        )
+        template_assignment_response_resource_model_json['policy_template_references'] = [
+            template_assignment_response_resource_detail_model
+        ]
 
         # Construct a model instance of TemplateAssignmentResponseResource by calling from_dict on the json representation
-        template_assignment_response_resource_model = TemplateAssignmentResponseResource.from_dict(template_assignment_response_resource_model_json)
+        template_assignment_response_resource_model = TemplateAssignmentResponseResource.from_dict(
+            template_assignment_response_resource_model_json
+        )
         assert template_assignment_response_resource_model != False
 
         # Construct a model instance of TemplateAssignmentResponseResource by calling from_dict on the json representation
-        template_assignment_response_resource_model_dict = TemplateAssignmentResponseResource.from_dict(template_assignment_response_resource_model_json).__dict__
-        template_assignment_response_resource_model2 = TemplateAssignmentResponseResource(**template_assignment_response_resource_model_dict)
+        template_assignment_response_resource_model_dict = TemplateAssignmentResponseResource.from_dict(
+            template_assignment_response_resource_model_json
+        ).__dict__
+        template_assignment_response_resource_model2 = TemplateAssignmentResponseResource(
+            **template_assignment_response_resource_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert template_assignment_response_resource_model == template_assignment_response_resource_model2
@@ -13173,23 +13564,36 @@ class TestModel_TemplateAssignmentResponseResourceDetail:
         template_assignment_response_resource_detail_model_json['id'] = 'testString'
         template_assignment_response_resource_detail_model_json['version'] = 'testString'
         template_assignment_response_resource_detail_model_json['resource_created'] = template_assignment_resource_model
-        template_assignment_response_resource_detail_model_json['error_message'] = template_assignment_resource_error_model
+        template_assignment_response_resource_detail_model_json['error_message'] = (
+            template_assignment_resource_error_model
+        )
         template_assignment_response_resource_detail_model_json['status'] = 'testString'
 
         # Construct a model instance of TemplateAssignmentResponseResourceDetail by calling from_dict on the json representation
-        template_assignment_response_resource_detail_model = TemplateAssignmentResponseResourceDetail.from_dict(template_assignment_response_resource_detail_model_json)
+        template_assignment_response_resource_detail_model = TemplateAssignmentResponseResourceDetail.from_dict(
+            template_assignment_response_resource_detail_model_json
+        )
         assert template_assignment_response_resource_detail_model != False
 
         # Construct a model instance of TemplateAssignmentResponseResourceDetail by calling from_dict on the json representation
-        template_assignment_response_resource_detail_model_dict = TemplateAssignmentResponseResourceDetail.from_dict(template_assignment_response_resource_detail_model_json).__dict__
-        template_assignment_response_resource_detail_model2 = TemplateAssignmentResponseResourceDetail(**template_assignment_response_resource_detail_model_dict)
+        template_assignment_response_resource_detail_model_dict = TemplateAssignmentResponseResourceDetail.from_dict(
+            template_assignment_response_resource_detail_model_json
+        ).__dict__
+        template_assignment_response_resource_detail_model2 = TemplateAssignmentResponseResourceDetail(
+            **template_assignment_response_resource_detail_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert template_assignment_response_resource_detail_model == template_assignment_response_resource_detail_model2
 
         # Convert model instance back to dict and verify no loss of data
-        template_assignment_response_resource_detail_model_json2 = template_assignment_response_resource_detail_model.to_dict()
-        assert template_assignment_response_resource_detail_model_json2 == template_assignment_response_resource_detail_model_json
+        template_assignment_response_resource_detail_model_json2 = (
+            template_assignment_response_resource_detail_model.to_dict()
+        )
+        assert (
+            template_assignment_response_resource_detail_model_json2
+            == template_assignment_response_resource_detail_model_json
+        )
 
 
 class TestModel_TemplateCount:
@@ -13262,12 +13666,18 @@ class TestModel_TemplateProfileComponentRequest:
         template_profile_component_request_model_json['identities'] = [profile_identity_request_model]
 
         # Construct a model instance of TemplateProfileComponentRequest by calling from_dict on the json representation
-        template_profile_component_request_model = TemplateProfileComponentRequest.from_dict(template_profile_component_request_model_json)
+        template_profile_component_request_model = TemplateProfileComponentRequest.from_dict(
+            template_profile_component_request_model_json
+        )
         assert template_profile_component_request_model != False
 
         # Construct a model instance of TemplateProfileComponentRequest by calling from_dict on the json representation
-        template_profile_component_request_model_dict = TemplateProfileComponentRequest.from_dict(template_profile_component_request_model_json).__dict__
-        template_profile_component_request_model2 = TemplateProfileComponentRequest(**template_profile_component_request_model_dict)
+        template_profile_component_request_model_dict = TemplateProfileComponentRequest.from_dict(
+            template_profile_component_request_model_json
+        ).__dict__
+        template_profile_component_request_model2 = TemplateProfileComponentRequest(
+            **template_profile_component_request_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert template_profile_component_request_model == template_profile_component_request_model2
@@ -13317,12 +13727,18 @@ class TestModel_TemplateProfileComponentResponse:
         template_profile_component_response_model_json['identities'] = [profile_identity_response_model]
 
         # Construct a model instance of TemplateProfileComponentResponse by calling from_dict on the json representation
-        template_profile_component_response_model = TemplateProfileComponentResponse.from_dict(template_profile_component_response_model_json)
+        template_profile_component_response_model = TemplateProfileComponentResponse.from_dict(
+            template_profile_component_response_model_json
+        )
         assert template_profile_component_response_model != False
 
         # Construct a model instance of TemplateProfileComponentResponse by calling from_dict on the json representation
-        template_profile_component_response_model_dict = TemplateProfileComponentResponse.from_dict(template_profile_component_response_model_json).__dict__
-        template_profile_component_response_model2 = TemplateProfileComponentResponse(**template_profile_component_response_model_dict)
+        template_profile_component_response_model_dict = TemplateProfileComponentResponse.from_dict(
+            template_profile_component_response_model_json
+        ).__dict__
+        template_profile_component_response_model2 = TemplateProfileComponentResponse(
+            **template_profile_component_response_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert template_profile_component_response_model == template_profile_component_response_model2
@@ -13431,12 +13847,18 @@ class TestModel_TrustedProfileTemplateClaimRule:
         trusted_profile_template_claim_rule_model_json['conditions'] = [profile_claim_rule_conditions_model]
 
         # Construct a model instance of TrustedProfileTemplateClaimRule by calling from_dict on the json representation
-        trusted_profile_template_claim_rule_model = TrustedProfileTemplateClaimRule.from_dict(trusted_profile_template_claim_rule_model_json)
+        trusted_profile_template_claim_rule_model = TrustedProfileTemplateClaimRule.from_dict(
+            trusted_profile_template_claim_rule_model_json
+        )
         assert trusted_profile_template_claim_rule_model != False
 
         # Construct a model instance of TrustedProfileTemplateClaimRule by calling from_dict on the json representation
-        trusted_profile_template_claim_rule_model_dict = TrustedProfileTemplateClaimRule.from_dict(trusted_profile_template_claim_rule_model_json).__dict__
-        trusted_profile_template_claim_rule_model2 = TrustedProfileTemplateClaimRule(**trusted_profile_template_claim_rule_model_dict)
+        trusted_profile_template_claim_rule_model_dict = TrustedProfileTemplateClaimRule.from_dict(
+            trusted_profile_template_claim_rule_model_json
+        ).__dict__
+        trusted_profile_template_claim_rule_model2 = TrustedProfileTemplateClaimRule(
+            **trusted_profile_template_claim_rule_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert trusted_profile_template_claim_rule_model == trusted_profile_template_claim_rule_model2
@@ -13555,11 +13977,15 @@ class TestModel_TrustedProfileTemplateList:
         trusted_profile_template_list_model_json['profile_templates'] = [trusted_profile_template_response_model]
 
         # Construct a model instance of TrustedProfileTemplateList by calling from_dict on the json representation
-        trusted_profile_template_list_model = TrustedProfileTemplateList.from_dict(trusted_profile_template_list_model_json)
+        trusted_profile_template_list_model = TrustedProfileTemplateList.from_dict(
+            trusted_profile_template_list_model_json
+        )
         assert trusted_profile_template_list_model != False
 
         # Construct a model instance of TrustedProfileTemplateList by calling from_dict on the json representation
-        trusted_profile_template_list_model_dict = TrustedProfileTemplateList.from_dict(trusted_profile_template_list_model_json).__dict__
+        trusted_profile_template_list_model_dict = TrustedProfileTemplateList.from_dict(
+            trusted_profile_template_list_model_json
+        ).__dict__
         trusted_profile_template_list_model2 = TrustedProfileTemplateList(**trusted_profile_template_list_model_dict)
 
         # Verify the model instances are equivalent
@@ -13657,12 +14083,18 @@ class TestModel_TrustedProfileTemplateResponse:
         trusted_profile_template_response_model_json['last_modified_by_id'] = 'testString'
 
         # Construct a model instance of TrustedProfileTemplateResponse by calling from_dict on the json representation
-        trusted_profile_template_response_model = TrustedProfileTemplateResponse.from_dict(trusted_profile_template_response_model_json)
+        trusted_profile_template_response_model = TrustedProfileTemplateResponse.from_dict(
+            trusted_profile_template_response_model_json
+        )
         assert trusted_profile_template_response_model != False
 
         # Construct a model instance of TrustedProfileTemplateResponse by calling from_dict on the json representation
-        trusted_profile_template_response_model_dict = TrustedProfileTemplateResponse.from_dict(trusted_profile_template_response_model_json).__dict__
-        trusted_profile_template_response_model2 = TrustedProfileTemplateResponse(**trusted_profile_template_response_model_dict)
+        trusted_profile_template_response_model_dict = TrustedProfileTemplateResponse.from_dict(
+            trusted_profile_template_response_model_json
+        ).__dict__
+        trusted_profile_template_response_model2 = TrustedProfileTemplateResponse(
+            **trusted_profile_template_response_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert trusted_profile_template_response_model == trusted_profile_template_response_model2
@@ -13911,12 +14343,18 @@ class TestModel_UserReportMfaEnrollmentStatus:
         user_report_mfa_enrollment_status_model_json['account_based_mfa'] = account_based_mfa_enrollment_model
 
         # Construct a model instance of UserReportMfaEnrollmentStatus by calling from_dict on the json representation
-        user_report_mfa_enrollment_status_model = UserReportMfaEnrollmentStatus.from_dict(user_report_mfa_enrollment_status_model_json)
+        user_report_mfa_enrollment_status_model = UserReportMfaEnrollmentStatus.from_dict(
+            user_report_mfa_enrollment_status_model_json
+        )
         assert user_report_mfa_enrollment_status_model != False
 
         # Construct a model instance of UserReportMfaEnrollmentStatus by calling from_dict on the json representation
-        user_report_mfa_enrollment_status_model_dict = UserReportMfaEnrollmentStatus.from_dict(user_report_mfa_enrollment_status_model_json).__dict__
-        user_report_mfa_enrollment_status_model2 = UserReportMfaEnrollmentStatus(**user_report_mfa_enrollment_status_model_dict)
+        user_report_mfa_enrollment_status_model_dict = UserReportMfaEnrollmentStatus.from_dict(
+            user_report_mfa_enrollment_status_model_json
+        ).__dict__
+        user_report_mfa_enrollment_status_model2 = UserReportMfaEnrollmentStatus(
+            **user_report_mfa_enrollment_status_model_dict
+        )
 
         # Verify the model instances are equivalent
         assert user_report_mfa_enrollment_status_model == user_report_mfa_enrollment_status_model2

--- a/test/unit/test_iam_identity_v1.py
+++ b/test/unit/test_iam_identity_v1.py
@@ -31,7 +31,9 @@ import urllib
 from ibm_platform_services.iam_identity_v1 import *
 
 
-_service = IamIdentityV1(authenticator=NoAuthAuthenticator())
+_service = IamIdentityV1(
+    authenticator=NoAuthAuthenticator()
+)
 
 _base_url = 'https://iam.cloud.ibm.com'
 _service.set_service_url(_base_url)
@@ -7982,9 +7984,7 @@ class TestCreateAccountSettingsTemplate:
         # Construct a dict representation of a TemplateAccountSettingsRestrictUserDomains model
         template_account_settings_restrict_user_domains_model = {}
         template_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model['restrictions'] = [
-            account_settings_user_domain_restriction_model
-        ]
+        template_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
 
         # Construct a dict representation of a TemplateAccountSettings model
         template_account_settings_model = {}
@@ -8408,9 +8408,7 @@ class TestCreateAccountSettingsTemplateVersion:
         # Construct a dict representation of a TemplateAccountSettingsRestrictUserDomains model
         template_account_settings_restrict_user_domains_model = {}
         template_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model['restrictions'] = [
-            account_settings_user_domain_restriction_model
-        ]
+        template_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
 
         # Construct a dict representation of a TemplateAccountSettings model
         template_account_settings_model = {}
@@ -8493,9 +8491,7 @@ class TestCreateAccountSettingsTemplateVersion:
         # Construct a dict representation of a TemplateAccountSettingsRestrictUserDomains model
         template_account_settings_restrict_user_domains_model = {}
         template_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model['restrictions'] = [
-            account_settings_user_domain_restriction_model
-        ]
+        template_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
 
         # Construct a dict representation of a TemplateAccountSettings model
         template_account_settings_model = {}
@@ -8704,9 +8700,7 @@ class TestUpdateAccountSettingsTemplateVersion:
         # Construct a dict representation of a TemplateAccountSettingsRestrictUserDomains model
         template_account_settings_restrict_user_domains_model = {}
         template_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model['restrictions'] = [
-            account_settings_user_domain_restriction_model
-        ]
+        template_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
 
         # Construct a dict representation of a TemplateAccountSettings model
         template_account_settings_model = {}
@@ -8793,9 +8787,7 @@ class TestUpdateAccountSettingsTemplateVersion:
         # Construct a dict representation of a TemplateAccountSettingsRestrictUserDomains model
         template_account_settings_restrict_user_domains_model = {}
         template_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model['restrictions'] = [
-            account_settings_user_domain_restriction_model
-        ]
+        template_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
 
         # Construct a dict representation of a TemplateAccountSettings model
         template_account_settings_model = {}
@@ -9767,22 +9759,13 @@ class TestBulkListAccountEntityConsumption:
         # Set up parameter values
         account_id = 'testString'
         serviceid_groups = True
-        serviceids_per_group = [
-            'ServiceIdGroup-12345678-1234-1234-1234-123456789abc',
-            'ServiceIdGroup-12345678-1234-1234-1234-123456789def',
-        ]
+        serviceids_per_group = ['ServiceIdGroup-12345678-1234-1234-1234-123456789abc', 'ServiceIdGroup-12345678-1234-1234-1234-123456789def']
         profiles = True
         apikeys_per_identity = ['iam-ServiceId-12345678-1234-1234-1234-123456789def', 'IBMid-1234567ABC']
         templates = True
-        template_versions_per_template = [
-            'AccountSettingsTemplate-12345678-1234-1234-1234-123456789abc',
-            'ProfileTemplate-12345678-1234-1234-1234-123456789def',
-        ]
+        template_versions_per_template = ['AccountSettingsTemplate-12345678-1234-1234-1234-123456789abc', 'ProfileTemplate-12345678-1234-1234-1234-123456789def']
         idps = True
-        claim_rules_per_group = [
-            'AccessGroupId-12345678-1234-1234-1234-123456789abc',
-            'AccessGroupId-12345678-1234-1234-1234-123456789def',
-        ]
+        claim_rules_per_group = ['AccessGroupId-12345678-1234-1234-1234-123456789abc', 'AccessGroupId-12345678-1234-1234-1234-123456789def']
         claim_rules_per_profile = ['Profile-12345678-1234-1234-123456789abc', 'Profile-12345678-1234-1234-123456789def']
         cr_links = True
         cr_links_per_profile = ['Profile-12345678-1234-1234-123456789abc', 'Profile-12345678-1234-1234-123456789def']
@@ -9814,39 +9797,18 @@ class TestBulkListAccountEntityConsumption:
         # Validate body params
         req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
         assert req_body['serviceid_groups'] == True
-        assert req_body['serviceids_per_group'] == [
-            'ServiceIdGroup-12345678-1234-1234-1234-123456789abc',
-            'ServiceIdGroup-12345678-1234-1234-1234-123456789def',
-        ]
+        assert req_body['serviceids_per_group'] == ['ServiceIdGroup-12345678-1234-1234-1234-123456789abc', 'ServiceIdGroup-12345678-1234-1234-1234-123456789def']
         assert req_body['profiles'] == True
-        assert req_body['apikeys_per_identity'] == [
-            'iam-ServiceId-12345678-1234-1234-1234-123456789def',
-            'IBMid-1234567ABC',
-        ]
+        assert req_body['apikeys_per_identity'] == ['iam-ServiceId-12345678-1234-1234-1234-123456789def', 'IBMid-1234567ABC']
         assert req_body['templates'] == True
-        assert req_body['template_versions_per_template'] == [
-            'AccountSettingsTemplate-12345678-1234-1234-1234-123456789abc',
-            'ProfileTemplate-12345678-1234-1234-1234-123456789def',
-        ]
+        assert req_body['template_versions_per_template'] == ['AccountSettingsTemplate-12345678-1234-1234-1234-123456789abc', 'ProfileTemplate-12345678-1234-1234-1234-123456789def']
         assert req_body['idps'] == True
-        assert req_body['claim_rules_per_group'] == [
-            'AccessGroupId-12345678-1234-1234-1234-123456789abc',
-            'AccessGroupId-12345678-1234-1234-1234-123456789def',
-        ]
-        assert req_body['claim_rules_per_profile'] == [
-            'Profile-12345678-1234-1234-123456789abc',
-            'Profile-12345678-1234-1234-123456789def',
-        ]
+        assert req_body['claim_rules_per_group'] == ['AccessGroupId-12345678-1234-1234-1234-123456789abc', 'AccessGroupId-12345678-1234-1234-1234-123456789def']
+        assert req_body['claim_rules_per_profile'] == ['Profile-12345678-1234-1234-123456789abc', 'Profile-12345678-1234-1234-123456789def']
         assert req_body['cr_links'] == True
-        assert req_body['cr_links_per_profile'] == [
-            'Profile-12345678-1234-1234-123456789abc',
-            'Profile-12345678-1234-1234-123456789def',
-        ]
+        assert req_body['cr_links_per_profile'] == ['Profile-12345678-1234-1234-123456789abc', 'Profile-12345678-1234-1234-123456789def']
         assert req_body['cr_rules'] == True
-        assert req_body['cr_rules_per_profile'] == [
-            'Profile-12345678-1234-1234-123456789abc',
-            'Profile-12345678-1234-1234-123456789def',
-        ]
+        assert req_body['cr_rules_per_profile'] == ['Profile-12345678-1234-1234-123456789abc', 'Profile-12345678-1234-1234-123456789def']
 
     def test_bulk_list_account_entity_consumption_all_params_with_retries(self):
         # Enable retries and run test_bulk_list_account_entity_consumption_all_params.
@@ -10000,15 +9962,11 @@ class TestModel_AccountBasedMfaEnrollment:
         account_based_mfa_enrollment_model_json['complies'] = True
 
         # Construct a model instance of AccountBasedMfaEnrollment by calling from_dict on the json representation
-        account_based_mfa_enrollment_model = AccountBasedMfaEnrollment.from_dict(
-            account_based_mfa_enrollment_model_json
-        )
+        account_based_mfa_enrollment_model = AccountBasedMfaEnrollment.from_dict(account_based_mfa_enrollment_model_json)
         assert account_based_mfa_enrollment_model != False
 
         # Construct a model instance of AccountBasedMfaEnrollment by calling from_dict on the json representation
-        account_based_mfa_enrollment_model_dict = AccountBasedMfaEnrollment.from_dict(
-            account_based_mfa_enrollment_model_json
-        ).__dict__
+        account_based_mfa_enrollment_model_dict = AccountBasedMfaEnrollment.from_dict(account_based_mfa_enrollment_model_json).__dict__
         account_based_mfa_enrollment_model2 = AccountBasedMfaEnrollment(**account_based_mfa_enrollment_model_dict)
 
         # Verify the model instances are equivalent
@@ -10044,13 +10002,9 @@ class TestModel_AccountSettingsAssignedTemplatesSection:
         account_settings_user_domain_restriction_model['invitation_email_allow_patterns'] = []
         account_settings_user_domain_restriction_model['restrict_invitation'] = True
 
-        assigned_templates_account_settings_restrict_user_domains_model = (
-            {}
-        )  # AssignedTemplatesAccountSettingsRestrictUserDomains
+        assigned_templates_account_settings_restrict_user_domains_model = {}  # AssignedTemplatesAccountSettingsRestrictUserDomains
         assigned_templates_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        assigned_templates_account_settings_restrict_user_domains_model['restrictions'] = [
-            account_settings_user_domain_restriction_model
-        ]
+        assigned_templates_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
 
         # Construct a json representation of a AccountSettingsAssignedTemplatesSection model
         account_settings_assigned_templates_section_model_json = {}
@@ -10068,35 +10022,22 @@ class TestModel_AccountSettingsAssignedTemplatesSection:
         account_settings_assigned_templates_section_model_json['system_refresh_token_expiration_in_seconds'] = '259200'
         account_settings_assigned_templates_section_model_json['restrict_user_list_visibility'] = 'RESTRICTED'
         account_settings_assigned_templates_section_model_json['user_mfa'] = [account_settings_user_mfa_response_model]
-        account_settings_assigned_templates_section_model_json['restrict_user_domains'] = (
-            assigned_templates_account_settings_restrict_user_domains_model
-        )
+        account_settings_assigned_templates_section_model_json['restrict_user_domains'] = assigned_templates_account_settings_restrict_user_domains_model
 
         # Construct a model instance of AccountSettingsAssignedTemplatesSection by calling from_dict on the json representation
-        account_settings_assigned_templates_section_model = AccountSettingsAssignedTemplatesSection.from_dict(
-            account_settings_assigned_templates_section_model_json
-        )
+        account_settings_assigned_templates_section_model = AccountSettingsAssignedTemplatesSection.from_dict(account_settings_assigned_templates_section_model_json)
         assert account_settings_assigned_templates_section_model != False
 
         # Construct a model instance of AccountSettingsAssignedTemplatesSection by calling from_dict on the json representation
-        account_settings_assigned_templates_section_model_dict = AccountSettingsAssignedTemplatesSection.from_dict(
-            account_settings_assigned_templates_section_model_json
-        ).__dict__
-        account_settings_assigned_templates_section_model2 = AccountSettingsAssignedTemplatesSection(
-            **account_settings_assigned_templates_section_model_dict
-        )
+        account_settings_assigned_templates_section_model_dict = AccountSettingsAssignedTemplatesSection.from_dict(account_settings_assigned_templates_section_model_json).__dict__
+        account_settings_assigned_templates_section_model2 = AccountSettingsAssignedTemplatesSection(**account_settings_assigned_templates_section_model_dict)
 
         # Verify the model instances are equivalent
         assert account_settings_assigned_templates_section_model == account_settings_assigned_templates_section_model2
 
         # Convert model instance back to dict and verify no loss of data
-        account_settings_assigned_templates_section_model_json2 = (
-            account_settings_assigned_templates_section_model.to_dict()
-        )
-        assert (
-            account_settings_assigned_templates_section_model_json2
-            == account_settings_assigned_templates_section_model_json
-        )
+        account_settings_assigned_templates_section_model_json2 = account_settings_assigned_templates_section_model.to_dict()
+        assert account_settings_assigned_templates_section_model_json2 == account_settings_assigned_templates_section_model_json
 
 
 class TestModel_AccountSettingsEffectiveSection:
@@ -10134,18 +10075,12 @@ class TestModel_AccountSettingsEffectiveSection:
         account_settings_effective_section_model_json['system_refresh_token_expiration_in_seconds'] = '259200'
 
         # Construct a model instance of AccountSettingsEffectiveSection by calling from_dict on the json representation
-        account_settings_effective_section_model = AccountSettingsEffectiveSection.from_dict(
-            account_settings_effective_section_model_json
-        )
+        account_settings_effective_section_model = AccountSettingsEffectiveSection.from_dict(account_settings_effective_section_model_json)
         assert account_settings_effective_section_model != False
 
         # Construct a model instance of AccountSettingsEffectiveSection by calling from_dict on the json representation
-        account_settings_effective_section_model_dict = AccountSettingsEffectiveSection.from_dict(
-            account_settings_effective_section_model_json
-        ).__dict__
-        account_settings_effective_section_model2 = AccountSettingsEffectiveSection(
-            **account_settings_effective_section_model_dict
-        )
+        account_settings_effective_section_model_dict = AccountSettingsEffectiveSection.from_dict(account_settings_effective_section_model_json).__dict__
+        account_settings_effective_section_model2 = AccountSettingsEffectiveSection(**account_settings_effective_section_model_dict)
 
         # Verify the model instances are equivalent
         assert account_settings_effective_section_model == account_settings_effective_section_model2
@@ -10225,9 +10160,7 @@ class TestModel_AccountSettingsResponse:
         assert account_settings_response_model != False
 
         # Construct a model instance of AccountSettingsResponse by calling from_dict on the json representation
-        account_settings_response_model_dict = AccountSettingsResponse.from_dict(
-            account_settings_response_model_json
-        ).__dict__
+        account_settings_response_model_dict = AccountSettingsResponse.from_dict(account_settings_response_model_json).__dict__
         account_settings_response_model2 = AccountSettingsResponse(**account_settings_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -10274,9 +10207,7 @@ class TestModel_AccountSettingsTemplateList:
 
         template_account_settings_restrict_user_domains_model = {}  # TemplateAccountSettingsRestrictUserDomains
         template_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model['restrictions'] = [
-            account_settings_user_domain_restriction_model
-        ]
+        template_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
 
         template_account_settings_model = {}  # TemplateAccountSettings
         template_account_settings_model['restrict_create_service_id'] = 'NOT_SET'
@@ -10324,20 +10255,14 @@ class TestModel_AccountSettingsTemplateList:
         account_settings_template_list_model_json['first'] = 'testString'
         account_settings_template_list_model_json['previous'] = 'testString'
         account_settings_template_list_model_json['next'] = 'testString'
-        account_settings_template_list_model_json['account_settings_templates'] = [
-            account_settings_template_response_model
-        ]
+        account_settings_template_list_model_json['account_settings_templates'] = [account_settings_template_response_model]
 
         # Construct a model instance of AccountSettingsTemplateList by calling from_dict on the json representation
-        account_settings_template_list_model = AccountSettingsTemplateList.from_dict(
-            account_settings_template_list_model_json
-        )
+        account_settings_template_list_model = AccountSettingsTemplateList.from_dict(account_settings_template_list_model_json)
         assert account_settings_template_list_model != False
 
         # Construct a model instance of AccountSettingsTemplateList by calling from_dict on the json representation
-        account_settings_template_list_model_dict = AccountSettingsTemplateList.from_dict(
-            account_settings_template_list_model_json
-        ).__dict__
+        account_settings_template_list_model_dict = AccountSettingsTemplateList.from_dict(account_settings_template_list_model_json).__dict__
         account_settings_template_list_model2 = AccountSettingsTemplateList(**account_settings_template_list_model_dict)
 
         # Verify the model instances are equivalent
@@ -10371,9 +10296,7 @@ class TestModel_AccountSettingsTemplateResponse:
 
         template_account_settings_restrict_user_domains_model = {}  # TemplateAccountSettingsRestrictUserDomains
         template_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model['restrictions'] = [
-            account_settings_user_domain_restriction_model
-        ]
+        template_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
 
         template_account_settings_model = {}  # TemplateAccountSettings
         template_account_settings_model['restrict_create_service_id'] = 'NOT_SET'
@@ -10415,18 +10338,12 @@ class TestModel_AccountSettingsTemplateResponse:
         account_settings_template_response_model_json['last_modified_by_id'] = 'testString'
 
         # Construct a model instance of AccountSettingsTemplateResponse by calling from_dict on the json representation
-        account_settings_template_response_model = AccountSettingsTemplateResponse.from_dict(
-            account_settings_template_response_model_json
-        )
+        account_settings_template_response_model = AccountSettingsTemplateResponse.from_dict(account_settings_template_response_model_json)
         assert account_settings_template_response_model != False
 
         # Construct a model instance of AccountSettingsTemplateResponse by calling from_dict on the json representation
-        account_settings_template_response_model_dict = AccountSettingsTemplateResponse.from_dict(
-            account_settings_template_response_model_json
-        ).__dict__
-        account_settings_template_response_model2 = AccountSettingsTemplateResponse(
-            **account_settings_template_response_model_dict
-        )
+        account_settings_template_response_model_dict = AccountSettingsTemplateResponse.from_dict(account_settings_template_response_model_json).__dict__
+        account_settings_template_response_model2 = AccountSettingsTemplateResponse(**account_settings_template_response_model_dict)
 
         # Verify the model instances are equivalent
         assert account_settings_template_response_model == account_settings_template_response_model2
@@ -10453,27 +10370,19 @@ class TestModel_AccountSettingsUserDomainRestriction:
         account_settings_user_domain_restriction_model_json['restrict_invitation'] = True
 
         # Construct a model instance of AccountSettingsUserDomainRestriction by calling from_dict on the json representation
-        account_settings_user_domain_restriction_model = AccountSettingsUserDomainRestriction.from_dict(
-            account_settings_user_domain_restriction_model_json
-        )
+        account_settings_user_domain_restriction_model = AccountSettingsUserDomainRestriction.from_dict(account_settings_user_domain_restriction_model_json)
         assert account_settings_user_domain_restriction_model != False
 
         # Construct a model instance of AccountSettingsUserDomainRestriction by calling from_dict on the json representation
-        account_settings_user_domain_restriction_model_dict = AccountSettingsUserDomainRestriction.from_dict(
-            account_settings_user_domain_restriction_model_json
-        ).__dict__
-        account_settings_user_domain_restriction_model2 = AccountSettingsUserDomainRestriction(
-            **account_settings_user_domain_restriction_model_dict
-        )
+        account_settings_user_domain_restriction_model_dict = AccountSettingsUserDomainRestriction.from_dict(account_settings_user_domain_restriction_model_json).__dict__
+        account_settings_user_domain_restriction_model2 = AccountSettingsUserDomainRestriction(**account_settings_user_domain_restriction_model_dict)
 
         # Verify the model instances are equivalent
         assert account_settings_user_domain_restriction_model == account_settings_user_domain_restriction_model2
 
         # Convert model instance back to dict and verify no loss of data
         account_settings_user_domain_restriction_model_json2 = account_settings_user_domain_restriction_model.to_dict()
-        assert (
-            account_settings_user_domain_restriction_model_json2 == account_settings_user_domain_restriction_model_json
-        )
+        assert account_settings_user_domain_restriction_model_json2 == account_settings_user_domain_restriction_model_json
 
 
 class TestModel_AccountSettingsUserMFAResponse:
@@ -10496,18 +10405,12 @@ class TestModel_AccountSettingsUserMFAResponse:
         account_settings_user_mfa_response_model_json['description'] = 'testString'
 
         # Construct a model instance of AccountSettingsUserMFAResponse by calling from_dict on the json representation
-        account_settings_user_mfa_response_model = AccountSettingsUserMFAResponse.from_dict(
-            account_settings_user_mfa_response_model_json
-        )
+        account_settings_user_mfa_response_model = AccountSettingsUserMFAResponse.from_dict(account_settings_user_mfa_response_model_json)
         assert account_settings_user_mfa_response_model != False
 
         # Construct a model instance of AccountSettingsUserMFAResponse by calling from_dict on the json representation
-        account_settings_user_mfa_response_model_dict = AccountSettingsUserMFAResponse.from_dict(
-            account_settings_user_mfa_response_model_json
-        ).__dict__
-        account_settings_user_mfa_response_model2 = AccountSettingsUserMFAResponse(
-            **account_settings_user_mfa_response_model_dict
-        )
+        account_settings_user_mfa_response_model_dict = AccountSettingsUserMFAResponse.from_dict(account_settings_user_mfa_response_model_json).__dict__
+        account_settings_user_mfa_response_model2 = AccountSettingsUserMFAResponse(**account_settings_user_mfa_response_model_dict)
 
         # Verify the model instances are equivalent
         assert account_settings_user_mfa_response_model == account_settings_user_mfa_response_model2
@@ -10583,9 +10486,7 @@ class TestModel_ActionControlsIdentities:
         assert action_controls_identities_model != False
 
         # Construct a model instance of ActionControlsIdentities by calling from_dict on the json representation
-        action_controls_identities_model_dict = ActionControlsIdentities.from_dict(
-            action_controls_identities_model_json
-        ).__dict__
+        action_controls_identities_model_dict = ActionControlsIdentities.from_dict(action_controls_identities_model_json).__dict__
         action_controls_identities_model2 = ActionControlsIdentities(**action_controls_identities_model_dict)
 
         # Verify the model instances are equivalent
@@ -10616,9 +10517,7 @@ class TestModel_ActionControlsPolicies:
         assert action_controls_policies_model != False
 
         # Construct a model instance of ActionControlsPolicies by calling from_dict on the json representation
-        action_controls_policies_model_dict = ActionControlsPolicies.from_dict(
-            action_controls_policies_model_json
-        ).__dict__
+        action_controls_policies_model_dict = ActionControlsPolicies.from_dict(action_controls_policies_model_json).__dict__
         action_controls_policies_model2 = ActionControlsPolicies(**action_controls_policies_model_dict)
 
         # Verify the model instances are equivalent
@@ -10786,27 +10685,19 @@ class TestModel_ApiKeyInsideCreateServiceIdRequest:
         api_key_inside_create_service_id_request_model_json['expires_at'] = 'testString'
 
         # Construct a model instance of ApiKeyInsideCreateServiceIdRequest by calling from_dict on the json representation
-        api_key_inside_create_service_id_request_model = ApiKeyInsideCreateServiceIdRequest.from_dict(
-            api_key_inside_create_service_id_request_model_json
-        )
+        api_key_inside_create_service_id_request_model = ApiKeyInsideCreateServiceIdRequest.from_dict(api_key_inside_create_service_id_request_model_json)
         assert api_key_inside_create_service_id_request_model != False
 
         # Construct a model instance of ApiKeyInsideCreateServiceIdRequest by calling from_dict on the json representation
-        api_key_inside_create_service_id_request_model_dict = ApiKeyInsideCreateServiceIdRequest.from_dict(
-            api_key_inside_create_service_id_request_model_json
-        ).__dict__
-        api_key_inside_create_service_id_request_model2 = ApiKeyInsideCreateServiceIdRequest(
-            **api_key_inside_create_service_id_request_model_dict
-        )
+        api_key_inside_create_service_id_request_model_dict = ApiKeyInsideCreateServiceIdRequest.from_dict(api_key_inside_create_service_id_request_model_json).__dict__
+        api_key_inside_create_service_id_request_model2 = ApiKeyInsideCreateServiceIdRequest(**api_key_inside_create_service_id_request_model_dict)
 
         # Verify the model instances are equivalent
         assert api_key_inside_create_service_id_request_model == api_key_inside_create_service_id_request_model2
 
         # Convert model instance back to dict and verify no loss of data
         api_key_inside_create_service_id_request_model_json2 = api_key_inside_create_service_id_request_model.to_dict()
-        assert (
-            api_key_inside_create_service_id_request_model_json2 == api_key_inside_create_service_id_request_model_json
-        )
+        assert api_key_inside_create_service_id_request_model_json2 == api_key_inside_create_service_id_request_model_json
 
 
 class TestModel_ApiKeyList:
@@ -10960,9 +10851,7 @@ class TestModel_ApikeyActivityServiceid:
         assert apikey_activity_serviceid_model != False
 
         # Construct a model instance of ApikeyActivityServiceid by calling from_dict on the json representation
-        apikey_activity_serviceid_model_dict = ApikeyActivityServiceid.from_dict(
-            apikey_activity_serviceid_model_json
-        ).__dict__
+        apikey_activity_serviceid_model_dict = ApikeyActivityServiceid.from_dict(apikey_activity_serviceid_model_json).__dict__
         apikey_activity_serviceid_model2 = ApikeyActivityServiceid(**apikey_activity_serviceid_model_dict)
 
         # Verify the model instances are equivalent
@@ -11026,44 +10915,22 @@ class TestModel_AssignedTemplatesAccountSettingsRestrictUserDomains:
         # Construct a json representation of a AssignedTemplatesAccountSettingsRestrictUserDomains model
         assigned_templates_account_settings_restrict_user_domains_model_json = {}
         assigned_templates_account_settings_restrict_user_domains_model_json['account_sufficient'] = True
-        assigned_templates_account_settings_restrict_user_domains_model_json['restrictions'] = [
-            account_settings_user_domain_restriction_model
-        ]
+        assigned_templates_account_settings_restrict_user_domains_model_json['restrictions'] = [account_settings_user_domain_restriction_model]
 
         # Construct a model instance of AssignedTemplatesAccountSettingsRestrictUserDomains by calling from_dict on the json representation
-        assigned_templates_account_settings_restrict_user_domains_model = (
-            AssignedTemplatesAccountSettingsRestrictUserDomains.from_dict(
-                assigned_templates_account_settings_restrict_user_domains_model_json
-            )
-        )
+        assigned_templates_account_settings_restrict_user_domains_model = AssignedTemplatesAccountSettingsRestrictUserDomains.from_dict(assigned_templates_account_settings_restrict_user_domains_model_json)
         assert assigned_templates_account_settings_restrict_user_domains_model != False
 
         # Construct a model instance of AssignedTemplatesAccountSettingsRestrictUserDomains by calling from_dict on the json representation
-        assigned_templates_account_settings_restrict_user_domains_model_dict = (
-            AssignedTemplatesAccountSettingsRestrictUserDomains.from_dict(
-                assigned_templates_account_settings_restrict_user_domains_model_json
-            ).__dict__
-        )
-        assigned_templates_account_settings_restrict_user_domains_model2 = (
-            AssignedTemplatesAccountSettingsRestrictUserDomains(
-                **assigned_templates_account_settings_restrict_user_domains_model_dict
-            )
-        )
+        assigned_templates_account_settings_restrict_user_domains_model_dict = AssignedTemplatesAccountSettingsRestrictUserDomains.from_dict(assigned_templates_account_settings_restrict_user_domains_model_json).__dict__
+        assigned_templates_account_settings_restrict_user_domains_model2 = AssignedTemplatesAccountSettingsRestrictUserDomains(**assigned_templates_account_settings_restrict_user_domains_model_dict)
 
         # Verify the model instances are equivalent
-        assert (
-            assigned_templates_account_settings_restrict_user_domains_model
-            == assigned_templates_account_settings_restrict_user_domains_model2
-        )
+        assert assigned_templates_account_settings_restrict_user_domains_model == assigned_templates_account_settings_restrict_user_domains_model2
 
         # Convert model instance back to dict and verify no loss of data
-        assigned_templates_account_settings_restrict_user_domains_model_json2 = (
-            assigned_templates_account_settings_restrict_user_domains_model.to_dict()
-        )
-        assert (
-            assigned_templates_account_settings_restrict_user_domains_model_json2
-            == assigned_templates_account_settings_restrict_user_domains_model_json
-        )
+        assigned_templates_account_settings_restrict_user_domains_model_json2 = assigned_templates_account_settings_restrict_user_domains_model.to_dict()
+        assert assigned_templates_account_settings_restrict_user_domains_model_json2 == assigned_templates_account_settings_restrict_user_domains_model_json
 
 
 class TestModel_CreateProfileLinkRequestLink:
@@ -11085,18 +10952,12 @@ class TestModel_CreateProfileLinkRequestLink:
         create_profile_link_request_link_model_json['component_name'] = 'testString'
 
         # Construct a model instance of CreateProfileLinkRequestLink by calling from_dict on the json representation
-        create_profile_link_request_link_model = CreateProfileLinkRequestLink.from_dict(
-            create_profile_link_request_link_model_json
-        )
+        create_profile_link_request_link_model = CreateProfileLinkRequestLink.from_dict(create_profile_link_request_link_model_json)
         assert create_profile_link_request_link_model != False
 
         # Construct a model instance of CreateProfileLinkRequestLink by calling from_dict on the json representation
-        create_profile_link_request_link_model_dict = CreateProfileLinkRequestLink.from_dict(
-            create_profile_link_request_link_model_json
-        ).__dict__
-        create_profile_link_request_link_model2 = CreateProfileLinkRequestLink(
-            **create_profile_link_request_link_model_dict
-        )
+        create_profile_link_request_link_model_dict = CreateProfileLinkRequestLink.from_dict(create_profile_link_request_link_model_json).__dict__
+        create_profile_link_request_link_model2 = CreateProfileLinkRequestLink(**create_profile_link_request_link_model_dict)
 
         # Verify the model instances are equivalent
         assert create_profile_link_request_link_model == create_profile_link_request_link_model2
@@ -11183,13 +11044,9 @@ class TestModel_EffectiveAccountSettingsResponse:
         account_settings_response_model['user_mfa'] = [account_settings_user_mfa_response_model]
         account_settings_response_model['restrict_user_domains'] = [account_settings_user_domain_restriction_model]
 
-        assigned_templates_account_settings_restrict_user_domains_model = (
-            {}
-        )  # AssignedTemplatesAccountSettingsRestrictUserDomains
+        assigned_templates_account_settings_restrict_user_domains_model = {}  # AssignedTemplatesAccountSettingsRestrictUserDomains
         assigned_templates_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        assigned_templates_account_settings_restrict_user_domains_model['restrictions'] = [
-            account_settings_user_domain_restriction_model
-        ]
+        assigned_templates_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
 
         account_settings_assigned_templates_section_model = {}  # AccountSettingsAssignedTemplatesSection
         account_settings_assigned_templates_section_model['template_id'] = 'testString'
@@ -11206,9 +11063,7 @@ class TestModel_EffectiveAccountSettingsResponse:
         account_settings_assigned_templates_section_model['system_refresh_token_expiration_in_seconds'] = '259200'
         account_settings_assigned_templates_section_model['restrict_user_list_visibility'] = 'RESTRICTED'
         account_settings_assigned_templates_section_model['user_mfa'] = [account_settings_user_mfa_response_model]
-        account_settings_assigned_templates_section_model['restrict_user_domains'] = (
-            assigned_templates_account_settings_restrict_user_domains_model
-        )
+        account_settings_assigned_templates_section_model['restrict_user_domains'] = assigned_templates_account_settings_restrict_user_domains_model
 
         # Construct a json representation of a EffectiveAccountSettingsResponse model
         effective_account_settings_response_model_json = {}
@@ -11216,23 +11071,15 @@ class TestModel_EffectiveAccountSettingsResponse:
         effective_account_settings_response_model_json['account_id'] = 'testString'
         effective_account_settings_response_model_json['effective'] = account_settings_effective_section_model
         effective_account_settings_response_model_json['account'] = account_settings_response_model
-        effective_account_settings_response_model_json['assigned_templates'] = [
-            account_settings_assigned_templates_section_model
-        ]
+        effective_account_settings_response_model_json['assigned_templates'] = [account_settings_assigned_templates_section_model]
 
         # Construct a model instance of EffectiveAccountSettingsResponse by calling from_dict on the json representation
-        effective_account_settings_response_model = EffectiveAccountSettingsResponse.from_dict(
-            effective_account_settings_response_model_json
-        )
+        effective_account_settings_response_model = EffectiveAccountSettingsResponse.from_dict(effective_account_settings_response_model_json)
         assert effective_account_settings_response_model != False
 
         # Construct a model instance of EffectiveAccountSettingsResponse by calling from_dict on the json representation
-        effective_account_settings_response_model_dict = EffectiveAccountSettingsResponse.from_dict(
-            effective_account_settings_response_model_json
-        ).__dict__
-        effective_account_settings_response_model2 = EffectiveAccountSettingsResponse(
-            **effective_account_settings_response_model_dict
-        )
+        effective_account_settings_response_model_dict = EffectiveAccountSettingsResponse.from_dict(effective_account_settings_response_model_json).__dict__
+        effective_account_settings_response_model2 = EffectiveAccountSettingsResponse(**effective_account_settings_response_model_dict)
 
         # Verify the model instances are equivalent
         assert effective_account_settings_response_model == effective_account_settings_response_model2
@@ -11497,9 +11344,7 @@ class TestModel_IdentityLimitsUsageResponse:
         template_count_model['template_id'] = 'testString'
         template_count_model['count'] = 38
 
-        identity_limits_usage_response_template_versions_per_template_model = (
-            {}
-        )  # IdentityLimitsUsageResponseTemplateVersionsPerTemplate
+        identity_limits_usage_response_template_versions_per_template_model = {}  # IdentityLimitsUsageResponseTemplateVersionsPerTemplate
         identity_limits_usage_response_template_versions_per_template_model['limit'] = 38
         identity_limits_usage_response_template_versions_per_template_model['templates'] = [template_count_model]
 
@@ -11515,9 +11360,7 @@ class TestModel_IdentityLimitsUsageResponse:
         profile_count_model['profile_id'] = 'testString'
         profile_count_model['count'] = 38
 
-        identity_limits_usage_response_claim_rules_per_profile_model = (
-            {}
-        )  # IdentityLimitsUsageResponseClaimRulesPerProfile
+        identity_limits_usage_response_claim_rules_per_profile_model = {}  # IdentityLimitsUsageResponseClaimRulesPerProfile
         identity_limits_usage_response_claim_rules_per_profile_model['limit'] = 38
         identity_limits_usage_response_claim_rules_per_profile_model['profiles'] = [profile_count_model]
 
@@ -11532,44 +11375,26 @@ class TestModel_IdentityLimitsUsageResponse:
         # Construct a json representation of a IdentityLimitsUsageResponse model
         identity_limits_usage_response_model_json = {}
         identity_limits_usage_response_model_json['serviceid_groups'] = limit_count_model
-        identity_limits_usage_response_model_json['serviceids_per_group'] = (
-            identity_limits_usage_response_serviceids_per_group_model
-        )
+        identity_limits_usage_response_model_json['serviceids_per_group'] = identity_limits_usage_response_serviceids_per_group_model
         identity_limits_usage_response_model_json['profiles'] = limit_count_model
-        identity_limits_usage_response_model_json['apikeys_per_identity'] = (
-            identity_limits_usage_response_apikeys_per_identity_model
-        )
+        identity_limits_usage_response_model_json['apikeys_per_identity'] = identity_limits_usage_response_apikeys_per_identity_model
         identity_limits_usage_response_model_json['profile_templates'] = limit_count_model
         identity_limits_usage_response_model_json['account_settings_templates'] = limit_count_model
-        identity_limits_usage_response_model_json['template_versions_per_template'] = (
-            identity_limits_usage_response_template_versions_per_template_model
-        )
+        identity_limits_usage_response_model_json['template_versions_per_template'] = identity_limits_usage_response_template_versions_per_template_model
         identity_limits_usage_response_model_json['idps'] = limit_count_model
-        identity_limits_usage_response_model_json['claim_rules_per_group'] = (
-            identity_limits_usage_response_claim_rules_per_group_model
-        )
-        identity_limits_usage_response_model_json['claim_rules_per_profile'] = (
-            identity_limits_usage_response_claim_rules_per_profile_model
-        )
+        identity_limits_usage_response_model_json['claim_rules_per_group'] = identity_limits_usage_response_claim_rules_per_group_model
+        identity_limits_usage_response_model_json['claim_rules_per_profile'] = identity_limits_usage_response_claim_rules_per_profile_model
         identity_limits_usage_response_model_json['cr_links'] = limit_count_model
-        identity_limits_usage_response_model_json['cr_links_per_profile'] = (
-            identity_limits_usage_response_cr_links_per_profile_model
-        )
+        identity_limits_usage_response_model_json['cr_links_per_profile'] = identity_limits_usage_response_cr_links_per_profile_model
         identity_limits_usage_response_model_json['cr_rules'] = limit_count_model
-        identity_limits_usage_response_model_json['cr_rules_per_profile'] = (
-            identity_limits_usage_response_cr_rules_per_profile_model
-        )
+        identity_limits_usage_response_model_json['cr_rules_per_profile'] = identity_limits_usage_response_cr_rules_per_profile_model
 
         # Construct a model instance of IdentityLimitsUsageResponse by calling from_dict on the json representation
-        identity_limits_usage_response_model = IdentityLimitsUsageResponse.from_dict(
-            identity_limits_usage_response_model_json
-        )
+        identity_limits_usage_response_model = IdentityLimitsUsageResponse.from_dict(identity_limits_usage_response_model_json)
         assert identity_limits_usage_response_model != False
 
         # Construct a model instance of IdentityLimitsUsageResponse by calling from_dict on the json representation
-        identity_limits_usage_response_model_dict = IdentityLimitsUsageResponse.from_dict(
-            identity_limits_usage_response_model_json
-        ).__dict__
+        identity_limits_usage_response_model_dict = IdentityLimitsUsageResponse.from_dict(identity_limits_usage_response_model_json).__dict__
         identity_limits_usage_response_model2 = IdentityLimitsUsageResponse(**identity_limits_usage_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -11602,37 +11427,19 @@ class TestModel_IdentityLimitsUsageResponseApikeysPerIdentity:
         identity_limits_usage_response_apikeys_per_identity_model_json['identities'] = [identity_count_model]
 
         # Construct a model instance of IdentityLimitsUsageResponseApikeysPerIdentity by calling from_dict on the json representation
-        identity_limits_usage_response_apikeys_per_identity_model = (
-            IdentityLimitsUsageResponseApikeysPerIdentity.from_dict(
-                identity_limits_usage_response_apikeys_per_identity_model_json
-            )
-        )
+        identity_limits_usage_response_apikeys_per_identity_model = IdentityLimitsUsageResponseApikeysPerIdentity.from_dict(identity_limits_usage_response_apikeys_per_identity_model_json)
         assert identity_limits_usage_response_apikeys_per_identity_model != False
 
         # Construct a model instance of IdentityLimitsUsageResponseApikeysPerIdentity by calling from_dict on the json representation
-        identity_limits_usage_response_apikeys_per_identity_model_dict = (
-            IdentityLimitsUsageResponseApikeysPerIdentity.from_dict(
-                identity_limits_usage_response_apikeys_per_identity_model_json
-            ).__dict__
-        )
-        identity_limits_usage_response_apikeys_per_identity_model2 = IdentityLimitsUsageResponseApikeysPerIdentity(
-            **identity_limits_usage_response_apikeys_per_identity_model_dict
-        )
+        identity_limits_usage_response_apikeys_per_identity_model_dict = IdentityLimitsUsageResponseApikeysPerIdentity.from_dict(identity_limits_usage_response_apikeys_per_identity_model_json).__dict__
+        identity_limits_usage_response_apikeys_per_identity_model2 = IdentityLimitsUsageResponseApikeysPerIdentity(**identity_limits_usage_response_apikeys_per_identity_model_dict)
 
         # Verify the model instances are equivalent
-        assert (
-            identity_limits_usage_response_apikeys_per_identity_model
-            == identity_limits_usage_response_apikeys_per_identity_model2
-        )
+        assert identity_limits_usage_response_apikeys_per_identity_model == identity_limits_usage_response_apikeys_per_identity_model2
 
         # Convert model instance back to dict and verify no loss of data
-        identity_limits_usage_response_apikeys_per_identity_model_json2 = (
-            identity_limits_usage_response_apikeys_per_identity_model.to_dict()
-        )
-        assert (
-            identity_limits_usage_response_apikeys_per_identity_model_json2
-            == identity_limits_usage_response_apikeys_per_identity_model_json
-        )
+        identity_limits_usage_response_apikeys_per_identity_model_json2 = identity_limits_usage_response_apikeys_per_identity_model.to_dict()
+        assert identity_limits_usage_response_apikeys_per_identity_model_json2 == identity_limits_usage_response_apikeys_per_identity_model_json
 
 
 class TestModel_IdentityLimitsUsageResponseClaimRulesPerGroup:
@@ -11657,37 +11464,19 @@ class TestModel_IdentityLimitsUsageResponseClaimRulesPerGroup:
         identity_limits_usage_response_claim_rules_per_group_model_json['access_groups'] = [access_group_count_model]
 
         # Construct a model instance of IdentityLimitsUsageResponseClaimRulesPerGroup by calling from_dict on the json representation
-        identity_limits_usage_response_claim_rules_per_group_model = (
-            IdentityLimitsUsageResponseClaimRulesPerGroup.from_dict(
-                identity_limits_usage_response_claim_rules_per_group_model_json
-            )
-        )
+        identity_limits_usage_response_claim_rules_per_group_model = IdentityLimitsUsageResponseClaimRulesPerGroup.from_dict(identity_limits_usage_response_claim_rules_per_group_model_json)
         assert identity_limits_usage_response_claim_rules_per_group_model != False
 
         # Construct a model instance of IdentityLimitsUsageResponseClaimRulesPerGroup by calling from_dict on the json representation
-        identity_limits_usage_response_claim_rules_per_group_model_dict = (
-            IdentityLimitsUsageResponseClaimRulesPerGroup.from_dict(
-                identity_limits_usage_response_claim_rules_per_group_model_json
-            ).__dict__
-        )
-        identity_limits_usage_response_claim_rules_per_group_model2 = IdentityLimitsUsageResponseClaimRulesPerGroup(
-            **identity_limits_usage_response_claim_rules_per_group_model_dict
-        )
+        identity_limits_usage_response_claim_rules_per_group_model_dict = IdentityLimitsUsageResponseClaimRulesPerGroup.from_dict(identity_limits_usage_response_claim_rules_per_group_model_json).__dict__
+        identity_limits_usage_response_claim_rules_per_group_model2 = IdentityLimitsUsageResponseClaimRulesPerGroup(**identity_limits_usage_response_claim_rules_per_group_model_dict)
 
         # Verify the model instances are equivalent
-        assert (
-            identity_limits_usage_response_claim_rules_per_group_model
-            == identity_limits_usage_response_claim_rules_per_group_model2
-        )
+        assert identity_limits_usage_response_claim_rules_per_group_model == identity_limits_usage_response_claim_rules_per_group_model2
 
         # Convert model instance back to dict and verify no loss of data
-        identity_limits_usage_response_claim_rules_per_group_model_json2 = (
-            identity_limits_usage_response_claim_rules_per_group_model.to_dict()
-        )
-        assert (
-            identity_limits_usage_response_claim_rules_per_group_model_json2
-            == identity_limits_usage_response_claim_rules_per_group_model_json
-        )
+        identity_limits_usage_response_claim_rules_per_group_model_json2 = identity_limits_usage_response_claim_rules_per_group_model.to_dict()
+        assert identity_limits_usage_response_claim_rules_per_group_model_json2 == identity_limits_usage_response_claim_rules_per_group_model_json
 
 
 class TestModel_IdentityLimitsUsageResponseClaimRulesPerProfile:
@@ -11712,37 +11501,19 @@ class TestModel_IdentityLimitsUsageResponseClaimRulesPerProfile:
         identity_limits_usage_response_claim_rules_per_profile_model_json['profiles'] = [profile_count_model]
 
         # Construct a model instance of IdentityLimitsUsageResponseClaimRulesPerProfile by calling from_dict on the json representation
-        identity_limits_usage_response_claim_rules_per_profile_model = (
-            IdentityLimitsUsageResponseClaimRulesPerProfile.from_dict(
-                identity_limits_usage_response_claim_rules_per_profile_model_json
-            )
-        )
+        identity_limits_usage_response_claim_rules_per_profile_model = IdentityLimitsUsageResponseClaimRulesPerProfile.from_dict(identity_limits_usage_response_claim_rules_per_profile_model_json)
         assert identity_limits_usage_response_claim_rules_per_profile_model != False
 
         # Construct a model instance of IdentityLimitsUsageResponseClaimRulesPerProfile by calling from_dict on the json representation
-        identity_limits_usage_response_claim_rules_per_profile_model_dict = (
-            IdentityLimitsUsageResponseClaimRulesPerProfile.from_dict(
-                identity_limits_usage_response_claim_rules_per_profile_model_json
-            ).__dict__
-        )
-        identity_limits_usage_response_claim_rules_per_profile_model2 = IdentityLimitsUsageResponseClaimRulesPerProfile(
-            **identity_limits_usage_response_claim_rules_per_profile_model_dict
-        )
+        identity_limits_usage_response_claim_rules_per_profile_model_dict = IdentityLimitsUsageResponseClaimRulesPerProfile.from_dict(identity_limits_usage_response_claim_rules_per_profile_model_json).__dict__
+        identity_limits_usage_response_claim_rules_per_profile_model2 = IdentityLimitsUsageResponseClaimRulesPerProfile(**identity_limits_usage_response_claim_rules_per_profile_model_dict)
 
         # Verify the model instances are equivalent
-        assert (
-            identity_limits_usage_response_claim_rules_per_profile_model
-            == identity_limits_usage_response_claim_rules_per_profile_model2
-        )
+        assert identity_limits_usage_response_claim_rules_per_profile_model == identity_limits_usage_response_claim_rules_per_profile_model2
 
         # Convert model instance back to dict and verify no loss of data
-        identity_limits_usage_response_claim_rules_per_profile_model_json2 = (
-            identity_limits_usage_response_claim_rules_per_profile_model.to_dict()
-        )
-        assert (
-            identity_limits_usage_response_claim_rules_per_profile_model_json2
-            == identity_limits_usage_response_claim_rules_per_profile_model_json
-        )
+        identity_limits_usage_response_claim_rules_per_profile_model_json2 = identity_limits_usage_response_claim_rules_per_profile_model.to_dict()
+        assert identity_limits_usage_response_claim_rules_per_profile_model_json2 == identity_limits_usage_response_claim_rules_per_profile_model_json
 
 
 class TestModel_IdentityLimitsUsageResponseCrLinksPerProfile:
@@ -11767,37 +11538,19 @@ class TestModel_IdentityLimitsUsageResponseCrLinksPerProfile:
         identity_limits_usage_response_cr_links_per_profile_model_json['profiles'] = [profile_count_model]
 
         # Construct a model instance of IdentityLimitsUsageResponseCrLinksPerProfile by calling from_dict on the json representation
-        identity_limits_usage_response_cr_links_per_profile_model = (
-            IdentityLimitsUsageResponseCrLinksPerProfile.from_dict(
-                identity_limits_usage_response_cr_links_per_profile_model_json
-            )
-        )
+        identity_limits_usage_response_cr_links_per_profile_model = IdentityLimitsUsageResponseCrLinksPerProfile.from_dict(identity_limits_usage_response_cr_links_per_profile_model_json)
         assert identity_limits_usage_response_cr_links_per_profile_model != False
 
         # Construct a model instance of IdentityLimitsUsageResponseCrLinksPerProfile by calling from_dict on the json representation
-        identity_limits_usage_response_cr_links_per_profile_model_dict = (
-            IdentityLimitsUsageResponseCrLinksPerProfile.from_dict(
-                identity_limits_usage_response_cr_links_per_profile_model_json
-            ).__dict__
-        )
-        identity_limits_usage_response_cr_links_per_profile_model2 = IdentityLimitsUsageResponseCrLinksPerProfile(
-            **identity_limits_usage_response_cr_links_per_profile_model_dict
-        )
+        identity_limits_usage_response_cr_links_per_profile_model_dict = IdentityLimitsUsageResponseCrLinksPerProfile.from_dict(identity_limits_usage_response_cr_links_per_profile_model_json).__dict__
+        identity_limits_usage_response_cr_links_per_profile_model2 = IdentityLimitsUsageResponseCrLinksPerProfile(**identity_limits_usage_response_cr_links_per_profile_model_dict)
 
         # Verify the model instances are equivalent
-        assert (
-            identity_limits_usage_response_cr_links_per_profile_model
-            == identity_limits_usage_response_cr_links_per_profile_model2
-        )
+        assert identity_limits_usage_response_cr_links_per_profile_model == identity_limits_usage_response_cr_links_per_profile_model2
 
         # Convert model instance back to dict and verify no loss of data
-        identity_limits_usage_response_cr_links_per_profile_model_json2 = (
-            identity_limits_usage_response_cr_links_per_profile_model.to_dict()
-        )
-        assert (
-            identity_limits_usage_response_cr_links_per_profile_model_json2
-            == identity_limits_usage_response_cr_links_per_profile_model_json
-        )
+        identity_limits_usage_response_cr_links_per_profile_model_json2 = identity_limits_usage_response_cr_links_per_profile_model.to_dict()
+        assert identity_limits_usage_response_cr_links_per_profile_model_json2 == identity_limits_usage_response_cr_links_per_profile_model_json
 
 
 class TestModel_IdentityLimitsUsageResponseCrRulesPerProfile:
@@ -11822,37 +11575,19 @@ class TestModel_IdentityLimitsUsageResponseCrRulesPerProfile:
         identity_limits_usage_response_cr_rules_per_profile_model_json['profiles'] = [profile_count_model]
 
         # Construct a model instance of IdentityLimitsUsageResponseCrRulesPerProfile by calling from_dict on the json representation
-        identity_limits_usage_response_cr_rules_per_profile_model = (
-            IdentityLimitsUsageResponseCrRulesPerProfile.from_dict(
-                identity_limits_usage_response_cr_rules_per_profile_model_json
-            )
-        )
+        identity_limits_usage_response_cr_rules_per_profile_model = IdentityLimitsUsageResponseCrRulesPerProfile.from_dict(identity_limits_usage_response_cr_rules_per_profile_model_json)
         assert identity_limits_usage_response_cr_rules_per_profile_model != False
 
         # Construct a model instance of IdentityLimitsUsageResponseCrRulesPerProfile by calling from_dict on the json representation
-        identity_limits_usage_response_cr_rules_per_profile_model_dict = (
-            IdentityLimitsUsageResponseCrRulesPerProfile.from_dict(
-                identity_limits_usage_response_cr_rules_per_profile_model_json
-            ).__dict__
-        )
-        identity_limits_usage_response_cr_rules_per_profile_model2 = IdentityLimitsUsageResponseCrRulesPerProfile(
-            **identity_limits_usage_response_cr_rules_per_profile_model_dict
-        )
+        identity_limits_usage_response_cr_rules_per_profile_model_dict = IdentityLimitsUsageResponseCrRulesPerProfile.from_dict(identity_limits_usage_response_cr_rules_per_profile_model_json).__dict__
+        identity_limits_usage_response_cr_rules_per_profile_model2 = IdentityLimitsUsageResponseCrRulesPerProfile(**identity_limits_usage_response_cr_rules_per_profile_model_dict)
 
         # Verify the model instances are equivalent
-        assert (
-            identity_limits_usage_response_cr_rules_per_profile_model
-            == identity_limits_usage_response_cr_rules_per_profile_model2
-        )
+        assert identity_limits_usage_response_cr_rules_per_profile_model == identity_limits_usage_response_cr_rules_per_profile_model2
 
         # Convert model instance back to dict and verify no loss of data
-        identity_limits_usage_response_cr_rules_per_profile_model_json2 = (
-            identity_limits_usage_response_cr_rules_per_profile_model.to_dict()
-        )
-        assert (
-            identity_limits_usage_response_cr_rules_per_profile_model_json2
-            == identity_limits_usage_response_cr_rules_per_profile_model_json
-        )
+        identity_limits_usage_response_cr_rules_per_profile_model_json2 = identity_limits_usage_response_cr_rules_per_profile_model.to_dict()
+        assert identity_limits_usage_response_cr_rules_per_profile_model_json2 == identity_limits_usage_response_cr_rules_per_profile_model_json
 
 
 class TestModel_IdentityLimitsUsageResponseServiceidsPerGroup:
@@ -11874,42 +11609,22 @@ class TestModel_IdentityLimitsUsageResponseServiceidsPerGroup:
         # Construct a json representation of a IdentityLimitsUsageResponseServiceidsPerGroup model
         identity_limits_usage_response_serviceids_per_group_model_json = {}
         identity_limits_usage_response_serviceids_per_group_model_json['limit'] = 38
-        identity_limits_usage_response_serviceids_per_group_model_json['serviceid_groups'] = [
-            service_id_group_count_model
-        ]
+        identity_limits_usage_response_serviceids_per_group_model_json['serviceid_groups'] = [service_id_group_count_model]
 
         # Construct a model instance of IdentityLimitsUsageResponseServiceidsPerGroup by calling from_dict on the json representation
-        identity_limits_usage_response_serviceids_per_group_model = (
-            IdentityLimitsUsageResponseServiceidsPerGroup.from_dict(
-                identity_limits_usage_response_serviceids_per_group_model_json
-            )
-        )
+        identity_limits_usage_response_serviceids_per_group_model = IdentityLimitsUsageResponseServiceidsPerGroup.from_dict(identity_limits_usage_response_serviceids_per_group_model_json)
         assert identity_limits_usage_response_serviceids_per_group_model != False
 
         # Construct a model instance of IdentityLimitsUsageResponseServiceidsPerGroup by calling from_dict on the json representation
-        identity_limits_usage_response_serviceids_per_group_model_dict = (
-            IdentityLimitsUsageResponseServiceidsPerGroup.from_dict(
-                identity_limits_usage_response_serviceids_per_group_model_json
-            ).__dict__
-        )
-        identity_limits_usage_response_serviceids_per_group_model2 = IdentityLimitsUsageResponseServiceidsPerGroup(
-            **identity_limits_usage_response_serviceids_per_group_model_dict
-        )
+        identity_limits_usage_response_serviceids_per_group_model_dict = IdentityLimitsUsageResponseServiceidsPerGroup.from_dict(identity_limits_usage_response_serviceids_per_group_model_json).__dict__
+        identity_limits_usage_response_serviceids_per_group_model2 = IdentityLimitsUsageResponseServiceidsPerGroup(**identity_limits_usage_response_serviceids_per_group_model_dict)
 
         # Verify the model instances are equivalent
-        assert (
-            identity_limits_usage_response_serviceids_per_group_model
-            == identity_limits_usage_response_serviceids_per_group_model2
-        )
+        assert identity_limits_usage_response_serviceids_per_group_model == identity_limits_usage_response_serviceids_per_group_model2
 
         # Convert model instance back to dict and verify no loss of data
-        identity_limits_usage_response_serviceids_per_group_model_json2 = (
-            identity_limits_usage_response_serviceids_per_group_model.to_dict()
-        )
-        assert (
-            identity_limits_usage_response_serviceids_per_group_model_json2
-            == identity_limits_usage_response_serviceids_per_group_model_json
-        )
+        identity_limits_usage_response_serviceids_per_group_model_json2 = identity_limits_usage_response_serviceids_per_group_model.to_dict()
+        assert identity_limits_usage_response_serviceids_per_group_model_json2 == identity_limits_usage_response_serviceids_per_group_model_json
 
 
 class TestModel_IdentityLimitsUsageResponseTemplateVersionsPerTemplate:
@@ -11934,39 +11649,19 @@ class TestModel_IdentityLimitsUsageResponseTemplateVersionsPerTemplate:
         identity_limits_usage_response_template_versions_per_template_model_json['templates'] = [template_count_model]
 
         # Construct a model instance of IdentityLimitsUsageResponseTemplateVersionsPerTemplate by calling from_dict on the json representation
-        identity_limits_usage_response_template_versions_per_template_model = (
-            IdentityLimitsUsageResponseTemplateVersionsPerTemplate.from_dict(
-                identity_limits_usage_response_template_versions_per_template_model_json
-            )
-        )
+        identity_limits_usage_response_template_versions_per_template_model = IdentityLimitsUsageResponseTemplateVersionsPerTemplate.from_dict(identity_limits_usage_response_template_versions_per_template_model_json)
         assert identity_limits_usage_response_template_versions_per_template_model != False
 
         # Construct a model instance of IdentityLimitsUsageResponseTemplateVersionsPerTemplate by calling from_dict on the json representation
-        identity_limits_usage_response_template_versions_per_template_model_dict = (
-            IdentityLimitsUsageResponseTemplateVersionsPerTemplate.from_dict(
-                identity_limits_usage_response_template_versions_per_template_model_json
-            ).__dict__
-        )
-        identity_limits_usage_response_template_versions_per_template_model2 = (
-            IdentityLimitsUsageResponseTemplateVersionsPerTemplate(
-                **identity_limits_usage_response_template_versions_per_template_model_dict
-            )
-        )
+        identity_limits_usage_response_template_versions_per_template_model_dict = IdentityLimitsUsageResponseTemplateVersionsPerTemplate.from_dict(identity_limits_usage_response_template_versions_per_template_model_json).__dict__
+        identity_limits_usage_response_template_versions_per_template_model2 = IdentityLimitsUsageResponseTemplateVersionsPerTemplate(**identity_limits_usage_response_template_versions_per_template_model_dict)
 
         # Verify the model instances are equivalent
-        assert (
-            identity_limits_usage_response_template_versions_per_template_model
-            == identity_limits_usage_response_template_versions_per_template_model2
-        )
+        assert identity_limits_usage_response_template_versions_per_template_model == identity_limits_usage_response_template_versions_per_template_model2
 
         # Convert model instance back to dict and verify no loss of data
-        identity_limits_usage_response_template_versions_per_template_model_json2 = (
-            identity_limits_usage_response_template_versions_per_template_model.to_dict()
-        )
-        assert (
-            identity_limits_usage_response_template_versions_per_template_model_json2
-            == identity_limits_usage_response_template_versions_per_template_model_json
-        )
+        identity_limits_usage_response_template_versions_per_template_model_json2 = identity_limits_usage_response_template_versions_per_template_model.to_dict()
+        assert identity_limits_usage_response_template_versions_per_template_model_json2 == identity_limits_usage_response_template_versions_per_template_model_json
 
 
 class TestModel_IdentityPreferenceResponse:
@@ -11989,15 +11684,11 @@ class TestModel_IdentityPreferenceResponse:
         identity_preference_response_model_json['value_list_of_strings'] = ['testString']
 
         # Construct a model instance of IdentityPreferenceResponse by calling from_dict on the json representation
-        identity_preference_response_model = IdentityPreferenceResponse.from_dict(
-            identity_preference_response_model_json
-        )
+        identity_preference_response_model = IdentityPreferenceResponse.from_dict(identity_preference_response_model_json)
         assert identity_preference_response_model != False
 
         # Construct a model instance of IdentityPreferenceResponse by calling from_dict on the json representation
-        identity_preference_response_model_dict = IdentityPreferenceResponse.from_dict(
-            identity_preference_response_model_json
-        ).__dict__
+        identity_preference_response_model_dict = IdentityPreferenceResponse.from_dict(identity_preference_response_model_json).__dict__
         identity_preference_response_model2 = IdentityPreferenceResponse(**identity_preference_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -12033,15 +11724,11 @@ class TestModel_IdentityPreferencesResponse:
         identity_preferences_response_model_json['preferences'] = [identity_preference_response_model]
 
         # Construct a model instance of IdentityPreferencesResponse by calling from_dict on the json representation
-        identity_preferences_response_model = IdentityPreferencesResponse.from_dict(
-            identity_preferences_response_model_json
-        )
+        identity_preferences_response_model = IdentityPreferencesResponse.from_dict(identity_preferences_response_model_json)
         assert identity_preferences_response_model != False
 
         # Construct a model instance of IdentityPreferencesResponse by calling from_dict on the json representation
-        identity_preferences_response_model_dict = IdentityPreferencesResponse.from_dict(
-            identity_preferences_response_model_json
-        ).__dict__
+        identity_preferences_response_model_dict = IdentityPreferencesResponse.from_dict(identity_preferences_response_model_json).__dict__
         identity_preferences_response_model2 = IdentityPreferencesResponse(**identity_preferences_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -12103,9 +11790,7 @@ class TestModel_MfaEnrollmentTypeStatus:
         assert mfa_enrollment_type_status_model != False
 
         # Construct a model instance of MfaEnrollmentTypeStatus by calling from_dict on the json representation
-        mfa_enrollment_type_status_model_dict = MfaEnrollmentTypeStatus.from_dict(
-            mfa_enrollment_type_status_model_json
-        ).__dict__
+        mfa_enrollment_type_status_model_dict = MfaEnrollmentTypeStatus.from_dict(mfa_enrollment_type_status_model_json).__dict__
         mfa_enrollment_type_status_model2 = MfaEnrollmentTypeStatus(**mfa_enrollment_type_status_model_dict)
 
         # Verify the model instances are equivalent
@@ -12136,9 +11821,7 @@ class TestModel_PolicyTemplateReference:
         assert policy_template_reference_model != False
 
         # Construct a model instance of PolicyTemplateReference by calling from_dict on the json representation
-        policy_template_reference_model_dict = PolicyTemplateReference.from_dict(
-            policy_template_reference_model_json
-        ).__dict__
+        policy_template_reference_model_dict = PolicyTemplateReference.from_dict(policy_template_reference_model_json).__dict__
         policy_template_reference_model2 = PolicyTemplateReference(**policy_template_reference_model_dict)
 
         # Verify the model instances are equivalent
@@ -12212,15 +11895,11 @@ class TestModel_ProfileClaimRuleConditions:
         profile_claim_rule_conditions_model_json['value'] = 'testString'
 
         # Construct a model instance of ProfileClaimRuleConditions by calling from_dict on the json representation
-        profile_claim_rule_conditions_model = ProfileClaimRuleConditions.from_dict(
-            profile_claim_rule_conditions_model_json
-        )
+        profile_claim_rule_conditions_model = ProfileClaimRuleConditions.from_dict(profile_claim_rule_conditions_model_json)
         assert profile_claim_rule_conditions_model != False
 
         # Construct a model instance of ProfileClaimRuleConditions by calling from_dict on the json representation
-        profile_claim_rule_conditions_model_dict = ProfileClaimRuleConditions.from_dict(
-            profile_claim_rule_conditions_model_json
-        ).__dict__
+        profile_claim_rule_conditions_model_dict = ProfileClaimRuleConditions.from_dict(profile_claim_rule_conditions_model_json).__dict__
         profile_claim_rule_conditions_model2 = ProfileClaimRuleConditions(**profile_claim_rule_conditions_model_dict)
 
         # Verify the model instances are equivalent
@@ -12354,9 +12033,7 @@ class TestModel_ProfileIdentitiesResponse:
         assert profile_identities_response_model != False
 
         # Construct a model instance of ProfileIdentitiesResponse by calling from_dict on the json representation
-        profile_identities_response_model_dict = ProfileIdentitiesResponse.from_dict(
-            profile_identities_response_model_json
-        ).__dict__
+        profile_identities_response_model_dict = ProfileIdentitiesResponse.from_dict(profile_identities_response_model_json).__dict__
         profile_identities_response_model2 = ProfileIdentitiesResponse(**profile_identities_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -12389,9 +12066,7 @@ class TestModel_ProfileIdentityRequest:
         assert profile_identity_request_model != False
 
         # Construct a model instance of ProfileIdentityRequest by calling from_dict on the json representation
-        profile_identity_request_model_dict = ProfileIdentityRequest.from_dict(
-            profile_identity_request_model_json
-        ).__dict__
+        profile_identity_request_model_dict = ProfileIdentityRequest.from_dict(profile_identity_request_model_json).__dict__
         profile_identity_request_model2 = ProfileIdentityRequest(**profile_identity_request_model_dict)
 
         # Verify the model instances are equivalent
@@ -12425,9 +12100,7 @@ class TestModel_ProfileIdentityResponse:
         assert profile_identity_response_model != False
 
         # Construct a model instance of ProfileIdentityResponse by calling from_dict on the json representation
-        profile_identity_response_model_dict = ProfileIdentityResponse.from_dict(
-            profile_identity_response_model_json
-        ).__dict__
+        profile_identity_response_model_dict = ProfileIdentityResponse.from_dict(profile_identity_response_model_json).__dict__
         profile_identity_response_model2 = ProfileIdentityResponse(**profile_identity_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -12685,15 +12358,11 @@ class TestModel_ReportMfaEnrollmentStatus:
         report_mfa_enrollment_status_model_json['users'] = [user_report_mfa_enrollment_status_model]
 
         # Construct a model instance of ReportMfaEnrollmentStatus by calling from_dict on the json representation
-        report_mfa_enrollment_status_model = ReportMfaEnrollmentStatus.from_dict(
-            report_mfa_enrollment_status_model_json
-        )
+        report_mfa_enrollment_status_model = ReportMfaEnrollmentStatus.from_dict(report_mfa_enrollment_status_model_json)
         assert report_mfa_enrollment_status_model != False
 
         # Construct a model instance of ReportMfaEnrollmentStatus by calling from_dict on the json representation
-        report_mfa_enrollment_status_model_dict = ReportMfaEnrollmentStatus.from_dict(
-            report_mfa_enrollment_status_model_json
-        ).__dict__
+        report_mfa_enrollment_status_model_dict = ReportMfaEnrollmentStatus.from_dict(report_mfa_enrollment_status_model_json).__dict__
         report_mfa_enrollment_status_model2 = ReportMfaEnrollmentStatus(**report_mfa_enrollment_status_model_dict)
 
         # Verify the model instances are equivalent
@@ -13104,9 +12773,7 @@ class TestModel_TemplateAccountSettings:
 
         template_account_settings_restrict_user_domains_model = {}  # TemplateAccountSettingsRestrictUserDomains
         template_account_settings_restrict_user_domains_model['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model['restrictions'] = [
-            account_settings_user_domain_restriction_model
-        ]
+        template_account_settings_restrict_user_domains_model['restrictions'] = [account_settings_user_domain_restriction_model]
 
         # Construct a json representation of a TemplateAccountSettings model
         template_account_settings_model_json = {}
@@ -13121,18 +12788,14 @@ class TestModel_TemplateAccountSettings:
         template_account_settings_model_json['system_access_token_expiration_in_seconds'] = '3600'
         template_account_settings_model_json['system_refresh_token_expiration_in_seconds'] = '259200'
         template_account_settings_model_json['restrict_user_list_visibility'] = 'RESTRICTED'
-        template_account_settings_model_json['restrict_user_domains'] = (
-            template_account_settings_restrict_user_domains_model
-        )
+        template_account_settings_model_json['restrict_user_domains'] = template_account_settings_restrict_user_domains_model
 
         # Construct a model instance of TemplateAccountSettings by calling from_dict on the json representation
         template_account_settings_model = TemplateAccountSettings.from_dict(template_account_settings_model_json)
         assert template_account_settings_model != False
 
         # Construct a model instance of TemplateAccountSettings by calling from_dict on the json representation
-        template_account_settings_model_dict = TemplateAccountSettings.from_dict(
-            template_account_settings_model_json
-        ).__dict__
+        template_account_settings_model_dict = TemplateAccountSettings.from_dict(template_account_settings_model_json).__dict__
         template_account_settings_model2 = TemplateAccountSettings(**template_account_settings_model_dict)
 
         # Verify the model instances are equivalent
@@ -13163,40 +12826,22 @@ class TestModel_TemplateAccountSettingsRestrictUserDomains:
         # Construct a json representation of a TemplateAccountSettingsRestrictUserDomains model
         template_account_settings_restrict_user_domains_model_json = {}
         template_account_settings_restrict_user_domains_model_json['account_sufficient'] = True
-        template_account_settings_restrict_user_domains_model_json['restrictions'] = [
-            account_settings_user_domain_restriction_model
-        ]
+        template_account_settings_restrict_user_domains_model_json['restrictions'] = [account_settings_user_domain_restriction_model]
 
         # Construct a model instance of TemplateAccountSettingsRestrictUserDomains by calling from_dict on the json representation
-        template_account_settings_restrict_user_domains_model = TemplateAccountSettingsRestrictUserDomains.from_dict(
-            template_account_settings_restrict_user_domains_model_json
-        )
+        template_account_settings_restrict_user_domains_model = TemplateAccountSettingsRestrictUserDomains.from_dict(template_account_settings_restrict_user_domains_model_json)
         assert template_account_settings_restrict_user_domains_model != False
 
         # Construct a model instance of TemplateAccountSettingsRestrictUserDomains by calling from_dict on the json representation
-        template_account_settings_restrict_user_domains_model_dict = (
-            TemplateAccountSettingsRestrictUserDomains.from_dict(
-                template_account_settings_restrict_user_domains_model_json
-            ).__dict__
-        )
-        template_account_settings_restrict_user_domains_model2 = TemplateAccountSettingsRestrictUserDomains(
-            **template_account_settings_restrict_user_domains_model_dict
-        )
+        template_account_settings_restrict_user_domains_model_dict = TemplateAccountSettingsRestrictUserDomains.from_dict(template_account_settings_restrict_user_domains_model_json).__dict__
+        template_account_settings_restrict_user_domains_model2 = TemplateAccountSettingsRestrictUserDomains(**template_account_settings_restrict_user_domains_model_dict)
 
         # Verify the model instances are equivalent
-        assert (
-            template_account_settings_restrict_user_domains_model
-            == template_account_settings_restrict_user_domains_model2
-        )
+        assert template_account_settings_restrict_user_domains_model == template_account_settings_restrict_user_domains_model2
 
         # Convert model instance back to dict and verify no loss of data
-        template_account_settings_restrict_user_domains_model_json2 = (
-            template_account_settings_restrict_user_domains_model.to_dict()
-        )
-        assert (
-            template_account_settings_restrict_user_domains_model_json2
-            == template_account_settings_restrict_user_domains_model_json
-        )
+        template_account_settings_restrict_user_domains_model_json2 = template_account_settings_restrict_user_domains_model.to_dict()
+        assert template_account_settings_restrict_user_domains_model_json2 == template_account_settings_restrict_user_domains_model_json
 
 
 class TestModel_TemplateAssignmentListResponse:
@@ -13243,12 +12888,8 @@ class TestModel_TemplateAssignmentListResponse:
         template_assignment_response_resource_model = {}  # TemplateAssignmentResponseResource
         template_assignment_response_resource_model['target'] = 'testString'
         template_assignment_response_resource_model['profile'] = template_assignment_response_resource_detail_model
-        template_assignment_response_resource_model['account_settings'] = (
-            template_assignment_response_resource_detail_model
-        )
-        template_assignment_response_resource_model['policy_template_references'] = [
-            template_assignment_response_resource_detail_model
-        ]
+        template_assignment_response_resource_model['account_settings'] = template_assignment_response_resource_detail_model
+        template_assignment_response_resource_model['policy_template_references'] = [template_assignment_response_resource_detail_model]
 
         enity_history_record_model = {}  # EnityHistoryRecord
         enity_history_record_model['timestamp'] = 'testString'
@@ -13287,18 +12928,12 @@ class TestModel_TemplateAssignmentListResponse:
         template_assignment_list_response_model_json['assignments'] = [template_assignment_response_model]
 
         # Construct a model instance of TemplateAssignmentListResponse by calling from_dict on the json representation
-        template_assignment_list_response_model = TemplateAssignmentListResponse.from_dict(
-            template_assignment_list_response_model_json
-        )
+        template_assignment_list_response_model = TemplateAssignmentListResponse.from_dict(template_assignment_list_response_model_json)
         assert template_assignment_list_response_model != False
 
         # Construct a model instance of TemplateAssignmentListResponse by calling from_dict on the json representation
-        template_assignment_list_response_model_dict = TemplateAssignmentListResponse.from_dict(
-            template_assignment_list_response_model_json
-        ).__dict__
-        template_assignment_list_response_model2 = TemplateAssignmentListResponse(
-            **template_assignment_list_response_model_dict
-        )
+        template_assignment_list_response_model_dict = TemplateAssignmentListResponse.from_dict(template_assignment_list_response_model_json).__dict__
+        template_assignment_list_response_model2 = TemplateAssignmentListResponse(**template_assignment_list_response_model_dict)
 
         # Verify the model instances are equivalent
         assert template_assignment_list_response_model == template_assignment_list_response_model2
@@ -13323,15 +12958,11 @@ class TestModel_TemplateAssignmentResource:
         template_assignment_resource_model_json['id'] = 'testString'
 
         # Construct a model instance of TemplateAssignmentResource by calling from_dict on the json representation
-        template_assignment_resource_model = TemplateAssignmentResource.from_dict(
-            template_assignment_resource_model_json
-        )
+        template_assignment_resource_model = TemplateAssignmentResource.from_dict(template_assignment_resource_model_json)
         assert template_assignment_resource_model != False
 
         # Construct a model instance of TemplateAssignmentResource by calling from_dict on the json representation
-        template_assignment_resource_model_dict = TemplateAssignmentResource.from_dict(
-            template_assignment_resource_model_json
-        ).__dict__
+        template_assignment_resource_model_dict = TemplateAssignmentResource.from_dict(template_assignment_resource_model_json).__dict__
         template_assignment_resource_model2 = TemplateAssignmentResource(**template_assignment_resource_model_dict)
 
         # Verify the model instances are equivalent
@@ -13360,18 +12991,12 @@ class TestModel_TemplateAssignmentResourceError:
         template_assignment_resource_error_model_json['statusCode'] = 'testString'
 
         # Construct a model instance of TemplateAssignmentResourceError by calling from_dict on the json representation
-        template_assignment_resource_error_model = TemplateAssignmentResourceError.from_dict(
-            template_assignment_resource_error_model_json
-        )
+        template_assignment_resource_error_model = TemplateAssignmentResourceError.from_dict(template_assignment_resource_error_model_json)
         assert template_assignment_resource_error_model != False
 
         # Construct a model instance of TemplateAssignmentResourceError by calling from_dict on the json representation
-        template_assignment_resource_error_model_dict = TemplateAssignmentResourceError.from_dict(
-            template_assignment_resource_error_model_json
-        ).__dict__
-        template_assignment_resource_error_model2 = TemplateAssignmentResourceError(
-            **template_assignment_resource_error_model_dict
-        )
+        template_assignment_resource_error_model_dict = TemplateAssignmentResourceError.from_dict(template_assignment_resource_error_model_json).__dict__
+        template_assignment_resource_error_model2 = TemplateAssignmentResourceError(**template_assignment_resource_error_model_dict)
 
         # Verify the model instances are equivalent
         assert template_assignment_resource_error_model == template_assignment_resource_error_model2
@@ -13425,12 +13050,8 @@ class TestModel_TemplateAssignmentResponse:
         template_assignment_response_resource_model = {}  # TemplateAssignmentResponseResource
         template_assignment_response_resource_model['target'] = 'testString'
         template_assignment_response_resource_model['profile'] = template_assignment_response_resource_detail_model
-        template_assignment_response_resource_model['account_settings'] = (
-            template_assignment_response_resource_detail_model
-        )
-        template_assignment_response_resource_model['policy_template_references'] = [
-            template_assignment_response_resource_detail_model
-        ]
+        template_assignment_response_resource_model['account_settings'] = template_assignment_response_resource_detail_model
+        template_assignment_response_resource_model['policy_template_references'] = [template_assignment_response_resource_detail_model]
 
         enity_history_record_model = {}  # EnityHistoryRecord
         enity_history_record_model['timestamp'] = 'testString'
@@ -13460,15 +13081,11 @@ class TestModel_TemplateAssignmentResponse:
         template_assignment_response_model_json['entity_tag'] = 'testString'
 
         # Construct a model instance of TemplateAssignmentResponse by calling from_dict on the json representation
-        template_assignment_response_model = TemplateAssignmentResponse.from_dict(
-            template_assignment_response_model_json
-        )
+        template_assignment_response_model = TemplateAssignmentResponse.from_dict(template_assignment_response_model_json)
         assert template_assignment_response_model != False
 
         # Construct a model instance of TemplateAssignmentResponse by calling from_dict on the json representation
-        template_assignment_response_model_dict = TemplateAssignmentResponse.from_dict(
-            template_assignment_response_model_json
-        ).__dict__
+        template_assignment_response_model_dict = TemplateAssignmentResponse.from_dict(template_assignment_response_model_json).__dict__
         template_assignment_response_model2 = TemplateAssignmentResponse(**template_assignment_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -13511,26 +13128,16 @@ class TestModel_TemplateAssignmentResponseResource:
         template_assignment_response_resource_model_json = {}
         template_assignment_response_resource_model_json['target'] = 'testString'
         template_assignment_response_resource_model_json['profile'] = template_assignment_response_resource_detail_model
-        template_assignment_response_resource_model_json['account_settings'] = (
-            template_assignment_response_resource_detail_model
-        )
-        template_assignment_response_resource_model_json['policy_template_references'] = [
-            template_assignment_response_resource_detail_model
-        ]
+        template_assignment_response_resource_model_json['account_settings'] = template_assignment_response_resource_detail_model
+        template_assignment_response_resource_model_json['policy_template_references'] = [template_assignment_response_resource_detail_model]
 
         # Construct a model instance of TemplateAssignmentResponseResource by calling from_dict on the json representation
-        template_assignment_response_resource_model = TemplateAssignmentResponseResource.from_dict(
-            template_assignment_response_resource_model_json
-        )
+        template_assignment_response_resource_model = TemplateAssignmentResponseResource.from_dict(template_assignment_response_resource_model_json)
         assert template_assignment_response_resource_model != False
 
         # Construct a model instance of TemplateAssignmentResponseResource by calling from_dict on the json representation
-        template_assignment_response_resource_model_dict = TemplateAssignmentResponseResource.from_dict(
-            template_assignment_response_resource_model_json
-        ).__dict__
-        template_assignment_response_resource_model2 = TemplateAssignmentResponseResource(
-            **template_assignment_response_resource_model_dict
-        )
+        template_assignment_response_resource_model_dict = TemplateAssignmentResponseResource.from_dict(template_assignment_response_resource_model_json).__dict__
+        template_assignment_response_resource_model2 = TemplateAssignmentResponseResource(**template_assignment_response_resource_model_dict)
 
         # Verify the model instances are equivalent
         assert template_assignment_response_resource_model == template_assignment_response_resource_model2
@@ -13566,36 +13173,23 @@ class TestModel_TemplateAssignmentResponseResourceDetail:
         template_assignment_response_resource_detail_model_json['id'] = 'testString'
         template_assignment_response_resource_detail_model_json['version'] = 'testString'
         template_assignment_response_resource_detail_model_json['resource_created'] = template_assignment_resource_model
-        template_assignment_response_resource_detail_model_json['error_message'] = (
-            template_assignment_resource_error_model
-        )
+        template_assignment_response_resource_detail_model_json['error_message'] = template_assignment_resource_error_model
         template_assignment_response_resource_detail_model_json['status'] = 'testString'
 
         # Construct a model instance of TemplateAssignmentResponseResourceDetail by calling from_dict on the json representation
-        template_assignment_response_resource_detail_model = TemplateAssignmentResponseResourceDetail.from_dict(
-            template_assignment_response_resource_detail_model_json
-        )
+        template_assignment_response_resource_detail_model = TemplateAssignmentResponseResourceDetail.from_dict(template_assignment_response_resource_detail_model_json)
         assert template_assignment_response_resource_detail_model != False
 
         # Construct a model instance of TemplateAssignmentResponseResourceDetail by calling from_dict on the json representation
-        template_assignment_response_resource_detail_model_dict = TemplateAssignmentResponseResourceDetail.from_dict(
-            template_assignment_response_resource_detail_model_json
-        ).__dict__
-        template_assignment_response_resource_detail_model2 = TemplateAssignmentResponseResourceDetail(
-            **template_assignment_response_resource_detail_model_dict
-        )
+        template_assignment_response_resource_detail_model_dict = TemplateAssignmentResponseResourceDetail.from_dict(template_assignment_response_resource_detail_model_json).__dict__
+        template_assignment_response_resource_detail_model2 = TemplateAssignmentResponseResourceDetail(**template_assignment_response_resource_detail_model_dict)
 
         # Verify the model instances are equivalent
         assert template_assignment_response_resource_detail_model == template_assignment_response_resource_detail_model2
 
         # Convert model instance back to dict and verify no loss of data
-        template_assignment_response_resource_detail_model_json2 = (
-            template_assignment_response_resource_detail_model.to_dict()
-        )
-        assert (
-            template_assignment_response_resource_detail_model_json2
-            == template_assignment_response_resource_detail_model_json
-        )
+        template_assignment_response_resource_detail_model_json2 = template_assignment_response_resource_detail_model.to_dict()
+        assert template_assignment_response_resource_detail_model_json2 == template_assignment_response_resource_detail_model_json
 
 
 class TestModel_TemplateCount:
@@ -13668,18 +13262,12 @@ class TestModel_TemplateProfileComponentRequest:
         template_profile_component_request_model_json['identities'] = [profile_identity_request_model]
 
         # Construct a model instance of TemplateProfileComponentRequest by calling from_dict on the json representation
-        template_profile_component_request_model = TemplateProfileComponentRequest.from_dict(
-            template_profile_component_request_model_json
-        )
+        template_profile_component_request_model = TemplateProfileComponentRequest.from_dict(template_profile_component_request_model_json)
         assert template_profile_component_request_model != False
 
         # Construct a model instance of TemplateProfileComponentRequest by calling from_dict on the json representation
-        template_profile_component_request_model_dict = TemplateProfileComponentRequest.from_dict(
-            template_profile_component_request_model_json
-        ).__dict__
-        template_profile_component_request_model2 = TemplateProfileComponentRequest(
-            **template_profile_component_request_model_dict
-        )
+        template_profile_component_request_model_dict = TemplateProfileComponentRequest.from_dict(template_profile_component_request_model_json).__dict__
+        template_profile_component_request_model2 = TemplateProfileComponentRequest(**template_profile_component_request_model_dict)
 
         # Verify the model instances are equivalent
         assert template_profile_component_request_model == template_profile_component_request_model2
@@ -13729,18 +13317,12 @@ class TestModel_TemplateProfileComponentResponse:
         template_profile_component_response_model_json['identities'] = [profile_identity_response_model]
 
         # Construct a model instance of TemplateProfileComponentResponse by calling from_dict on the json representation
-        template_profile_component_response_model = TemplateProfileComponentResponse.from_dict(
-            template_profile_component_response_model_json
-        )
+        template_profile_component_response_model = TemplateProfileComponentResponse.from_dict(template_profile_component_response_model_json)
         assert template_profile_component_response_model != False
 
         # Construct a model instance of TemplateProfileComponentResponse by calling from_dict on the json representation
-        template_profile_component_response_model_dict = TemplateProfileComponentResponse.from_dict(
-            template_profile_component_response_model_json
-        ).__dict__
-        template_profile_component_response_model2 = TemplateProfileComponentResponse(
-            **template_profile_component_response_model_dict
-        )
+        template_profile_component_response_model_dict = TemplateProfileComponentResponse.from_dict(template_profile_component_response_model_json).__dict__
+        template_profile_component_response_model2 = TemplateProfileComponentResponse(**template_profile_component_response_model_dict)
 
         # Verify the model instances are equivalent
         assert template_profile_component_response_model == template_profile_component_response_model2
@@ -13849,18 +13431,12 @@ class TestModel_TrustedProfileTemplateClaimRule:
         trusted_profile_template_claim_rule_model_json['conditions'] = [profile_claim_rule_conditions_model]
 
         # Construct a model instance of TrustedProfileTemplateClaimRule by calling from_dict on the json representation
-        trusted_profile_template_claim_rule_model = TrustedProfileTemplateClaimRule.from_dict(
-            trusted_profile_template_claim_rule_model_json
-        )
+        trusted_profile_template_claim_rule_model = TrustedProfileTemplateClaimRule.from_dict(trusted_profile_template_claim_rule_model_json)
         assert trusted_profile_template_claim_rule_model != False
 
         # Construct a model instance of TrustedProfileTemplateClaimRule by calling from_dict on the json representation
-        trusted_profile_template_claim_rule_model_dict = TrustedProfileTemplateClaimRule.from_dict(
-            trusted_profile_template_claim_rule_model_json
-        ).__dict__
-        trusted_profile_template_claim_rule_model2 = TrustedProfileTemplateClaimRule(
-            **trusted_profile_template_claim_rule_model_dict
-        )
+        trusted_profile_template_claim_rule_model_dict = TrustedProfileTemplateClaimRule.from_dict(trusted_profile_template_claim_rule_model_json).__dict__
+        trusted_profile_template_claim_rule_model2 = TrustedProfileTemplateClaimRule(**trusted_profile_template_claim_rule_model_dict)
 
         # Verify the model instances are equivalent
         assert trusted_profile_template_claim_rule_model == trusted_profile_template_claim_rule_model2
@@ -13979,15 +13555,11 @@ class TestModel_TrustedProfileTemplateList:
         trusted_profile_template_list_model_json['profile_templates'] = [trusted_profile_template_response_model]
 
         # Construct a model instance of TrustedProfileTemplateList by calling from_dict on the json representation
-        trusted_profile_template_list_model = TrustedProfileTemplateList.from_dict(
-            trusted_profile_template_list_model_json
-        )
+        trusted_profile_template_list_model = TrustedProfileTemplateList.from_dict(trusted_profile_template_list_model_json)
         assert trusted_profile_template_list_model != False
 
         # Construct a model instance of TrustedProfileTemplateList by calling from_dict on the json representation
-        trusted_profile_template_list_model_dict = TrustedProfileTemplateList.from_dict(
-            trusted_profile_template_list_model_json
-        ).__dict__
+        trusted_profile_template_list_model_dict = TrustedProfileTemplateList.from_dict(trusted_profile_template_list_model_json).__dict__
         trusted_profile_template_list_model2 = TrustedProfileTemplateList(**trusted_profile_template_list_model_dict)
 
         # Verify the model instances are equivalent
@@ -14085,18 +13657,12 @@ class TestModel_TrustedProfileTemplateResponse:
         trusted_profile_template_response_model_json['last_modified_by_id'] = 'testString'
 
         # Construct a model instance of TrustedProfileTemplateResponse by calling from_dict on the json representation
-        trusted_profile_template_response_model = TrustedProfileTemplateResponse.from_dict(
-            trusted_profile_template_response_model_json
-        )
+        trusted_profile_template_response_model = TrustedProfileTemplateResponse.from_dict(trusted_profile_template_response_model_json)
         assert trusted_profile_template_response_model != False
 
         # Construct a model instance of TrustedProfileTemplateResponse by calling from_dict on the json representation
-        trusted_profile_template_response_model_dict = TrustedProfileTemplateResponse.from_dict(
-            trusted_profile_template_response_model_json
-        ).__dict__
-        trusted_profile_template_response_model2 = TrustedProfileTemplateResponse(
-            **trusted_profile_template_response_model_dict
-        )
+        trusted_profile_template_response_model_dict = TrustedProfileTemplateResponse.from_dict(trusted_profile_template_response_model_json).__dict__
+        trusted_profile_template_response_model2 = TrustedProfileTemplateResponse(**trusted_profile_template_response_model_dict)
 
         # Verify the model instances are equivalent
         assert trusted_profile_template_response_model == trusted_profile_template_response_model2
@@ -14345,18 +13911,12 @@ class TestModel_UserReportMfaEnrollmentStatus:
         user_report_mfa_enrollment_status_model_json['account_based_mfa'] = account_based_mfa_enrollment_model
 
         # Construct a model instance of UserReportMfaEnrollmentStatus by calling from_dict on the json representation
-        user_report_mfa_enrollment_status_model = UserReportMfaEnrollmentStatus.from_dict(
-            user_report_mfa_enrollment_status_model_json
-        )
+        user_report_mfa_enrollment_status_model = UserReportMfaEnrollmentStatus.from_dict(user_report_mfa_enrollment_status_model_json)
         assert user_report_mfa_enrollment_status_model != False
 
         # Construct a model instance of UserReportMfaEnrollmentStatus by calling from_dict on the json representation
-        user_report_mfa_enrollment_status_model_dict = UserReportMfaEnrollmentStatus.from_dict(
-            user_report_mfa_enrollment_status_model_json
-        ).__dict__
-        user_report_mfa_enrollment_status_model2 = UserReportMfaEnrollmentStatus(
-            **user_report_mfa_enrollment_status_model_dict
-        )
+        user_report_mfa_enrollment_status_model_dict = UserReportMfaEnrollmentStatus.from_dict(user_report_mfa_enrollment_status_model_json).__dict__
+        user_report_mfa_enrollment_status_model2 = UserReportMfaEnrollmentStatus(**user_report_mfa_enrollment_status_model_dict)
 
         # Verify the model instances are equivalent
         assert user_report_mfa_enrollment_status_model == user_report_mfa_enrollment_status_model2


### PR DESCRIPTION
## PR summary
This PR replaces and fixes this previous PR: https://github.com/IBM/platform-services-python-sdk/pull/324

- Add support for PowerVS compute resource type
- Fix issue with `value_string` in Identity Preference handling by making it not required

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

```
$ make test-int
python -m pytest test/integration/test_iam_identity_v1*
=================== test session starts ===================
platform win32 -- Python 3.14.4, pytest-7.4.4, pluggy-1.6.0
rootdir: C:\Snaps\terraform\platform-services-python-sdk
collected 105 items
============= 105 passed in 798.26s (0:13:18) =============


$ make test-examples
python -m pytest examples/test_iam_identity_v1*
=================== test session starts ===================
platform win32 -- Python 3.14.4, pytest-7.4.4, pluggy-1.6.0
rootdir: C:\Snaps\terraform\platform-services-python-sdk
collected 83 items

examples\test_iam_identity_v1_examples.py .......    [100%]

============== 83 passed in 746.63s (0:12:26) =============
```