### PR TITLE
build: use dependency cooldown logic

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+minimummin-release-age=3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,6 @@ packages = ["ibm_platform_services"]
 [tool.black]
 line-length = 120
 skip-string-normalization = true
+
+[tool.pip.install]
+uploaded-prior-to = "P3D"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,6 @@ skip-string-normalization = true
 
 [tool.pip.install]
 uploaded-prior-to = "P3D"
+
+[tool.uv]
+exclude-newer = "3 days"

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "prConcurrentLimit": 4,
-  "reviewers": ["Norbert-Biczo", "Lidia-Tarcza", "Andras-Felleg"],
+  "reviewers": ["pyrooka", "diatrcz", "Andris28"],
   "packageRules": [
     {
       "matchManagers": ["pep621"],

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,8 @@
     },
     {
       "matchManagers": ["npm"],
-      "extends": ["security:minimumReleaseAgeNpm"]
+      "extends": ["security:minimumReleaseAgeNpm"],
+      "description": "Wait 3 days before updating semantic release dependencies"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-    "packageRules": [
+  "prConcurrentLimit": 4,
+  "reviewers": ["Norbert-Biczo", "Lidia-Tarcza", "Andras-Felleg"],
+  "packageRules": [
     {
-      "internalChecksFilter": "strict",
       "matchManagers": ["pep621"],
       "matchDatasources": ["pypi"],
       "minimumReleaseAge": "3 days",
       "description": "Wait 3 days before updating Python dependencies"
+    },
+    {
+      "matchManagers": ["npm"],
+      "extends": ["security:minimumReleaseAgeNpm"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+    "packageRules": [
+    {
+      "internalChecksFilter": "strict",
+      "matchManagers": ["pep621"],
+      "matchDatasources": ["pypi"],
+      "minimumReleaseAge": "3 days",
+      "description": "Wait 3 days before updating Python dependencies"
+    }
+  ]
 }


### PR DESCRIPTION
In this commit we add dependency cooldown logic
that enables us to update more frequently and worry
less about compromised packages.